### PR TITLE
[Rust] Added version to local path

### DIFF
--- a/rust/azure_iot_operations_protocol/Cargo.toml
+++ b/rust/azure_iot_operations_protocol/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-azure_iot_operations_mqtt = { version = "0.2", path = "../azure_iot_operations_mqtt" }   # TODO: Need to have more specific dependency for release
+azure_iot_operations_mqtt = { version = "0.2", path = "../azure_iot_operations_mqtt" }
 bytes = "1.5.0"
 derive_builder = "0.20"
 log = "0.4.21"                                                          # For performance, I believe this should have some filters on it


### PR DESCRIPTION
This will validate that the version is correct when built locally (or pulled by a customer), and will also be used when a hard registry version is required (such as shipping a crate)