### PR TITLE
[.NET] Target upstream nuget feed to fix build errors

### DIFF
--- a/codegen/nuget.config
+++ b/codegen/nuget.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="DTDLParser-prerelease" value="https://pkgs.dev.azure.com/azure-dtdl/DTDLParser/_packaging/DTDLParser-prerelease/nuget/v3/index.json" />  
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
+        <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/dotnet/nuget.config
+++ b/dotnet/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
 </packageSources>
 </configuration>

--- a/eng/test/docgen/src/Azure.Iot.Operations.Protocol.UnitTests.Docgen/nuget.config
+++ b/eng/test/docgen/src/Azure.Iot.Operations.Protocol.UnitTests.Docgen/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/test/faultablemqttbroker/src/Azure.Iot.Operations.FaultableMqttBroker/nuget.config
+++ b/eng/test/faultablemqttbroker/src/Azure.Iot.Operations.FaultableMqttBroker/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/test/schema-registry/src/Azure.Iot.Operations.Services.SchemaRegistry.Host/nuget.config
+++ b/eng/test/schema-registry/src/Azure.Iot.Operations.Services.SchemaRegistry.Host/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/tools/dsscli/src/nuget.config
+++ b/tools/dsscli/src/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="preview" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="Upstream" value="https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/Upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The upstream nuget feed already has a local copy of the necessary public nuget packages that we need to build our project. This should spare users the need to login to azure just to download publicly available nuget packages.