### PR TITLE
Remove directory.build.props file from code gen folder

### DIFF
--- a/codegen/src/Akri.Dtdl.Codegen/EnvoyGenerator/EnvoyTransformFactory.cs
+++ b/codegen/src/Akri.Dtdl.Codegen/EnvoyGenerator/EnvoyTransformFactory.cs
@@ -270,7 +270,7 @@ namespace Akri.Dtdl.Codegen
 
             foreach (string resourceName in Assembly.GetExecutingAssembly().GetManifestResourceNames())
             {
-                Regex rx = new($"^{ThisAssembly.AssemblyName}\\.{ResourceNames.SerializerFolder}\\.({serializerSubNamespace})(?:\\.(\\w+))?\\.{ext}$", RegexOptions.IgnoreCase);
+                Regex rx = new($"^{Assembly.GetExecutingAssembly().GetName().Name}\\.{ResourceNames.SerializerFolder}\\.({serializerSubNamespace})(?:\\.(\\w+))?\\.{ext}$", RegexOptions.IgnoreCase);
                 Match? match = rx.Match(resourceName);
                 if (match.Success)
                 {

--- a/codegen/src/Akri.Dtdl.Codegen/SchemaGenerator/SchemaTransformFactory.cs
+++ b/codegen/src/Akri.Dtdl.Codegen/SchemaGenerator/SchemaTransformFactory.cs
@@ -179,7 +179,7 @@ namespace Akri.Dtdl.Codegen
 
             foreach (string resourceName in Assembly.GetExecutingAssembly().GetManifestResourceNames())
             {
-                Regex rx =  new($"^{ThisAssembly.AssemblyName}\\.{ResourceNames.SchemaFolder}(?:\\.(\\w+))+\\.(\\w+)\\.{ext}$");
+                Regex rx = new($"^{Assembly.GetExecutingAssembly().GetName().Name}\\.{ResourceNames.SchemaFolder}(?:\\.(\\w+))+\\.(\\w+)\\.{ext}$");
                 Match? match = rx.Match(resourceName);
                 if (match.Success)
                 {

--- a/codegen/src/Akri.Dtdl.Codegen/T4/communication/dotnet/Project/code/DotNetProject.cs
+++ b/codegen/src/Akri.Dtdl.Codegen/T4/communication/dotnet/Project/code/DotNetProject.cs
@@ -43,7 +43,7 @@ namespace Akri.Dtdl.Codegen
             this.projectName = projectName;
             this.sdkProjPath = sdkPath != null ? $"{sdkPath}\\{SdkProjectName}" : null;
 
-            Match? majorMinorMatch = MajorMinorRegex.Match(ThisAssembly.AssemblyVersion);
+            Match? majorMinorMatch = MajorMinorRegex.Match(Assembly.GetExecutingAssembly().GetName().Version!.ToString());
             sdkVersion = majorMinorMatch.Success ? $"{majorMinorMatch.Groups[1].Captures[0].Value}.*-*" : null;
 
             Version frameworkVersion = new FrameworkName(Assembly.GetExecutingAssembly().GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName!).Version;

--- a/codegen/test/Akri.Dtdl.Codegen.UnitTests/EnvoyGeneratorTests/DotNetProjectTests.cs
+++ b/codegen/test/Akri.Dtdl.Codegen.UnitTests/EnvoyGeneratorTests/DotNetProjectTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Akri.Dtdl.Codegen.UnitTests.EnvoyGeneratorTests
 {
     using System.IO;
+    using System.Reflection;
     using System.Text.RegularExpressions;
     using System.Xml;
     using NuGet.Versioning;
@@ -18,7 +19,7 @@
         public DotNetProjectTests()
         {
             Regex MajorMinorRegex = new("^(\\d+\\.\\d+).", RegexOptions.Compiled);
-            Match? majorMinorMatch = MajorMinorRegex.Match(ThisAssembly.AssemblyVersion);
+            Match? majorMinorMatch = MajorMinorRegex.Match(typeof(DotNetProject).Assembly.GetName().Version!.ToString());
 
             Assert.True(majorMinorMatch.Success);
 


### PR DESCRIPTION
This allows us to specify the version of this package within the .csproj file instead which gives us flexibility to assign a version suffix when pushing a nightly build

Also delete some unused .NET cd pipeline code. Currently, the .NET cd pipeline code lives in ADO