### PR TITLE
Doc workflow for Rust

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -3,10 +3,8 @@ name: CD Docs
 on:
   workflow_dispatch:
   push:
-    branches:
-      - doc-workflow
-#    tags:
-#      - '**'
+    tags:
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
Create Rust doc workflow to gh pages.

This workflow is failing on my fork as its saying that I cant generate private pages because my org doesnt allow it, but my org doesnt seem to have the option to turn this on. Maybe this is possible in Azure because its an enterprise org.