### PR TITLE
[Rust][Services][State Store] State Store Client API proposal

### DIFF
--- a/rust/azure_iot_operations_services/api-surface.md
+++ b/rust/azure_iot_operations_services/api-surface.md
@@ -92,7 +92,7 @@ pub async fn del(
       key: Vec<u8>,
       fencing_token: Option<HybridLogicalClock>,
       timeout: Duration,
-  ) -> Result<state_store::Response<usize>, StateStoreError>;
+  ) -> Result<state_store::Response<i64>, StateStoreError>;
 
 /// Deletes a key from the State Store Service if and only if the value matches the one provided
 /// 
@@ -100,7 +100,7 @@ pub async fn del(
 /// waiting for a `V Delete` response from the Service. This value is not linked
 /// to the key in the State Store.
 ///
-/// Returns the number of keys deleted. Will be `0` if the key was not found or the value did not match, otherwise `1`
+/// Returns the number of keys deleted. Will be `0` if the key was not found, `-1` if the value did not match, otherwise `1`
 /// # Errors
 /// [`StateStoreError`] of kind [`KeyLengthZero`](StateStoreErrorKind::KeyLengthZero) if the `key` is empty
 ///
@@ -117,7 +117,7 @@ pub async fn vdel(
       value: Vec<u8>,
       fencing_token: Option<HybridLogicalClock>,
       timeout: Duration,
-  ) -> Result<state_store::Response<usize>, StateStoreError>;
+  ) -> Result<state_store::Response<i64>, StateStoreError>;
 
 /// Starts observation of any changes on a key from the State Store Service
 /// 


### PR DESCRIPTION
This is the public facing API proposed for the Rust State Store Client. The `recv_notification` function could look like this, but might change as we continue to discuss this pattern. Everything else should only have minor changes once this proposal is merged.

If you'd like more context for how this connects under the hood, I have a PoC of this API here: https://github.com/vaavva/iot-operations-sdks/tree/state-store, but I still have several changes planned for this implementation, so don't take it as set in stone.