### PR TITLE
Use default kubernetes namespace for deployed test resources

### DIFF
--- a/dotnet/samples/SampleCloudEvents/deployment.yaml
+++ b/dotnet/samples/SampleCloudEvents/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: samplecloudevents
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/dotnet/samples/SampleReadCloudEvents/deployment.yaml
+++ b/dotnet/samples/SampleReadCloudEvents/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: samplereadcloudevents
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/tools/deployment/deploy-aio.sh
+++ b/tools/deployment/deploy-aio.sh
@@ -32,24 +32,24 @@ if [ "$deploy_type" = "nightly" ]; then
 
     # install AIO Broker
     helm uninstall broker --ignore-not-found
-    helm install broker --atomic --create-namespace -n azure-iot-operations --version 0.7.0-nightly oci://mqbuilds.azurecr.io/helm/aio-broker --wait
+    helm install broker --atomic --create-namespace -n default --version 0.7.0-nightly oci://mqbuilds.azurecr.io/helm/aio-broker --wait
 fi
 
 # clean up any deployed Broker pieces
-kubectl delete configmap client-ca-trust-bundle -n azure-iot-operations --ignore-not-found
-kubectl delete BrokerAuthentication -n azure-iot-operations --all
-kubectl delete BrokerListener -n azure-iot-operations --all
-kubectl delete Broker -n azure-iot-operations --all
+kubectl delete configmap client-ca-trust-bundle -n default --ignore-not-found
+kubectl delete BrokerAuthentication -n default --all
+kubectl delete BrokerListener -n default --all
+kubectl delete Broker -n default --all
 
-# install trust-manager with azure-iot-operations as the trusted domain
-helm upgrade trust-manager jetstack/trust-manager --install --create-namespace -n azure-iot-operations --set app.trust.namespace=azure-iot-operations --wait
+# install trust-manager with default as the trusted domain
+helm upgrade trust-manager jetstack/trust-manager --install --create-namespace -n default --set app.trust.namespace=default --wait
 
 # install cert issuers and trust bundle
 kubectl apply -f yaml/certificates.yaml
 
 # Wait for CA trust bundle to be generated (for external connections to the MQTT Broker) and then push to a local file
-kubectl wait --for=create --timeout=30s secret/aio-broker-external-ca -n azure-iot-operations
-kubectl get secret aio-broker-external-ca -n azure-iot-operations -o jsonpath='{.data.ca\.crt}' | base64 -d > $session_dir/broker-ca.crt
+kubectl wait --for=create --timeout=30s secret/aio-broker-external-ca -n default
+kubectl get secret aio-broker-external-ca -n default -o jsonpath='{.data.ca\.crt}' | base64 -d > $session_dir/broker-ca.crt
 
 # create CA for client connections. This will not be used directly by a service so many of the fields are not applicable
 echo "my-ca-password" > /tmp/password.txt
@@ -74,11 +74,11 @@ step certificate create client $session_dir/client.crt $session_dir/client.key \
 
 # create client trust bundle used to validate x509 client connections to the broker
 kubectl create configmap client-ca-trust-bundle \
-    -n azure-iot-operations \
+    -n default \
     --from-literal=client_ca.pem="$(cat ~/.step/certs/intermediate_ca.crt ~/.step/certs/root_ca.crt)"
 
 # Create a SAT auth file for local testing
-kubectl create token default --namespace azure-iot-operations --duration=86400s --audience=aio-internal > $session_dir/token.txt
+kubectl create token default --namespace default --duration=86400s --audience=aio-internal > $session_dir/token.txt
 
 # setup new Broker
 kubectl apply -f yaml/aio-$deploy_type.yaml

--- a/tools/deployment/initialize-cluster.sh
+++ b/tools/deployment/initialize-cluster.sh
@@ -25,5 +25,5 @@ k3d cluster create \
     --registry-create k3d-registry.localhost:127.0.0.1:5000 \
     --wait
 
-# Set the default context / namespace to azure-iot-operations
-kubectl config set-context k3d-k3s-default --namespace=azure-iot-operations
+# Set the default context / namespace to default
+kubectl config set-context k3d-k3s-default --namespace=default

--- a/tools/deployment/yaml/aio-nightly.yaml
+++ b/tools/deployment/yaml/aio-nightly.yaml
@@ -2,7 +2,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: Broker
 metadata:
   name: broker
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   generateResourceLimits:
     cpu: disabled
@@ -18,7 +18,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   brokerRef: broker
   serviceName: aio-broker
@@ -41,7 +41,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener-external
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   brokerRef: broker
   serviceName: aio-broker-external
@@ -81,7 +81,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: sat-auth
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   authenticationMethods:
     - method: serviceAccountToken
@@ -92,7 +92,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: x509-auth
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   authenticationMethods:
     - method: x509Certificate

--- a/tools/deployment/yaml/aio-release.yaml
+++ b/tools/deployment/yaml/aio-release.yaml
@@ -2,7 +2,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: Broker
 metadata:
   name: broker
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   generateResourceLimits:
     cpu: disabled
@@ -18,7 +18,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   brokerRef: broker
   serviceName: aio-broker
@@ -41,7 +41,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener-external
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   brokerRef: broker
   serviceName: aio-broker-external
@@ -82,7 +82,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: sat-auth
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   authenticationMethods:
     - method: serviceAccountToken
@@ -93,7 +93,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: x509-auth
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   authenticationMethods:
     - method: x509Credentials

--- a/tools/deployment/yaml/certificates.yaml
+++ b/tools/deployment/yaml/certificates.yaml
@@ -11,7 +11,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: aio-broker-external-ca
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   isCA: true
   secretName: aio-broker-external-ca
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: aio-broker-external
-  namespace: azure-iot-operations
+  namespace: default
 spec:
   ca:
     secretName: aio-broker-external-ca


### PR DESCRIPTION
We hit some build issues starting today around certificates being scoped to the default namespace only unexpectedly. While we wait on the broker team to address this unexpected issue, we can just deploy our resources and scope our certificates to the default namespace to unblock ourselves.