### PR TITLE
enable case sensativity in markdown, and dont check code blocks

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -42,16 +42,10 @@
     ],    
     "languageSettings": [
         {
-            // markdown is case sensative
+            // markdown is case sensative and ignore comment blocks
             "languageId": "markdown",
+            "ignoreRegExpList": [ "/^```[\\s\\S]*?```/gm" ],
             "caseSensitive": true
-        },
-        {
-            // markdown code blocks not case sensative and include additional dictionaries
-            "languageId": "markdown",
-            "includeRegExpList": [ "/^```[\\s\\S]*?```/gm" ],
-            "dictionaries": ["bash"],
-            "caseSensitive": false
         },
         {
             // go specific words


### PR DESCRIPTION
Unfortunately, Cspell doesn't allow different dictionaries to be used in different parts of a file. The dictionaries are compiled together for each file. This means for markdown there are restrictions in that you can either prioritise the text by enabling case sensitivity and using an english dictionary, or prioritise the code blocks by disabling case sensativity and added additional programming language dictionaries.

This PR prioritises the text.