### PR TITLE
[Rust][Protocol][MQTT] Lifetime annotation changes

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
@@ -26,7 +26,7 @@ use crate::CompletionToken;
 #[derive(Clone)]
 pub struct SessionManagedClient<PS>
 where
-    PS: MqttPubSub + Clone + Send + Sync + 'static,
+    PS: MqttPubSub + Clone + Send + Sync,
 {
     // Client ID of the `Session` that manages this client
     pub(crate) client_id: String,
@@ -40,7 +40,7 @@ where
 
 impl<PS> ManagedClient for SessionManagedClient<PS>
 where
-    PS: MqttPubSub + Clone + Send + Sync + 'static,
+    PS: MqttPubSub + Clone + Send + Sync,
 {
     type PubReceiver = SessionPubReceiver;
 
@@ -70,7 +70,7 @@ where
 #[async_trait]
 impl<PS> MqttPubSub for SessionManagedClient<PS>
 where
-    PS: MqttPubSub + Clone + Send + Sync + 'static,
+    PS: MqttPubSub + Clone + Send + Sync,
 {
     async fn publish(
         &self,

--- a/rust/azure_iot_operations_protocol/src/rpc/command_executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc/command_executor.rs
@@ -241,10 +241,10 @@ pub struct CommandExecutorOptions {
 #[allow(unused)]
 pub struct CommandExecutor<TReq, TResp, C>
 where
-    TReq: PayloadSerialize + Send,
-    TResp: PayloadSerialize + Send,
+    TReq: PayloadSerialize + Send + 'static,
+    TResp: PayloadSerialize + Send + 'static,
     C: ManagedClient + Clone + Send + Sync + 'static,
-    C::PubReceiver: Send + Sync,
+    C::PubReceiver: Send + Sync + 'static,
 {
     // Static properties of the executor
     mqtt_client: C,
@@ -265,10 +265,10 @@ where
 /// Implementation of Command Executor.
 impl<TReq, TResp, C> CommandExecutor<TReq, TResp, C>
 where
-    TReq: PayloadSerialize + Send,
+    TReq: PayloadSerialize + Send + 'static,
     TResp: PayloadSerialize + Send + 'static,
-    C: ManagedClient + Clone + Send + Sync,
-    C::PubReceiver: Send + Sync,
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static,
 {
     /// Create a new [`CommandExecutor`].
     ///
@@ -905,10 +905,10 @@ where
 
 impl<TReq, TResp, C> Drop for CommandExecutor<TReq, TResp, C>
 where
-    TReq: PayloadSerialize + Send,
-    TResp: PayloadSerialize + Send,
-    C: ManagedClient + Clone + Send + Sync,
-    C::PubReceiver: Send + Sync,
+    TReq: PayloadSerialize + Send + 'static,
+    TResp: PayloadSerialize + Send + 'static,
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static,
 {
     fn drop(&mut self) {}
 }

--- a/rust/azure_iot_operations_protocol/src/rpc/command_invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc/command_invoker.rs
@@ -188,9 +188,10 @@ pub struct CommandInvokerOptions {
 #[allow(unused)] // TODO: remove once drop is implemented
 pub struct CommandInvoker<TReq, TResp, C>
 where
-    TReq: PayloadSerialize,
-    TResp: PayloadSerialize,
-    C: ManagedClient + Clone + Send + Sync,
+    TReq: PayloadSerialize + 'static,
+    TResp: PayloadSerialize + 'static,
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static,
 {
     // static properties of the invoker
     mqtt_client: C,
@@ -209,9 +210,9 @@ where
 /// Implementation of Command Invoker.
 impl<TReq, TResp, C> CommandInvoker<TReq, TResp, C>
 where
-    TReq: PayloadSerialize,
-    TResp: PayloadSerialize,
-    C: ManagedClient + Clone + Send + Sync,
+    TReq: PayloadSerialize + 'static,
+    TResp: PayloadSerialize + 'static,
+    C: ManagedClient + Clone + Send + Sync + 'static,
     C::PubReceiver: Send + Sync + 'static,
 {
     /// Creates a new [`CommandInvoker`].
@@ -936,9 +937,10 @@ fn validate_and_parse_response<TResp: PayloadSerialize>(
 
 impl<TReq, TResp, C> Drop for CommandInvoker<TReq, TResp, C>
 where
-    TReq: PayloadSerialize,
-    TResp: PayloadSerialize,
-    C: ManagedClient + Clone + Send + Sync,
+    TReq: PayloadSerialize + 'static,
+    TResp: PayloadSerialize + 'static,
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static,
 {
     fn drop(&mut self) {}
 }


### PR DESCRIPTION
While working on codegen, it became clear that we want to preserve design space to change our envoy concurrency model without breaking consumers.

Enforcing 'static lifetimes within envoys consistently guarantees us that flexibility, even if it's not yet strictly required everywhere.

Furthermore, after researching the topic as part of this PR, it became apparent that there was a completely unnecessary (and useless) annotation on the ManagedClient.