### PR TITLE
[.NET] Add setup script for connector sample deployment

### DIFF
--- a/dotnet/samples/ConnectorApp/connector-config.yaml
+++ b/dotnet/samples/ConnectorApp/connector-config.yaml
@@ -2,7 +2,7 @@ apiVersion: akri.microsoft.com/v1  # This is spec.group/versions.name from conne
 kind: ConnectorConfig
 metadata:
   name: http-connector-app-config
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   replicas: 1
   endpointProfileType: http-dss

--- a/dotnet/samples/ConnectorApp/http-connector-secrets.yaml
+++ b/dotnet/samples/ConnectorApp/http-connector-secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: http-username
-  namespace: default
+  namespace: azure-iot-operations
 type: Opaque
 data:
   http-username: c29tZS11c2VybmFtZQ== # "some-username"
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: http-password
-  namespace: default
+  namespace: azure-iot-operations
 type: Opaque
 data:
   http-password: c29tZS1wYXNzd29yZA== # "some-password"

--- a/dotnet/samples/ConnectorApp/http-server-aep.yaml
+++ b/dotnet/samples/ConnectorApp/http-server-aep.yaml
@@ -2,7 +2,7 @@ apiVersion: deviceregistry.microsoft.com/v1beta2 # This is spec.group/versions.n
 kind: AssetEndpointProfile
 metadata:
   name: my-http-dss-aep
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   additionalConfiguration: '{"DataSourceType": "Http", "HttpPath": "contexts/quality", "RequestIntervalInSeconds":15, "DssKey": "quality", "MqttClientId": "myHttpDssClient"}'
   authentication:
@@ -12,5 +12,5 @@ spec:
       passwordSecretName: http-password
   discoveredAssetEndpointProfileRef: my-http-dss-discovered-asset-endpoint-profile
   endpointProfileType: http-dss
-  targetAddress: http://http-server-service.default.svc.cluster.local:80 # http-server.yaml => <Service.metadata.name>.<namespace>.svc.cluster.local:<port>)
+  targetAddress: http://http-server-service.azure-iot-operations.svc.cluster.local:80 # http-server.yaml => <Service.metadata.name>.<namespace>.svc.cluster.local:<port>)
   uuid: 1234-5678-9012-3456

--- a/dotnet/samples/ConnectorApp/setup-cluster.sh
+++ b/dotnet/samples/ConnectorApp/setup-cluster.sh
@@ -5,7 +5,7 @@
 ../../../tools/deployment/deploy-aio.sh nightly
 
 # Deploy ADR
-helm install adrcommonprp --version 0.3.0 oci://azureadr.azurecr.io/helm/adr/common/adr-crds-prp -n default --wait
+helm install adrcommonprp --version 0.3.0 oci://azureadr.azurecr.io/helm/adr/common/adr-crds-prp -n azure-iot-operations --wait
 
 # Build connector image
 dotnet publish /t:PublishContainer
@@ -26,10 +26,11 @@ kubectl apply -f ./http-connector-secrets.yaml
 kubectl apply -f ./http-server-aep.yaml
 
 # Deploy Operator helm chart
-helm install akri-operator oci://akribuilds.azurecr.io/helm/microsoft-managed-akri-operator --version 0.4.0-main-20241004.2-buddy -n default --wait
+helm install akri-operator oci://akribuilds.azurecr.io/helm/microsoft-managed-akri-operator --version 0.4.0-main-20241004.2-buddy -n azure-iot-operations --wait
 
 # TODO this should be part of the above helm chart. Sync w/ Abhipsa/Daniel
 kubectl apply -f ./connector_config_crd.yaml
 
 # Deploy connector config
 kubectl apply -f ./connector-config.yaml
+

--- a/dotnet/samples/SampleCloudEvents/deployment.yaml
+++ b/dotnet/samples/SampleCloudEvents/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: samplecloudevents
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   replicas: 1
   selector:

--- a/dotnet/samples/SampleReadCloudEvents/deployment.yaml
+++ b/dotnet/samples/SampleReadCloudEvents/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: samplereadcloudevents
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   replicas: 1
   selector:

--- a/tools/deployment/deploy-aio.sh
+++ b/tools/deployment/deploy-aio.sh
@@ -32,24 +32,24 @@ if [ "$deploy_type" = "nightly" ]; then
 
     # install AIO Broker
     helm uninstall broker --ignore-not-found
-    helm install broker --atomic --create-namespace -n default --version 0.7.0-nightly oci://mqbuilds.azurecr.io/helm/aio-broker --wait
+    helm install broker --atomic --create-namespace -n azure-iot-operations --version 0.7.0-nightly oci://mqbuilds.azurecr.io/helm/aio-broker --wait
 fi
 
 # clean up any deployed Broker pieces
-kubectl delete configmap client-ca-trust-bundle -n default --ignore-not-found
-kubectl delete BrokerAuthentication -n default --all
-kubectl delete BrokerListener -n default --all
-kubectl delete Broker -n default --all
+kubectl delete configmap client-ca-trust-bundle -n azure-iot-operations --ignore-not-found
+kubectl delete BrokerAuthentication -n azure-iot-operations --all
+kubectl delete BrokerListener -n azure-iot-operations --all
+kubectl delete Broker -n azure-iot-operations --all
 
-# install trust-manager with default as the trusted domain
-helm upgrade trust-manager jetstack/trust-manager --install --create-namespace -n default --set app.trust.namespace=default --wait
+# install trust-manager with azure-iot-operations as the trusted domain
+helm upgrade trust-manager jetstack/trust-manager --install --create-namespace -n azure-iot-operations --set app.trust.namespace=azure-iot-operations --wait
 
 # install cert issuers and trust bundle
 kubectl apply -f yaml/certificates.yaml
 
 # Wait for CA trust bundle to be generated (for external connections to the MQTT Broker) and then push to a local file
-kubectl wait --for=create --timeout=30s secret/aio-broker-external-ca -n default
-kubectl get secret aio-broker-external-ca -n default -o jsonpath='{.data.ca\.crt}' | base64 -d > $session_dir/broker-ca.crt
+kubectl wait --for=create --timeout=30s secret/aio-broker-external-ca -n azure-iot-operations
+kubectl get secret aio-broker-external-ca -n azure-iot-operations -o jsonpath='{.data.ca\.crt}' | base64 -d > $session_dir/broker-ca.crt
 
 # create CA for client connections. This will not be used directly by a service so many of the fields are not applicable
 echo "my-ca-password" > /tmp/password.txt
@@ -74,11 +74,11 @@ step certificate create client $session_dir/client.crt $session_dir/client.key \
 
 # create client trust bundle used to validate x509 client connections to the broker
 kubectl create configmap client-ca-trust-bundle \
-    -n default \
+    -n azure-iot-operations \
     --from-literal=client_ca.pem="$(cat ~/.step/certs/intermediate_ca.crt ~/.step/certs/root_ca.crt)"
 
 # Create a SAT auth file for local testing
-kubectl create token default --namespace default --duration=86400s --audience=aio-internal > $session_dir/token.txt
+kubectl create token default --namespace azure-iot-operations --duration=86400s --audience=aio-internal > $session_dir/token.txt
 
 # setup new Broker
 kubectl apply -f yaml/aio-$deploy_type.yaml

--- a/tools/deployment/initialize-cluster.sh
+++ b/tools/deployment/initialize-cluster.sh
@@ -25,5 +25,5 @@ k3d cluster create \
     --registry-create k3d-registry.localhost:127.0.0.1:5000 \
     --wait
 
-# Set the default context / namespace to default
-kubectl config set-context k3d-k3s-default --namespace=default
+# Set the default context / namespace to azure-iot-operations
+kubectl config set-context k3d-k3s-default --namespace=azure-iot-operations

--- a/tools/deployment/yaml/aio-nightly.yaml
+++ b/tools/deployment/yaml/aio-nightly.yaml
@@ -2,7 +2,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: Broker
 metadata:
   name: broker
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   generateResourceLimits:
     cpu: disabled
@@ -18,7 +18,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   brokerRef: broker
   serviceName: aio-broker
@@ -41,7 +41,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener-external
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   brokerRef: broker
   serviceName: aio-broker-external
@@ -81,7 +81,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: sat-auth
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   authenticationMethods:
     - method: serviceAccountToken
@@ -92,7 +92,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: x509-auth
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   authenticationMethods:
     - method: x509Certificate

--- a/tools/deployment/yaml/aio-release.yaml
+++ b/tools/deployment/yaml/aio-release.yaml
@@ -2,7 +2,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: Broker
 metadata:
   name: broker
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   generateResourceLimits:
     cpu: disabled
@@ -18,7 +18,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   brokerRef: broker
   serviceName: aio-broker
@@ -41,7 +41,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerListener
 metadata:
   name: listener-external
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   brokerRef: broker
   serviceName: aio-broker-external
@@ -82,7 +82,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: sat-auth
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   authenticationMethods:
     - method: serviceAccountToken
@@ -93,7 +93,7 @@ apiVersion: mqttbroker.iotoperations.azure.com/v1beta1
 kind: BrokerAuthentication
 metadata:
   name: x509-auth
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   authenticationMethods:
     - method: x509Credentials

--- a/tools/deployment/yaml/certificates.yaml
+++ b/tools/deployment/yaml/certificates.yaml
@@ -11,7 +11,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: aio-broker-external-ca
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   isCA: true
   secretName: aio-broker-external-ca
@@ -30,7 +30,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: aio-broker-external
-  namespace: default
+  namespace: azure-iot-operations
 spec:
   ca:
     secretName: aio-broker-external-ca


### PR DESCRIPTION
Currently, the sample connector crashes because we don't instantiate the session client yet, but all the steps before then work as expected.

The script deploys the broker, the operator, and the relevant connector config + AEP config. With all that, the operator deploys the connector as expected.