### PR TITLE
[Rust][MQTT] Removed `unimplemented!` for QoS 0/2

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
@@ -99,15 +99,7 @@ where
         topic: impl Into<String> + Send,
         qos: QoS,
     ) -> Result<CompletionToken, ClientError> {
-        match qos {
-            QoS::AtMostOnce => {
-                unimplemented!("QoS 0 is not yet supported for subscribe operations")
-            }
-            QoS::AtLeastOnce => self.pub_sub.subscribe(topic, qos).await,
-            QoS::ExactlyOnce => {
-                unimplemented!("QoS 2 is not yet supported for subscribe operations")
-            }
-        }
+        self.pub_sub.subscribe(topic, qos).await
     }
 
     async fn subscribe_with_properties(
@@ -116,19 +108,9 @@ where
         qos: QoS,
         properties: SubscribeProperties,
     ) -> Result<CompletionToken, ClientError> {
-        match qos {
-            QoS::AtMostOnce => {
-                unimplemented!("QoS 0 is not yet supported for subscribe operations")
-            }
-            QoS::AtLeastOnce => {
-                self.pub_sub
-                    .subscribe_with_properties(topic, qos, properties)
-                    .await
-            }
-            QoS::ExactlyOnce => {
-                unimplemented!("QoS 2 is not yet supported for subscribe operations")
-            }
-        }
+        self.pub_sub
+            .subscribe_with_properties(topic, qos, properties)
+            .await
     }
 
     async fn unsubscribe(


### PR DESCRIPTION
This got missed in earlier PRs