### PR TITLE
run ci-go workflow on relevant codegen changes

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'go/**'
       - 'eng/test/test-cases/Protocol/**'
+      - 'codegen/src/**'
+      - '!codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication'
+      - 'codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/common'
+      - 'codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/go'
+      - '!codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/encapsulation'
+      - 'codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/encapsulation/common'
+      - 'codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/encapsulation/go'
   push:
     branches:
     - main  


### PR DESCRIPTION
Trigger the ci-go workflow on changes to the `codegen/src` folder hierarchy, but ignore:
* changes to `communication` templates other than `common` and `go`
* changes to `encapsulation` templates other than `common` and `go`