### PR TITLE
[Rust] Update `upload-artifact` in CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -59,7 +59,7 @@ jobs:
         set -e
         make coverage
 
-    - uses: "actions/upload-artifact@v3"
+    - uses: "actions/upload-artifact@v4"
       with:
         name: "report-azure-iot-operations"
         path: "${{ runner.temp }}/report"


### PR DESCRIPTION
`upload-artifact@v3` is being deprecated and [will begin breaking in December](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/). Moved to the latest version.