### PR TITLE
Add METL sanity checks and fix Go tester

### DIFF
--- a/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandExecutorTester.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandExecutorTester.cs
@@ -21,7 +21,7 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
     {
         private const string testCasesPath = "../../../../../../eng/test/test-cases";
         private const string executorCasesPath = $"{testCasesPath}/Protocol/CommandExecutor";
-        private const string defaultsFileName = "defaults.toml";
+        private const string defaultsFilePath = $"{testCasesPath}/Protocol/CommandExecutor/defaults.toml";
 
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
 
@@ -57,7 +57,6 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
                 })
                 .Build();
 
-            string defaultsFilePath = Path.Combine(executorCasesPath, defaultsFileName);
             if (File.Exists(defaultsFilePath))
             {
                 DefaultTestCase defaultTestCase = Toml.ToModel<DefaultTestCase>(File.ReadAllText(defaultsFilePath), defaultsFilePath, new TomlModelOptions { ConvertPropertyName = CaseConverter.PascalToKebabCase });

--- a/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandInvokerTester.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandInvokerTester.cs
@@ -15,7 +15,7 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
     {
         private const string testCasesPath = "../../../../../../eng/test/test-cases";
         private const string invokerCasesPath = $"{testCasesPath}/Protocol/CommandInvoker";
-        private const string defaultsFileName = "defaults.toml";
+        private const string defaultsFilePath = $"{testCasesPath}/Protocol/CommandInvoker/defaults.toml";
 
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
 
@@ -48,7 +48,6 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
                 })
                 .Build();
 
-            string defaultsFilePath = Path.Combine(invokerCasesPath, defaultsFileName);
             if (File.Exists(defaultsFilePath))
             {
                 DefaultTestCase defaultTestCase = Toml.ToModel<DefaultTestCase>(File.ReadAllText(defaultsFilePath), defaultsFilePath, new TomlModelOptions { ConvertPropertyName = CaseConverter.PascalToKebabCase });

--- a/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetryReceiverTester.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetryReceiverTester.cs
@@ -23,7 +23,7 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
     {
         private const string testCasesPath = "../../../../../../eng/test/test-cases";
         private const string receiverCasesPath = $"{testCasesPath}/Protocol/TelemetryReceiver";
-        private const string defaultsFileName = "defaults.toml";
+        private const string defaultsFilePath = $"{testCasesPath}/Protocol/TelemetryReceiver/defaults.toml";
 
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
 
@@ -53,7 +53,6 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
                 })
                 .Build();
 
-            string defaultsFilePath = Path.Combine(receiverCasesPath, defaultsFileName);
             if (File.Exists(defaultsFilePath))
             {
                 DefaultTestCase defaultTestCase = Toml.ToModel<DefaultTestCase>(File.ReadAllText(defaultsFilePath), defaultsFilePath, new TomlModelOptions { ConvertPropertyName = CaseConverter.PascalToKebabCase });

--- a/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetrySenderTester.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetrySenderTester.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
     {
         private const string testCasesPath = "../../../../../../eng/test/test-cases";
         private const string senderCasesPath = $"{testCasesPath}/Protocol/TelemetrySender";
-        private const string defaultsFileName = "defaults.toml";
+        private const string defaultsFilePath = $"{testCasesPath}/Protocol/TelemetrySender/defaults.toml";
 
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
 
@@ -44,7 +44,6 @@ namespace Azure.Iot.Operations.Protocol.MetlTests
                 })
                 .Build();
 
-            string defaultsFilePath = Path.Combine(senderCasesPath, defaultsFileName);
             if (File.Exists(defaultsFilePath))
             {
                 DefaultTestCase defaultTestCase = Toml.ToModel<DefaultTestCase>(File.ReadAllText(defaultsFilePath), defaultsFilePath, new TomlModelOptions { ConvertPropertyName = CaseConverter.PascalToKebabCase });

--- a/eng/test/test-cases/.vscode/settings.json
+++ b/eng/test/test-cases/.vscode/settings.json
@@ -6,16 +6,20 @@
         "editor.insertSpaces": true
     },
     "schemas/ExecutorTestCase.schema.json": [
-        "Protocol/CommandExecutor/*.yaml"
+        "Protocol/CommandExecutor/*.yaml",
+        "SanityCheck/CommandExecutor/*.yaml"
     ],
     "schemas/InvokerTestCase.schema.json": [
-        "Protocol/CommandInvoker/*.yaml"
+        "Protocol/CommandInvoker/*.yaml",
+        "SanityCheck/CommandInvoker/*.yaml"
     ],
     "schemas/ReceiverTestCase.schema.json": [
-        "Protocol/TelemetryReceiver/*.yaml"
+        "Protocol/TelemetryReceiver/*.yaml",
+        "SanityCheck/TelemetryReceiver/*.yaml"
     ],
     "schemas/SenderTestCase.schema.json": [
-        "Protocol/TelemetrySender/*.yaml"
+        "Protocol/TelemetrySender/*.yaml",
+        "SanityCheck/TelemetrySender/*.yaml"
     ]
 }
 }

--- a/eng/test/test-cases/Protocol/TelemetryReceiver/TelemetryReceiverReceivesWithCloudEvent_Success.yaml
+++ b/eng/test/test-cases/Protocol/TelemetryReceiver/TelemetryReceiverReceivesWithCloudEvent_Success.yaml
@@ -1,5 +1,5 @@
 ---
-test-name: TelemetryReceiverReceivesWithCloudEvent_Success.yaml
+test-name: TelemetryReceiverReceivesWithCloudEvent_Success
 description:
   condition: >-
     TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorAwaitAckWithWrongPacketIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorAwaitAckWithWrongPacketIndex.yaml
@@ -1,0 +1,19 @@
+---
+test-name: CommandExecutorAwaitAckWithWrongPacketIndex
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case awaits acknowledgement expecting an incorrect packet index.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorAwaitPublishWithWrongCorrelationIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorAwaitPublishWithWrongCorrelationIndex.yaml
@@ -1,0 +1,18 @@
+---
+test-name: CommandExecutorAwaitPublishWithWrongCorrelationIndex
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case awaits publish expecting an incorrect correlation index.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+- action: await publish
+  correlation-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCanary.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCanary.yaml
@@ -1,0 +1,31 @@
+---
+test-name: CommandExecutorCanary
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    CommandExecutor sends response and acknowledges request.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  subscribed-topics:
+  - "mock/test"
+  acknowledgement-count: 1
+  published-messages:
+  - correlation-index: 0
+    topic: "response/mock/test"
+    command-status: 200 # OK
+    payload: "Test_Response"
+    metadata:
+      "__protVer": "0.1"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongErrorKind.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongErrorKind.yaml
@@ -1,0 +1,14 @@
+---
+test-name: CommandExecutorCatchWithWrongErrorKind
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw incorrect 'invalid argument' exception.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid argument
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongSupplementalPropertyName.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongSupplementalPropertyName.yaml
@@ -1,0 +1,16 @@
+---
+test-name: CommandExecutorCatchWithWrongSupplementalPropertyName
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw exception indicating incorrect property name.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-name: 'thisisnotright'
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongSupplementalPropertyValue.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWithWrongSupplementalPropertyValue.yaml
@@ -1,0 +1,16 @@
+---
+test-name: CommandExecutorCatchWithWrongSupplementalPropertyValue
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw exception indicating incorrect property value.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-value: "valid/namespace"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyInApplication.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyInApplication.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandExecutorCatchWronglyInApplication
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw exception incorrectly indicating error in application.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    in-application: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyNotShallow.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyNotShallow.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandExecutorCatchWronglyNotShallow
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw exception incorrectly indicating error is not shallow.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-shallow: !!bool false
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyRemote.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorCatchWronglyRemote.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandExecutorCatchWronglyRemote
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandExecutor to throw exception incorrectly indicating error is remomte.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-remote: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithErrorWronglyInApplication.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithErrorWronglyInApplication.yaml
@@ -1,0 +1,26 @@
+---
+test-name: CommandExecutorPublishedMessageWithErrorWronglyInApplication
+description:
+  condition: >-
+    CommandExecutor receives request with payload that cannot deserialize.
+  expect: >-
+    Erroneous test case expects a response incorrectly indicating error in application.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  payload: '{ "invalid" "json" }'
+  bypass-serialization: true
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    is-application-error: true
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithInappropriateMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithInappropriateMetadata.yaml
@@ -1,0 +1,25 @@
+---
+test-name: CommandExecutorPublishedMessageWithInappropriateMetadata
+description:
+  condition: >-
+    CommandExecutor receives basic valid request and responds.
+  expect: >-
+    Erroneous test case expects a response with metadata that will not be included.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    metadata:
+      "responseHeader": "responseValue"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithNonMatchingCorrelationIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithNonMatchingCorrelationIndex.yaml
@@ -1,0 +1,23 @@
+---
+test-name: CommandExecutorPublishedMessageWithNonMatchingCorrelationIndex
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a response with no matching correlation index.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithUnexpectedCommandStatus.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithUnexpectedCommandStatus.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandExecutorPublishedMessageWithUnexpectedCommandStatus
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a response without a command status code.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    command-status: # not present
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongCommandStatus.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongCommandStatus.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandExecutorPublishedMessageWithWrongCommandStatus
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a response with wrong command status code.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    command-status: 404 # NotFound
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongExpiry.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongExpiry.yaml
@@ -1,0 +1,27 @@
+---
+test-name: CommandExecutorPublishedMessageWithWrongExpiry
+description:
+  condition: >-
+    CommandExecutor receives request.
+  expect: >-
+    Erroneous test case expects a response with an incorrect message expiry interval.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: freeze time
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+  message-expiry: { seconds: 3 }
+- action: await acknowledgement
+  packet-index: 0
+- action: unfreeze time
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    expiry: 4
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongMetadata.yaml
@@ -1,0 +1,26 @@
+---
+test-name: CommandExecutorPublishedMessageWithWrongMetadata
+description:
+  condition: >-
+    CommandExecutor receives basic valid request and responds with metadata.
+  expect: >-
+    Erroneous test case expects a response with wrong metadata value.
+
+prologue:
+  executors:
+  - response-metadata:
+      "responseHeader": "responseValue"
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    metadata:
+      "responseHeader": "incorrectValue"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongPayload.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongPayload.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandExecutorPublishedMessageWithWrongPayload
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a response with wrong payload.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    payload: "This is not right"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorPublishedMessageWithWrongTopic.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandExecutorPublishedMessageWithWrongTopic
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a response with wrong publication topic.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    topic: "response/wrong/topic"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithInappropriateCatch.yaml
@@ -1,0 +1,14 @@
+---
+test-name: CommandExecutorWithInappropriateCatch
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is valid.
+  expect: >-
+    Erroneous test case inappropriately expects that CommandExecutor throws 'invalid configuration' exception.
+
+prologue:
+  executors:
+  - topic-namespace: "valid/namespace"
+  catch:
+    error-kind: invalid configuration
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithInappropriateSubscribedTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithInappropriateSubscribedTopic.yaml
@@ -1,0 +1,23 @@
+---
+test-name: CommandExecutorWithInappropriateSubscribedTopic
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects a subscription to a topic that will not be subscribed.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  subscribed-topics:
+  - "incorrect/subscription"
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongAcknowledgementCount.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongAcknowledgementCount.yaml
@@ -1,0 +1,22 @@
+---
+test-name: CommandExecutorWithWrongAcknowledgementCount
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects an incorrect acknowledgement count.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  acknowledgement-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongExecutionCount.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongExecutionCount.yaml
@@ -1,0 +1,22 @@
+---
+test-name: CommandExecutorWithWrongExecutionCount
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects an incorrect execution count.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  execution-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongPublicationCount.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithWrongPublicationCount.yaml
@@ -1,0 +1,22 @@
+---
+test-name: CommandExecutorWithWrongPublicationCount
+description:
+  condition: >-
+    CommandExecutor receives basic valid request.
+  expect: >-
+    Erroneous test case expects an incorrect publication count.
+
+prologue:
+  executors:
+  - { }
+
+actions:
+- action: receive request
+  correlation-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  publication-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandExecutor/CommandExecutorWithoutNeededCatch.yaml
@@ -1,0 +1,12 @@
+---
+test-name: CommandExecutorInvalidTopicNamespaceWithoutCatch
+description:
+  condition: >-
+    CommandExecutor initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case fails to expect that CommandExecutor throws 'invalid configuration' exception.
+
+prologue:
+  executors:
+  - topic-namespace: "invalid/{modelId}"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitAckWithWrongPacketIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitAckWithWrongPacketIndex.yaml
@@ -1,0 +1,25 @@
+---
+test-name: CommandInvokerAwaitAckWithWrongPacketIndex
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case awaits acknowledgement expecting an incorrect packet index.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithInappropriateCatch.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandInvokerAwaitInvocationWithInappropriateCatch
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case inappropriately expects that CommandExecutor throws 'invalid payload' exception.
+
+prologue:
+  invokers:
+  - { }
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+- action: await invocation
+  invocation-index: 0
+  catch:
+    error-kind: invalid payload
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithInappropriateMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithInappropriateMetadata.yaml
@@ -1,0 +1,27 @@
+---
+test-name: CommandInvokerAwaitInvocationWithInappropriateMetadata
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a response with metadata that will not be included..
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+  metadata:
+    "requestHeader": "requestValue"
+- action: await acknowledgement
+  packet-index: 0
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithUnexpectedResponseValue.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithUnexpectedResponseValue.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandInvokerAwaitInvocationWithUnexpectedResponseValue
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a response with no response value.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+  response-value:
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithWrongMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithWrongMetadata.yaml
@@ -1,0 +1,29 @@
+---
+test-name: CommandInvokerAwaitInvocationWithWrongMetadata
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a response with wrong metadata value.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  metadata:
+    "requestHeader": "requestValue"
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+  metadata:
+    "requestHeader": "incorrectValue"
+- action: await acknowledgement
+  packet-index: 0
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithWrongResponseValue.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithWrongResponseValue.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandInvokerAwaitInvocationWithWrongResponseValue
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a response with wrong response value.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+  response-value: "Incorrect_Response"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerAwaitInvocationWithoutNeededCatch.yaml
@@ -1,0 +1,24 @@
+---
+test-name: CommandInvokerAwaitInvocationWithoutNeededCatch
+description:
+  condition: >-
+    CommandInvoker receives response with no payload.
+  expect: >-
+    Erroneous test case fails to expect that invocation throws 'invalid payload' exception.
+
+prologue:
+  invokers:
+  - { }
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  payload:
+  status: "200" # OK
+- action: await invocation
+  invocation-index: 0
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCanary.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCanary.yaml
@@ -1,0 +1,31 @@
+---
+test-name: CommandInvokerCanary
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    CommandInvoker publishes reqest and completes command.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  acknowledgement-count: 1
+  published-messages:
+  - correlation-index: 0
+    payload: "Test_Request"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongErrorKind.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongErrorKind.yaml
@@ -1,0 +1,14 @@
+---
+test-name: CommandInvokerCatchWithWrongErrorKind
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw incorrect 'invalid argument' exception.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid argument
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongSupplementalPropertyName.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongSupplementalPropertyName.yaml
@@ -1,0 +1,16 @@
+---
+test-name: CommandInvokerCatchWithWrongSupplementalPropertyName
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw exception indicating incorrect property name.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-name: 'thisisnotright'
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongSupplementalPropertyValue.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWithWrongSupplementalPropertyValue.yaml
@@ -1,0 +1,16 @@
+---
+test-name: CommandInvokerCatchWithWrongSupplementalPropertyValue
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw exception indicating incorrect property value.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-value: "valid/namespace"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyInApplication.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyInApplication.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandInvokerCatchWronglyInApplication
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw exception incorrectly indicating error in application.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    in-application: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyNotShallow.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyNotShallow.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandInvokerCatchWronglyNotShallow
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw exception incorrectly indicating error is not shallow.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-shallow: !!bool false
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyRemote.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerCatchWronglyRemote.yaml
@@ -1,0 +1,15 @@
+---
+test-name: CommandInvokerCatchWronglyRemote
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects CommandInvoker to throw exception incorrectly indicating error is remomte.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-remote: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithInappropriateMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithInappropriateMetadata.yaml
@@ -1,0 +1,31 @@
+---
+test-name: CommandInvokerPublishedMessageWithInappropriateMetadata
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a request with metadata that will not be included.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    metadata:
+      "requestHeader": "requestValue"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithNonMatchingCorrelationIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithNonMatchingCorrelationIndex.yaml
@@ -1,0 +1,29 @@
+---
+test-name: CommandInvokerPublishedMessageWithNonMatchingCorrelationIndex
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a response with no matching correlation index.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongExpiry.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongExpiry.yaml
@@ -1,0 +1,31 @@
+---
+test-name: CommandInvokerPublishedMessageWithWrongExpiry
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a request with an incorrect message expiry interval.
+
+prologue:
+  invokers:
+  - { }
+
+actions:
+- action: invoke command
+  invocation-index: 0
+  timeout: { seconds: 3 }
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    expiry: 4
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongMetadata.yaml
@@ -1,0 +1,33 @@
+---
+test-name: CommandInvokerPublishedMessageWithInappropriateMetadata
+description:
+  condition: >-
+    CommandInvoker invokes command with metadata and receives response.
+  expect: >-
+    Erroneous test case expects a request with wrong metadata value.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+  metadata:
+    "requestHeader": "requestValue"
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    metadata:
+      "requestHeader": "incorrectValue"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongPayload.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongPayload.yaml
@@ -1,0 +1,30 @@
+---
+test-name: CommandInvokerPublishedMessageWithWrongPayload
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a request with wrong payload.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    payload: "This is not right"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongSourceId.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongSourceId.yaml
@@ -1,0 +1,34 @@
+---
+test-name: CommandInvokerPublishedMessageWithWrongSourceId
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a request with an incorrect source ID header.
+
+prologue:
+  mqtt-config:
+    client-id: "MyInvokerClientId"
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  acknowledgement-count: 1
+  published-messages:
+  - correlation-index: 0
+    metadata:
+      "__srcId": "ADifferentInvokerClientId"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerPublishedMessageWithWrongTopic.yaml
@@ -1,0 +1,30 @@
+---
+test-name: CommandInvokerPublishedMessageWithWrongTopic
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a request with wrong publication topic.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  published-messages:
+  - correlation-index: 0
+    topic: "wrong/topic"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithInappropriateCatch.yaml
@@ -1,0 +1,14 @@
+---
+test-name: CommandInvokerWithInappropriateCatch
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is valid.
+  expect: >-
+    Erroneous test case inappropriately expects that CommandInvoker throws 'invalid configuration' exception.
+
+prologue:
+  invokers:
+  - topic-namespace: "this/is/a/namespace"
+  catch:
+    error-kind: invalid configuration
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithInappropriateSubscribedTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithInappropriateSubscribedTopic.yaml
@@ -1,0 +1,29 @@
+---
+test-name: CommandInvokerWithInappropriateSubscribedTopic
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects a subscription to a topic that will not be subscribed.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  subscribed-topics:
+  - "incorrect/subscription"
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithWrongAcknowledgementCount.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithWrongAcknowledgementCount.yaml
@@ -1,0 +1,28 @@
+---
+test-name: CommandInvokerWithWrongAcknowledgementCount
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects an incorrect acknowledgement count.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  acknowledgement-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithWrongPublicationCount.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithWrongPublicationCount.yaml
@@ -1,0 +1,28 @@
+---
+test-name: CommandInvokerWithWrongPublicationCount
+description:
+  condition: >-
+    CommandInvoker invokes command and receives response.
+  expect: >-
+    Erroneous test case expects an incorrect publication count.
+
+prologue:
+  invokers:
+  - {}
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await publish
+  correlation-index: 0
+- action: receive response
+  correlation-index: 0
+  packet-index: 0
+- action: await invocation
+  invocation-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  publication-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/CommandInvoker/CommandInvokerWithoutNeededCatch.yaml
@@ -1,0 +1,18 @@
+---
+test-name: CommandInvokerWithoutNeededCatch
+description:
+  condition: >-
+    CommandInvoker initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case fails to expect that CommandInvoker throws 'invalid configuration' exception.
+
+prologue:
+  invokers:
+  - topic-namespace: "invalid/{modelId}"
+
+actions:
+- action: invoke command
+  invocation-index: 0
+- action: await invocation
+  invocation-index: 0
+...

--- a/eng/test/test-cases/SanityCheck/README.md
+++ b/eng/test/test-cases/SanityCheck/README.md
@@ -1,0 +1,20 @@
+# Sanity checks for METL execution systems
+
+When the SDK in some language passes all test cases exercised by the test execution system for that language, the SDK is nominally considered to be functionally correct.
+However, an absence of test failures could instead result from a test execution system that does not check all of the conditions it is supposed to check.
+To detect this situation, the present folder hierarchy contains a collection of test cases that are expected to fail.
+
+Each test case expects a value for one of the [METL check keys](../../../../doc/dev/generated/MetlSpec.md#keyvalue-kinds) that does not match the value that is actually expected for a correctly interpreted test of a correct implementation.
+To use these cases for validating a test execution system, point the tester to this root folder instead of [the correct test-case root](../Protocol/).
+Run the tester, and manually ensure that all test cases other than the designated canaries evince test failures.
+There is one 'canary' test case that should pass for each set of tests; this ensures that the other cases are not all failing for some trivial reason such as an incorrect file-system path.
+
+> Note: The folders herein do not duplicate the `defaults.toml` files in the correct test-case folder hierarchy.
+When temporarily modifying a tester to point to these test cases, no change should be made to the path for the defaults file, only to the path for the test-case files.
+
+## Pointers to file-system paths in testers
+
+| language | CommandExecutor | CommandInvoker | TelemetryReceiver | TelemetrySender |
+| --- | --- | --- | --- | --- |
+| C# | [CommandExecutorTester.cs](../../../../dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandExecutorTester.cs#L23) | [CommandInvokerTester.cs](../../../../dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/CommandInvokerTester.cs#L17) | [TelemetryReceiverTester.cs](../../../../dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetryReceiverTester.cs#L25) | [TelemetrySenderTester.cs](../../../../dotnet/test/Azure.Iot.Operations.Protocol.MetlTests/TelemetrySenderTester.cs#L19) |
+| Go | [command_executor_tester.go](../../../../go/test/protocol/command_executor_tester.go#L41) | [command_invoker_tester.go](../../../../go/test/protocol/command_invoker_tester.go#L37) | [telemetry_receiver_tester.go](../../../../go/test/protocol/telemetry_receiver_tester.go#L39) | [telemetry_sender_tester.go](../../../../go/test/protocol/telemetry_sender_tester.go#L37) |

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverAwaitAckWithWrongPacketIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverAwaitAckWithWrongPacketIndex.yaml
@@ -1,0 +1,18 @@
+---
+test-name: TelemetryReceiverAwaitAckWithWrongPacketIndex
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case awaits acknowledgement expecting an incorrect packet index.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCanary.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCanary.yaml
@@ -1,0 +1,26 @@
+---
+test-name: TelemetryReceiverCanary
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    TelemetryReceiver relays Telemetry to user code and acknowledges message.
+
+prologue:
+  receivers:
+  - {}
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  telemetry-count: 1
+  subscribed-topics:
+  - "mock/test"
+  acknowledgement-count: 1
+  received-telemetries:
+  - telemetry-value: "Test_Telemetry"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongErrorKind.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongErrorKind.yaml
@@ -1,0 +1,14 @@
+---
+test-name: TelemetryReceiverCatchWithWrongErrorKind
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw incorrect 'invalid argument' exception.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid argument
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongSupplementalPropertyName.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongSupplementalPropertyName.yaml
@@ -1,0 +1,16 @@
+---
+test-name: TelemetryReceiverCatchWithWrongSupplementalPropertyName
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw exception indicating incorrect property name.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-name: 'thisisnotright'
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongSupplementalPropertyValue.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWithWrongSupplementalPropertyValue.yaml
@@ -1,0 +1,16 @@
+---
+test-name: TelemetryReceiverCatchWithWrongSupplementalPropertyValue
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw exception indicating incorrect property value.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-value: "valid/namespace"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyInApplication.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyInApplication.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetryReceiverCatchWronglyInApplication
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw exception incorrectly indicating error in application.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    in-application: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyNotShallow.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyNotShallow.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetryReceiverCatchWronglyNotShallow
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw exception incorrectly indicating error is not shallow.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-shallow: !!bool false
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyRemote.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverCatchWronglyRemote.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetryReceiverCatchWronglyRemote
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetryReceiver to throw exception incorrectly indicating error is remomte.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-remote: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithInappropriateMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithInappropriateMetadata.yaml
@@ -1,0 +1,23 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithInappropriateMetadata
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with metadata that will not be included.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - metadata:
+      "telemHeader": "telemValue"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithUnexpectedTelemetryValue.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithUnexpectedTelemetryValue.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithUnexpectedTelemetryValue
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with no Telemetry value.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - telemetry-value:
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataContentType.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataContentType.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataContentType
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect data content type.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      data-content-type: "application/cbor"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataSchema.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataSchema.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventDataSchema
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect data schema.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      data-schema: "dtmi:test:SomethingElse;1"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSource.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSource.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventSource
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect source.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      source: "dtmi:test:aDifferentEventSource;1"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSpecVersion.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSpecVersion.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventSpecVersion
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect spec version.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      spec-version: "0.6"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSubject.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventSubject.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventSubject
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect subject.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      subject: "incorrect/source"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventType.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongCloudEventType.yaml
@@ -1,0 +1,31 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongCloudEventType
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with attached CloudEvent info.
+  expect: >-
+    Erroneous test case expects a Telemetry with CloudEvent that has an incorrect type.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "id": "dtmi:test:someAssignedId;1"
+    "source": "dtmi:test:myEventSource;1"
+    "type": "test-type"
+    "specversion": "1.0"
+    "datacontenttype": "application/json"
+    "subject": "mock/test"
+    "dataschema": "dtmi:test:MyModel:_contents:__test;1"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - cloud-event:
+      type: "incorrect-type"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongMetadata.yaml
@@ -1,0 +1,25 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongMetadata
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry with metadata.
+  expect: >-
+    Erroneous test case expects a Telemetry with wrong metadata value.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  metadata:
+    "telemHeader": "telemValue"
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - metadata:
+      "telemHeader": "incorrectValue"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongSourceIndex.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongSourceIndex.yaml
@@ -1,0 +1,23 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongSourceIndex
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with an incorrect source index.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  source-index: 0
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - source-index: 1
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongTelemetryValue.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverReceivedTelemetryWithWrongTelemetryValue.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetryReceiverReceivedTelemetryWithWrongTelemetryValue
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with an incorrect Telemetry value.
+
+prologue:
+  receivers:
+  - { }
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  received-telemetries:
+  - telemetry-value: "Incorrect_Telemetry"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithInappropriateCatch.yaml
@@ -1,0 +1,14 @@
+---
+test-name: TelemetryReceiverWithInappropriateCatch0
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is valid.
+  expect: >-
+    Erroneous test case inappropriately expects that TelemetryReceiver throws 'invalid configuration' exception.
+
+prologue:
+  receivers:
+  - topic-namespace: "this/is/a/namespace"
+  catch:
+    error-kind: invalid configuration
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithInappropriateSubscribedTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithInappropriateSubscribedTopic.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetryReceiverWithInappropriateSubscribedTopic
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects a subscription to a topic that will not be subscribed.
+
+prologue:
+  receivers:
+  - {}
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  subscribed-topics:
+  - "incorrect/subscription"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithWrongAcknowledgementCount.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithWrongAcknowledgementCount.yaml
@@ -1,0 +1,21 @@
+---
+test-name: TelemetryReceiverWithWrongAcknowledgementCount
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects an incorrect acknowledgement count.
+
+prologue:
+  receivers:
+  - {}
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  acknowledgement-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithWrongTelemetryCount.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithWrongTelemetryCount.yaml
@@ -1,0 +1,21 @@
+---
+test-name: TelemetryReceiverWithWrongTelemetryCount
+description:
+  condition: >-
+    TelemetryReceiver receives a single valid Telemetry.
+  expect: >-
+    Erroneous test case expects an incorrect acknowledgement count.
+
+prologue:
+  receivers:
+  - {}
+
+actions:
+- action: receive telemetry
+  packet-index: 0
+- action: await acknowledgement
+  packet-index: 0
+
+epilogue:
+  telemetry-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetryReceiver/TelemetryReceiverWithoutNeededCatch.yaml
@@ -1,0 +1,12 @@
+---
+test-name: TelemetryReceiverWithoutNeededCatch
+description:
+  condition: >-
+    TelemetryReceiver initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case fails to expect that TelemetryReceiver throws 'invalid configuration' exception.
+
+prologue:
+  receivers:
+  - topic-namespace: "invalid/{modelId}"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderAwaitSendWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderAwaitSendWithInappropriateCatch.yaml
@@ -1,0 +1,19 @@
+---
+test-name: TelemetrySenderAwaitSendWithInappropriateCatch
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    Erroneous test case inappropriately expects that TelemetrySender throws 'mqtt error' exception.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+  catch:
+    error-kind: mqtt error
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderAwaitSendWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderAwaitSendWithoutNeededCatch.yaml
@@ -1,0 +1,19 @@
+---
+test-name: TelemetrySenderAwaitSendWithoutNeededCatch
+description:
+  condition: >-
+    TelemetrySenders sends Telemetry but ACK fails when publishing request.
+  expect: >-
+    Erroneous test case fails to expect that CommandInvoker throws 'mqtt error' exception.
+
+prologue:
+  senders:
+  - { }
+  push-acks:
+    publish: [ fail ]
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCanary.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCanary.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetrySenderCanary
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    TelemetrySender performs send.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - topic: "mock/test"
+    payload: "Test_Telemetry"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongErrorKind.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongErrorKind.yaml
@@ -1,0 +1,14 @@
+---
+test-name: TelemetrySenderCatchWithWrongErrorKind
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw incorrect 'invalid argument' exception.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid argument
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongSupplementalPropertyName.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongSupplementalPropertyName.yaml
@@ -1,0 +1,16 @@
+---
+test-name: TelemetrySenderCatchWithWrongSupplementalPropertyName
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw exception indicating incorrect property name.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-name: 'thisisnotright'
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongSupplementalPropertyValue.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWithWrongSupplementalPropertyValue.yaml
@@ -1,0 +1,16 @@
+---
+test-name: TelemetrySenderCatchWithWrongSupplementalPropertyValue
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw exception indicating incorrect property value.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    supplemental:
+      property-value: "valid/namespace"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyInApplication.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyInApplication.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetrySenderCatchWronglyInApplication
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw exception incorrectly indicating error in application.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    in-application: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyNotShallow.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyNotShallow.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetrySenderCatchWronglyNotShallow
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw exception incorrectly indicating error is not shallow.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-shallow: !!bool false
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyRemote.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderCatchWronglyRemote.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetrySenderCatchWronglyRemote
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case expects TelemetrySender to throw exception incorrectly indicating error is remomte.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+  catch:
+    error-kind: invalid configuration
+    is-remote: !!bool true
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithInappropriateMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithInappropriateMetadata.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetrySenderPublishedMessageWithInappropriateMetadata
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with metadata that will not be included.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - metadata:
+      "telemHeader": "telemValue"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongExpiry.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongExpiry.yaml
@@ -1,0 +1,22 @@
+---
+test-name: TelemetrySenderPublishedMessageWithWrongExpiry
+description:
+  condition: >-
+    TelemetrySender sends a Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with an incorrect message expiry interval.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+  timeout: { seconds: 3 }
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - expiry: 4
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongMetadata.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongMetadata.yaml
@@ -1,0 +1,24 @@
+---
+test-name: TelemetrySenderPublishedMessageWithWrongMetadata
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry containing metadata.
+  expect: >-
+    Erroneous test case expects a Telemetry with wrong metadata value.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+  metadata:
+    "telemHeader": "telemValue"
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - metadata:
+      "telemHeader": "incorrectValue"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongPayload.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongPayload.yaml
@@ -1,0 +1,21 @@
+---
+test-name: TelemetrySenderPublishedMessageWithWrongPayload
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with wrong payload.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - payload: "Incorrect_Telemetry"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongSourceId.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongSourceId.yaml
@@ -1,0 +1,24 @@
+---
+test-name: TelemetrySenderPublishedMessageWithWrongSourceId
+description:
+  condition: >-
+    TelemetrySender sends a Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with an incorrect source ID header.
+
+prologue:
+  mqtt-config:
+    client-id: "MySenderClientId"
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - metadata:
+      "__srcId": "OtherSenderClientId"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongTopic.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderPublishedMessageWithWrongTopic.yaml
@@ -1,0 +1,21 @@
+---
+test-name: TelemetrySenderPublishedMessageWithWrongTopic
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    Erroneous test case expects a Telemetry with wrong publication topic.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  published-messages:
+  - topic: "wrong/topic"
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithInappropriateCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithInappropriateCatch.yaml
@@ -1,0 +1,14 @@
+---
+test-name: TelemetrySenderWithInappropriateCatch0
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is valid.
+  expect: >-
+    Erroneous test case inappropriately expects that TelemetrySender throws 'invalid configuration' exception.
+
+prologue:
+  senders:
+  - topic-namespace: "this/is/a/namespace"
+  catch:
+    error-kind: invalid configuration
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithWrongPublicationCount.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithWrongPublicationCount.yaml
@@ -1,0 +1,20 @@
+---
+test-name: TelemetrySenderWithWrongPublicationCount
+description:
+  condition: >-
+    TelemetrySender sends a single Telemetry.
+  expect: >-
+    Erroneous test case expects an incorrect publication count.
+
+prologue:
+  senders:
+  - { }
+
+actions:
+- action: send telemetry
+- action: await publish
+- action: await send
+
+epilogue:
+  publication-count: 2
+...

--- a/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithoutNeededCatch.yaml
+++ b/eng/test/test-cases/SanityCheck/TelemetrySender/TelemetrySenderWithoutNeededCatch.yaml
@@ -1,0 +1,15 @@
+---
+test-name: TelemetrySenderWithoutNeededCatch
+description:
+  condition: >-
+    TelemetrySender initialized with a topic namespace that is invalid.
+  expect: >-
+    Erroneous test case fails to expect that TelemetrySender throws 'invalid configuration' exception.
+
+prologue:
+  senders:
+  - topic-namespace: "invalid/{modelId}"
+
+actions:
+- action: send telemetry
+...

--- a/go/protocol/API.md
+++ b/go/protocol/API.md
@@ -91,6 +91,7 @@ import "github.com/Azure/iot-operations-sdks/go/protocol"
   - [func \(o \*TelemetrySenderOptions\) ApplyOptions\(opts \[\]Option, rest ...Option\)](<#TelemetrySenderOptions.ApplyOptions>)
 - [type WithCacheTTL](<#WithCacheTTL>)
 - [type WithConcurrency](<#WithConcurrency>)
+- [type WithDataSchema](<#WithDataSchema>)
 - [type WithFencingToken](<#WithFencingToken>)
 - [type WithIdempotent](<#WithIdempotent>)
 - [type WithManualAck](<#WithManualAck>)
@@ -124,7 +125,7 @@ const DefaultTimeout = 10 * time.Second
 ```
 
 <a name="WithLogger"></a>
-## func [WithLogger](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L194-L200>)
+## func [WithLogger](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L205-L211>)
 
 ```go
 func WithLogger(logger *slog.Logger) interface {
@@ -733,7 +734,7 @@ func (o *RespondOptions) Apply(opts []RespondOption, rest ...RespondOption)
 Apply resolves the provided list of options.
 
 <a name="SendOption"></a>
-## type [SendOption](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L35>)
+## type [SendOption](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L38>)
 
 SendOption represent a single per\-send option.
 
@@ -744,7 +745,7 @@ type SendOption interface {
 ```
 
 <a name="WithCloudEvent"></a>
-### func [WithCloudEvent](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L186>)
+### func [WithCloudEvent](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L191>)
 
 ```go
 func WithCloudEvent(ce *CloudEvent) SendOption
@@ -753,7 +754,7 @@ func WithCloudEvent(ce *CloudEvent) SendOption
 WithCloudEvent adds a cloud event payload to the telemetry message.
 
 <a name="SendOptions"></a>
-## type [SendOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L38-L45>)
+## type [SendOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L41-L48>)
 
 SendOptions are the resolved per\-send options.
 
@@ -769,7 +770,7 @@ type SendOptions struct {
 ```
 
 <a name="SendOptions.Apply"></a>
-### func \(\*SendOptions\) [Apply](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L166-L169>)
+### func \(\*SendOptions\) [Apply](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L171-L174>)
 
 ```go
 func (o *SendOptions) Apply(opts []SendOption, rest ...SendOption)
@@ -892,7 +893,7 @@ func (o *TelemetryReceiverOptions) ApplyOptions(opts []Option, rest ...Option)
 ApplyOptions filters and resolves the provided list of options.
 
 <a name="TelemetrySender"></a>
-## type [TelemetrySender](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L18-L20>)
+## type [TelemetrySender](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L19-L22>)
 
 TelemetrySender provides the ability to send a single telemetry.
 
@@ -903,7 +904,7 @@ type TelemetrySender[T any] struct {
 ```
 
 <a name="NewTelemetrySender"></a>
-### func [NewTelemetrySender](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L58-L63>)
+### func [NewTelemetrySender](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L61-L66>)
 
 ```go
 func NewTelemetrySender[T any](client MqttClient, encoding Encoding[T], topicPattern string, opt ...TelemetrySenderOption) (ts *TelemetrySender[T], err error)
@@ -912,7 +913,7 @@ func NewTelemetrySender[T any](client MqttClient, encoding Encoding[T], topicPat
 NewTelemetrySender creates a new telemetry sender.
 
 <a name="TelemetrySender[T].Send"></a>
-### func \(\*TelemetrySender\[T\]\) [Send](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L97-L101>)
+### func \(\*TelemetrySender\[T\]\) [Send](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L102-L106>)
 
 ```go
 func (ts *TelemetrySender[T]) Send(ctx context.Context, val T, opt ...SendOption) (err error)
@@ -921,7 +922,7 @@ func (ts *TelemetrySender[T]) Send(ctx context.Context, val T, opt ...SendOption
 Send emits the telemetry. This will block until the message is ack'd.
 
 <a name="TelemetrySenderOption"></a>
-## type [TelemetrySenderOption](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L23-L25>)
+## type [TelemetrySenderOption](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L25-L27>)
 
 TelemetrySenderOption represents a single telemetry sender option.
 
@@ -932,12 +933,13 @@ type TelemetrySenderOption interface {
 ```
 
 <a name="TelemetrySenderOptions"></a>
-## type [TelemetrySenderOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L28-L32>)
+## type [TelemetrySenderOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L30-L35>)
 
 TelemetrySenderOptions are the resolved telemetry sender options.
 
 ```go
 type TelemetrySenderOptions struct {
+    DataSchema     *url.URL
     TopicNamespace string
     TopicTokens    map[string]string
     Logger         *slog.Logger
@@ -945,7 +947,7 @@ type TelemetrySenderOptions struct {
 ```
 
 <a name="TelemetrySenderOptions.Apply"></a>
-### func \(\*TelemetrySenderOptions\) [Apply](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L141-L144>)
+### func \(\*TelemetrySenderOptions\) [Apply](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L146-L149>)
 
 ```go
 func (o *TelemetrySenderOptions) Apply(opts []TelemetrySenderOption, rest ...TelemetrySenderOption)
@@ -954,7 +956,7 @@ func (o *TelemetrySenderOptions) Apply(opts []TelemetrySenderOption, rest ...Tel
 Apply resolves the provided list of options.
 
 <a name="TelemetrySenderOptions.ApplyOptions"></a>
-### func \(\*TelemetrySenderOptions\) [ApplyOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L151>)
+### func \(\*TelemetrySenderOptions\) [ApplyOptions](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L156>)
 
 ```go
 func (o *TelemetrySenderOptions) ApplyOptions(opts []Option, rest ...Option)
@@ -972,12 +974,21 @@ type WithCacheTTL time.Duration
 ```
 
 <a name="WithConcurrency"></a>
-## type [WithConcurrency](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L12>)
+## type [WithConcurrency](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L13>)
 
 WithConcurrency indicates how many handlers can execute in parallel.
 
 ```go
 type WithConcurrency uint
+```
+
+<a name="WithDataSchema"></a>
+## type [WithDataSchema](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L35>)
+
+WithDataSchema specifies a data schema that will be used for CloudEvents.
+
+```go
+type WithDataSchema url.URL
 ```
 
 <a name="WithFencingToken"></a>
@@ -1008,7 +1019,7 @@ type WithManualAck bool
 ```
 
 <a name="WithMetadata"></a>
-## type [WithMetadata](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L31>)
+## type [WithMetadata](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L32>)
 
 WithMetadata specifies user\-provided metadata values.
 
@@ -1044,7 +1055,7 @@ type WithResponseTopicSuffix string
 ```
 
 <a name="WithRetain"></a>
-## type [WithRetain](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L49>)
+## type [WithRetain](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/telemetry_sender.go#L52>)
 
 WithRetain indicates that the telemetry event should be retained by the broker.
 
@@ -1053,7 +1064,7 @@ type WithRetain bool
 ```
 
 <a name="WithShareName"></a>
-## type [WithShareName](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L19>)
+## type [WithShareName](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L20>)
 
 WithShareName connects this listener to a shared MQTT subscription.
 
@@ -1062,7 +1073,7 @@ type WithShareName string
 ```
 
 <a name="WithTimeout"></a>
-## type [WithTimeout](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L16>)
+## type [WithTimeout](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L17>)
 
 WithTimeout applies a context timeout to the message invocation or handler execution, as appropriate.
 
@@ -1071,7 +1082,7 @@ type WithTimeout time.Duration
 ```
 
 <a name="WithTopicNamespace"></a>
-## type [WithTopicNamespace](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L35>)
+## type [WithTopicNamespace](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L39>)
 
 WithTopicNamespace specifies a namespace that will be prepended to the topic.
 
@@ -1080,7 +1091,7 @@ type WithTopicNamespace string
 ```
 
 <a name="WithTopicTokenNamespace"></a>
-## type [WithTopicTokenNamespace](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L28>)
+## type [WithTopicTokenNamespace](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L29>)
 
 WithTopicTokenNamespace specifies a namespace that will be prepended to all previously\-specified topic tokens. Topic tokens specified after this option will not be namespaced, allowing this to differentiate user tokens from system tokens.
 
@@ -1089,7 +1100,7 @@ type WithTopicTokenNamespace string
 ```
 
 <a name="WithTopicTokens"></a>
-## type [WithTopicTokens](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L22>)
+## type [WithTopicTokens](<https://github.com/Azure/iot-operations-sdks/blob/main/go/protocol/common_options.go#L23>)
 
 WithTopicTokens specifies topic token values.
 

--- a/go/protocol/common_options.go
+++ b/go/protocol/common_options.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"log/slog"
+	"net/url"
 	"time"
 )
 
@@ -29,6 +30,9 @@ type (
 
 	// WithMetadata specifies user-provided metadata values.
 	WithMetadata map[string]string
+
+	// WithDataSchema specifies a data schema that will be used for CloudEvents.
+	WithDataSchema url.URL
 
 	// WithTopicNamespace specifies a namespace that will be prepended to the
 	// topic.
@@ -74,6 +78,13 @@ func (WithShareName) option() {}
 
 func (o WithShareName) telemetryReceiver(opt *TelemetryReceiverOptions) {
 	opt.ShareName = string(o)
+}
+
+func (*WithDataSchema) option() {}
+
+func (o *WithDataSchema) telemetrySender(opt *TelemetrySenderOptions) {
+	dataSchema := url.URL(*o)
+	opt.DataSchema = &dataSchema
 }
 
 func (o WithTopicNamespace) commandExecutor(opt *CommandExecutorOptions) {

--- a/go/protocol/telemetry_cloud_event.go
+++ b/go/protocol/telemetry_cloud_event.go
@@ -85,7 +85,7 @@ func (ce *CloudEvent) Attrs() []slog.Attr {
 }
 
 // Initialize default values in the cloud event where possible; error where not.
-func cloudEventToMessage(msg *mqtt.Message, ce *CloudEvent) error {
+func cloudEventToMessage(msg *mqtt.Message, ce *CloudEvent, ds *url.URL) error {
 	// Cloud events were not specified; just bail out.
 	if ce == nil {
 		return nil
@@ -143,6 +143,8 @@ func cloudEventToMessage(msg *mqtt.Message, ce *CloudEvent) error {
 
 	if ce.DataSchema != nil {
 		msg.UserProperties[ceDataSchema] = ce.DataSchema.String()
+	} else if ds != nil {
+		msg.UserProperties[ceDataSchema] = ds.String()
 	}
 
 	if ce.Subject != "" {

--- a/go/protocol/telemetry_sender.go
+++ b/go/protocol/telemetry_sender.go
@@ -5,6 +5,7 @@ package protocol
 import (
 	"context"
 	"log/slog"
+	"net/url"
 	"time"
 
 	"github.com/Azure/iot-operations-sdks/go/internal/options"
@@ -16,7 +17,8 @@ import (
 type (
 	// TelemetrySender provides the ability to send a single telemetry.
 	TelemetrySender[T any] struct {
-		publisher *publisher[T]
+		publisher  *publisher[T]
+		dataSchema *url.URL
 	}
 
 	// TelemetrySenderOption represents a single telemetry sender option.
@@ -26,6 +28,7 @@ type (
 
 	// TelemetrySenderOptions are the resolved telemetry sender options.
 	TelemetrySenderOptions struct {
+		DataSchema     *url.URL
 		TopicNamespace string
 		TopicTokens    map[string]string
 		Logger         *slog.Logger
@@ -90,6 +93,8 @@ func NewTelemetrySender[T any](
 		topic:    tp,
 	}
 
+	ts.dataSchema = opts.DataSchema
+
 	return ts, nil
 }
 
@@ -128,7 +133,7 @@ func (ts *TelemetrySender[T]) Send(
 		return err
 	}
 
-	if err := cloudEventToMessage(pub, opts.CloudEvent); err != nil {
+	if err := cloudEventToMessage(pub, opts.CloudEvent, ts.dataSchema); err != nil {
 		return err
 	}
 	pub.Retain = opts.Retain

--- a/go/test/protocol/command_executor_tester.go
+++ b/go/test/protocol/command_executor_tester.go
@@ -432,9 +432,9 @@ func checkPublishedResponse(
 
 	for key, val := range publishedMessage.Metadata {
 		propVal, ok := getUserProperty(t, msg, key)
-		if val != "" {
+		if val != nil {
 			require.True(t, ok)
-			require.Equal(t, val, propVal)
+			require.Equal(t, *val, propVal)
 		} else {
 			require.False(t, ok)
 		}

--- a/go/test/protocol/command_invoker_tester.go
+++ b/go/test/protocol/command_invoker_tester.go
@@ -341,8 +341,18 @@ func awaitInvocation(
 			"Unexpected error returned when awaiting CommandInvoker.Invoke()",
 		)
 
-		if responseValue, ok := actionAwaitInvocation.ResponseValue.(string); ok {
+		if actionAwaitInvocation.ResponseValue == nil {
+			require.Empty(t, extResp.Response.Payload)
+		} else if responseValue, ok := actionAwaitInvocation.ResponseValue.(string); ok {
 			require.Equal(t, responseValue, extResp.Response.Payload)
+		}
+
+		if actionAwaitInvocation.Metadata != nil {
+			for key, val := range *actionAwaitInvocation.Metadata {
+				propVal, ok := extResp.Response.Metadata[key]
+				require.True(t, ok)
+				require.Equal(t, val, propVal)
+			}
 		}
 	} else {
 		require.Errorf(t, extResp.Error, "Expected %s error, but no error returned when awaiting CommandInvoker.Invoke()", actionAwaitInvocation.Catch.ErrorKind)
@@ -489,8 +499,12 @@ func checkPublishedRequest(
 
 	for key, val := range publishedMessage.Metadata {
 		propVal, ok := getUserProperty(t, msg, key)
-		require.True(t, ok)
-		require.Equal(t, val, propVal)
+		if val != nil {
+			require.True(t, ok)
+			require.Equal(t, *val, propVal)
+		} else {
+			require.False(t, ok)
+		}
 	}
 
 	if publishedMessage.SourceID != nil {

--- a/go/test/protocol/default_sender.go
+++ b/go/test/protocol/default_sender.go
@@ -6,6 +6,7 @@ type DefaultSender struct {
 	TelemetryName  *string `toml:"telemetry-name"`
 	TelemetryTopic *string `toml:"telemetry-topic"`
 	ModelID        *string `toml:"model-id"`
+	DataSchema     *string `toml:"data-schema"`
 	TopicNamespace *string `toml:"topic-namespace"`
 }
 
@@ -34,6 +35,15 @@ func (sender *DefaultSender) GetModelID() *string {
 
 	modelID := *sender.ModelID
 	return &modelID
+}
+
+func (sender *DefaultSender) GetDataSchema() *string {
+	if sender.DataSchema == nil {
+		return nil
+	}
+
+	dataSchema := *sender.DataSchema
+	return &dataSchema
 }
 
 func (sender *DefaultSender) GetTopicNamespace() *string {

--- a/go/test/protocol/telemetry_sender_tester.go
+++ b/go/test/protocol/telemetry_sender_tester.go
@@ -157,10 +157,6 @@ func runOneTelemetrySenderTest(
 		)
 	}
 
-	for _, topic := range testCase.Epilogue.SubscribedTopics {
-		require.True(t, stubBroker.HasSubscribed(topic))
-	}
-
 	if testCase.Epilogue.PublicationCount != nil {
 		require.Equal(
 			t,
@@ -171,14 +167,6 @@ func runOneTelemetrySenderTest(
 
 	for ix, publishedMessage := range testCase.Epilogue.PublishedMessages {
 		checkPublishedTelemetry(t, ix, &publishedMessage, stubBroker)
-	}
-
-	if testCase.Epilogue.AcknowledgementCount != nil {
-		require.Equal(
-			t,
-			*testCase.Epilogue.AcknowledgementCount,
-			stubBroker.AcknowledgementCount,
-		)
 	}
 }
 
@@ -192,6 +180,23 @@ func getTelemetrySender(
 	options := []protocol.TelemetrySenderOption{
 		protocol.WithTopicTokens(tcs.CustomTokenMap),
 		protocol.WithTopicTokenNamespace("ex:"),
+	}
+
+	if tcs.DataSchema != nil {
+		dataSchema, err := url.Parse(*tcs.DataSchema)
+		require.NoErrorf(
+			t,
+			err,
+			"Unable to parse DataSchema as a URL: %s",
+			*tcs.DataSchema,
+		)
+
+		dataSchemaOption := protocol.WithDataSchema(*dataSchema)
+
+		options = append(
+			options,
+			&dataSchemaOption,
+		)
 	}
 
 	if tcs.TopicNamespace != nil {
@@ -242,7 +247,7 @@ func sendTelemetry(
 		protocol.WithTimeout(actionSendTelemetry.Timeout.ToDuration()),
 	)
 
-	if actionSendTelemetry.Qos != nil {
+	if actionSendTelemetry.Qos != nil && *actionSendTelemetry.Qos != 1 {
 		t.Skipf(
 			"Skipping test because TelemetrySender does not support settable QoS",
 		)
@@ -326,8 +331,12 @@ func checkPublishedTelemetry(
 
 	for key, val := range publishedMessage.Metadata {
 		propVal, ok := getUserProperty(t, msg, key)
-		require.True(t, ok)
-		require.Equal(t, val, propVal)
+		if val != nil {
+			require.True(t, ok)
+			require.Equal(t, *val, propVal)
+		} else {
+			require.False(t, ok)
+		}
 	}
 
 	if publishedMessage.SourceID != nil {

--- a/go/test/protocol/test_case_published_message.go
+++ b/go/test/protocol/test_case_published_message.go
@@ -7,14 +7,14 @@ import (
 )
 
 type testCasePublishedMessage struct {
-	CorrelationIndex   *int              `yaml:"correlation-index"`
-	Topic              *string           `yaml:"topic"`
-	Payload            any               `yaml:"payload"`
-	Metadata           map[string]string `yaml:"metadata"`
-	CommandStatus      any               `yaml:"command-status"`
-	IsApplicationError *bool             `yaml:"is-application-error"`
-	SourceID           *string           `yaml:"source-id"`
-	Expiry             *uint32           `yaml:"expiry"`
+	CorrelationIndex   *int               `yaml:"correlation-index"`
+	Topic              *string            `yaml:"topic"`
+	Payload            any                `yaml:"payload"`
+	Metadata           map[string]*string `yaml:"metadata"`
+	CommandStatus      any                `yaml:"command-status"`
+	IsApplicationError *bool              `yaml:"is-application-error"`
+	SourceID           *string            `yaml:"source-id"`
+	Expiry             *uint32            `yaml:"expiry"`
 }
 
 type TestCasePublishedMessage struct {

--- a/go/test/protocol/test_case_sender.go
+++ b/go/test/protocol/test_case_sender.go
@@ -10,6 +10,7 @@ type testCaseSender struct {
 	TelemetryName  *string           `yaml:"telemetry-name"`
 	TelemetryTopic *string           `yaml:"telemetry-topic"`
 	ModelID        *string           `yaml:"model-id"`
+	DataSchema     *string           `yaml:"data-schema"`
 	TopicNamespace *string           `yaml:"topic-namespace"`
 	CustomTokenMap map[string]string `yaml:"custom-token-map"`
 }
@@ -24,6 +25,7 @@ func (sender *TestCaseSender) UnmarshalYAML(node *yaml.Node) error {
 	sender.TelemetryName = TestCaseDefaultInfo.Prologue.Sender.GetTelemetryName()
 	sender.TelemetryTopic = TestCaseDefaultInfo.Prologue.Sender.GetTelemetryTopic()
 	sender.ModelID = TestCaseDefaultInfo.Prologue.Sender.GetModelID()
+	sender.DataSchema = TestCaseDefaultInfo.Prologue.Sender.GetDataSchema()
 	sender.TopicNamespace = TestCaseDefaultInfo.Prologue.Sender.GetTopicNamespace()
 
 	return node.Decode(&sender.testCaseSender)


### PR DESCRIPTION
* METL test cases
  * Add 92 sanity-check test cases to validate that METL testers properly check all validation conditions
* Go testing changes (identified by running new sanity checks)
  * Add support for METL `data-schema` key in `senders`
  * Fix published message metadata checks for non-present headers
  * Remove inappropriate checks of subscribed topics and acknowledgement count from TelemetrySender tester
  * Do not skip TelemetrySender test cases that specify a QoS of 1
  * Add check for empty response value in CommandInvoker tester
  * Add checks of metadata values in CommandInvoker tester
* Go SDK changes
  * Add `WithDataSchema` option to TelemetrySender
    * needed to support METL language
    * aligns with public `DataSchema` property of .NET TelemetrySender
