### PR TITLE
Add --clientOnly and --serverOnly options to ProtocolCompiler

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ArgBinder.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ArgBinder.cs
@@ -1,0 +1,89 @@
+﻿namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using System.CommandLine;
+    using System.CommandLine.Binding;
+    using System.IO;
+
+    /// <summary>
+    /// Custom arguemnt binder for CLI.
+    /// </summary>
+    public class ArgBinder : BinderBase<OptionContainer>
+    {
+        private readonly Option<FileInfo[]> modelFile;
+        private readonly Option<string?> modelId;
+        private readonly Option<string?> dmrRoot;
+        private readonly Option<string?> workingDir;
+        private readonly Option<DirectoryInfo> outDir;
+#if DEBUG
+        private readonly Option<bool> sync;
+        private readonly Option<string?> sdkPath;
+#endif
+        private readonly Option<string> lang;
+        private readonly Option<bool> clientOnly;
+        private readonly Option<bool> serverOnly;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgBinder"/> class.
+        /// </summary>
+        /// <param name="modelFile">File(s) containing DTDL model(s) to process.</param>
+        /// <param name="modelId">DTMI of Interface to use for codegen (not needed when model has only one Mqtt Interface).</param>
+        /// <param name="dmrRoot">Directory or URL from which to retrieve referenced models.</param>
+        /// <param name="workingDir">Directory for storing temporary files (relative to outDir unless path is rooted).</param>
+        /// <param name="outDir">Directory for receiving generated code.</param>
+        /// <param name="lang">Programming language for generated code.</param>
+#if DEBUG
+        /// <param name="sync">Generate synchronous API.</param>
+        /// <param name="sdkPath">Local path or feed URL for Azure.Iot.Operations.Protocol SDK.</param>
+#endif
+        /// <param name="clientOnly">Generate only client-side code.</param>
+        /// <param name="serverOnly">Generate only server-side code.</param>
+        public ArgBinder(
+            Option<FileInfo[]> modelFile,
+            Option<string?> modelId,
+            Option<string?> dmrRoot,
+            Option<string?> workingDir,
+            Option<DirectoryInfo> outDir,
+#if DEBUG
+            Option<bool> sync,
+            Option<string?> sdkPath,
+#endif
+            Option<string> lang,
+            Option<bool> clientOnly,
+            Option<bool> serverOnly)
+        {
+            this.modelFile = modelFile;
+            this.modelId = modelId;
+            this.dmrRoot = dmrRoot;
+            this.workingDir = workingDir;
+            this.outDir = outDir;
+#if DEBUG
+            this.sync = sync;
+            this.sdkPath = sdkPath;
+#endif
+            this.lang = lang;
+            this.clientOnly = clientOnly;
+            this.serverOnly = serverOnly;
+        }
+
+        /// <inheritdoc/>
+        protected override OptionContainer GetBoundValue(BindingContext bindingContext) =>
+            new OptionContainer()
+            {
+                ModelFiles = bindingContext.ParseResult.GetValueForOption(this.modelFile)!,
+                ModelId = bindingContext.ParseResult.GetValueForOption(this.modelId),
+                DmrRoot = bindingContext.ParseResult.GetValueForOption(this.dmrRoot),
+                WorkingDir = bindingContext.ParseResult.GetValueForOption(this.workingDir),
+                OutDir = bindingContext.ParseResult.GetValueForOption(this.outDir)!,
+#if DEBUG
+                Sync = bindingContext.ParseResult.GetValueForOption(this.sync),
+                SdkPath = bindingContext.ParseResult.GetValueForOption(this.sdkPath),
+#else
+                Sync = false,
+                SdkPath = null,
+#endif
+                Lang = bindingContext.ParseResult.GetValueForOption(this.lang)!,
+                ClientOnly = bindingContext.ParseResult.GetValueForOption(this.clientOnly),
+                ServerOnly = bindingContext.ParseResult.GetValueForOption(this.serverOnly),
+            };
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
@@ -17,37 +17,37 @@
 
         public static readonly string[] SupportedLanguages = DefaultWorkingPaths.Keys.ToArray();
 
-        public static async Task<int> GenerateCode(FileInfo[] modelFiles, string? modelId, string? dmrRoot, string? workingPath, DirectoryInfo outDir, bool syncApi, string? sdkPath, string language)
+        public static async Task<int> GenerateCode(OptionContainer options)
         {
             try
             {
-                if (modelFiles.Length == 0 && (modelId == null || dmrRoot == null))
+                if (options.ModelFiles.Length == 0 && (options.ModelId == null || options.DmrRoot == null))
                 {
                     Console.WriteLine("You must specify at least one modelFile or both a modelId and dmrRoot");
                     return 1;
                 }
 
-                if (modelFiles.Any(mf => !mf.Exists))
+                if (options.ModelFiles.Any(mf => !mf.Exists))
                 {
                     Console.WriteLine("All modelFiles must exist");
                     return 1;
                 }
 
                 Dtmi? modelDtmi = null;
-                if (modelId != null && !Dtmi.TryCreateDtmi(modelId, out modelDtmi))
+                if (options.ModelId != null && !Dtmi.TryCreateDtmi(options.ModelId, out modelDtmi))
                 {
-                    Console.WriteLine($"modelId \"{modelId}\" is not a valid DTMI");
+                    Console.WriteLine($"modelId \"{options.ModelId}\" is not a valid DTMI");
                     return 1;
                 }
 
                 Uri? dmrUri = null;
-                if (dmrRoot != null)
+                if (options.DmrRoot != null)
                 {
-                    if (!Uri.TryCreate(dmrRoot, UriKind.Absolute, out dmrUri))
+                    if (!Uri.TryCreate(options.DmrRoot, UriKind.Absolute, out dmrUri))
                     {
-                        if (Directory.Exists(dmrRoot))
+                        if (Directory.Exists(options.DmrRoot))
                         {
-                            dmrUri = new Uri(Path.GetFullPath(dmrRoot));
+                            dmrUri = new Uri(Path.GetFullPath(options.DmrRoot));
                         }
                         else
                         {
@@ -57,14 +57,20 @@
                     }
                 }
 
-                if (!SupportedLanguages.Contains(language))
+                if (!SupportedLanguages.Contains(options.Lang))
                 {
                     Console.WriteLine($"language must be {string.Join(" or ", SupportedLanguages.Select(l => $"'{l}'"))}");
                     return 1;
                 }
 
-                string[] modelTexts = modelFiles.Select(mf => mf.OpenText().ReadToEnd()).ToArray();
-                string[] modelNames = modelFiles.Select(mf => mf.Name).ToArray();
+                if (options.ClientOnly && options.ServerOnly)
+                {
+                    Console.WriteLine("options --clientOnly and --serverOnly are mutually exclusive");
+                    return 1;
+                }
+
+                string[] modelTexts = options.ModelFiles.Select(mf => mf.OpenText().ReadToEnd()).ToArray();
+                string[] modelNames = options.ModelFiles.Select(mf => mf.Name).ToArray();
                 ModelSelector.ContextualizedInterface contextualizedInterface = await ModelSelector.GetInterfaceAndModelContext(modelTexts, modelNames, modelDtmi, dmrUri, Console.WriteLine);
 
                 if (contextualizedInterface.InterfaceId == null)
@@ -74,12 +80,12 @@
 
                 var modelParser = new ModelParser();
 
-                string projectName = Path.GetFileNameWithoutExtension(outDir.FullName);
+                string projectName = Path.GetFileNameWithoutExtension(options.OutDir.FullName);
 
                 string workingPathResolved =
-                    workingPath == null ? Path.Combine(outDir.FullName, DefaultWorkingPaths[language]) :
-                    Path.IsPathRooted(workingPath) ? workingPath :
-                    Path.Combine(outDir.FullName, workingPath);
+                    options.WorkingDir == null ? Path.Combine(options.OutDir.FullName, DefaultWorkingPaths[options.Lang]) :
+                    Path.IsPathRooted(options.WorkingDir) ? options.WorkingDir :
+                    Path.Combine(options.OutDir.FullName, options.WorkingDir);
                 DirectoryInfo workingDir = new(workingPathResolved);
 
                 string genNamespace = NameFormatter.DtmiToNamespace(contextualizedInterface.InterfaceId);
@@ -91,10 +97,10 @@
 
                 foreach (string schemaFileName in schemaFiles)
                 {
-                    TypesGenerator.GenerateType(language, projectName, schemaFileName, workingDir, outDir, genNamespace, sourceFilePaths, distinctSchemaKinds);
+                    TypesGenerator.GenerateType(options.Lang, projectName, schemaFileName, workingDir, options.OutDir, genNamespace, sourceFilePaths, distinctSchemaKinds);
                 }
 
-                EnvoyGenerator.GenerateEnvoys(language, projectName, annexFile, workingDir, outDir, genNamespace, sdkPath, syncApi, sourceFilePaths, distinctSchemaKinds);
+                EnvoyGenerator.GenerateEnvoys(options.Lang, projectName, annexFile, workingDir, options.OutDir, genNamespace, options.SdkPath, options.Sync, !options.ServerOnly, !options.ClientOnly, sourceFilePaths, distinctSchemaKinds);
             }
             catch (Exception ex)
             {

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/EnvoyGenerator/EnvoyGenerator.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/EnvoyGenerator/EnvoyGenerator.cs
@@ -9,12 +9,12 @@
 
     internal class EnvoyGenerator
     {
-        public static void GenerateEnvoys(string language, string projectName, string annexFileName, DirectoryInfo workingDir, DirectoryInfo outDir, string genNamespace, string? sdkPath, bool syncApi, HashSet<string> sourceFilePaths, HashSet<SchemaKind> distinctSchemaKinds)
+        public static void GenerateEnvoys(string language, string projectName, string annexFileName, DirectoryInfo workingDir, DirectoryInfo outDir, string genNamespace, string? sdkPath, bool syncApi, bool generateClient, bool generateServer, HashSet<string> sourceFilePaths, HashSet<SchemaKind> distinctSchemaKinds)
         {
             string? relativeSdkPath = sdkPath == null || sdkPath.StartsWith("http://") || sdkPath.StartsWith("https://") ? sdkPath : Path.GetRelativePath(outDir.FullName, sdkPath);
             using (JsonDocument annexDoc = JsonDocument.Parse(File.OpenText(Path.Combine(workingDir.FullName, genNamespace, annexFileName)).ReadToEnd()))
             {
-                foreach (ITemplateTransform templateTransform in EnvoyTransformFactory.GetTransforms(language, projectName, annexDoc, workingDir.FullName, relativeSdkPath, syncApi, sourceFilePaths, distinctSchemaKinds))
+                foreach (ITemplateTransform templateTransform in EnvoyTransformFactory.GetTransforms(language, projectName, annexDoc, workingDir.FullName, relativeSdkPath, syncApi, generateClient, generateServer, sourceFilePaths, distinctSchemaKinds))
                 {
                     string envoyFilePath = Path.Combine(outDir.FullName, templateTransform.FolderPath, templateTransform.FileName);
                     if (templateTransform is IUpdatingTransform updatingTransform)

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/OptionContainer.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/OptionContainer.cs
@@ -1,0 +1,40 @@
+﻿namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using System.IO;
+
+    /// <summary>
+    /// Custom container for holding CLI options.
+    /// </summary>
+    public class OptionContainer
+    {
+        /// <summary>Gets or sets the file(s) containing DTDL model(s) to process.</summary>
+        public required FileInfo[] ModelFiles { get; set; }
+
+        /// <summary>Gets or sets the DTMI of the Interface to use for codegen.</summary>
+        public string? ModelId { get; set; }
+
+        /// <summary>Gets or sets a directory or URL from which to retrieve referenced models.</summary>
+        public string? DmrRoot { get; set; }
+
+        /// <summary>Gets or sets the directory for storing temporary files.</summary>
+        public string? WorkingDir { get; set; }
+
+        /// <summary>Gets or sets the directory for receiving generated code.</summary>
+        public required DirectoryInfo OutDir { get; set; }
+
+        /// <summary>Gets or sets the programming language for generated code.</summary>
+        public required string Lang { get; set; }
+
+        /// <summary>Gets or sets an indication of whether to generate synchronous API.</summary>
+        public bool Sync { get; set; }
+
+        /// <summary>Gets or sets a local path or feed URL for Azure.Iot.Operations.Protocol SDK.</summary>
+        public string? SdkPath { get; set; }
+
+        /// <summary>Gets or sets an indication of whether to generate only client-side code.</summary>
+        public bool ClientOnly { get; set; }
+
+        /// <summary>Gets or sets an indication of whether to generate only server-side code.</summary>
+        public bool ServerOnly { get; set; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
@@ -54,6 +54,14 @@ internal class Program
             description: "Programming language for generated code")
             { ArgumentHelpName = string.Join('|', CommandHandler.SupportedLanguages) };
 
+        var clientOnlyOption = new Option<bool>(
+            name: "--clientOnly",
+            description: "Generate only client-side code");
+
+        var serverOnlyOption = new Option<bool>(
+            name: "--serverOnly",
+            description: "Generate only server-side code");
+
         var rootCommand = new RootCommand("Akri MQTT code generation tool for DTDL models")
         {
             modelFileOption,
@@ -66,14 +74,12 @@ internal class Program
             sdkPathOption,
 #endif
             langOption,
+            clientOnlyOption,
+            serverOnlyOption,
         };
 
-        rootCommand.SetHandler(
-#if DEBUG
-            async (modelFiles, modelId, dmrRoot, workingDir, outDir, syncApi, sdkPath, language) => { await CommandHandler.GenerateCode(modelFiles, modelId, dmrRoot, workingDir, outDir, syncApi, sdkPath, language); },
-#else
-            async (modelFiles, modelId, dmrRoot, workingDir, outDir, language) => { await CommandHandler.GenerateCode(modelFiles, modelId, dmrRoot, workingDir, outDir, false, null, language); },
-#endif
+
+        ArgBinder argBinder = new ArgBinder(
             modelFileOption,
             modelIdOption,
             dmrRootOption,
@@ -83,7 +89,13 @@ internal class Program
             syncOption,
             sdkPathOption,
 #endif
-            langOption);
+            langOption,
+            clientOnlyOption,
+            serverOnlyOption);
+
+        rootCommand.SetHandler(
+            async (OptionContainer options) => { await CommandHandler.GenerateCode(options); },
+            argBinder);
 
         return await rootCommand.InvokeAsync(args);
     }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Service/code/DotNetService.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Service/code/DotNetService.cs
@@ -19,6 +19,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly bool doesCommandTargetService;
         private readonly bool doesTelemetryTargetService;
         private readonly bool syncApi;
+        private readonly bool generateClient;
+        private readonly bool generateServer;
 
         public DotNetService(
             string projectName,
@@ -35,7 +37,9 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             bool doesCommandTargetExecutor,
             bool doesCommandTargetService,
             bool doesTelemetryTargetService,
-            bool syncApi)
+            bool syncApi,
+            bool generateClient,
+            bool generateServer)
         {
             this.projectName = projectName;
             this.genNamespace = genNamespace;
@@ -53,6 +57,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.doesCommandTargetService = doesCommandTargetService;
             this.doesTelemetryTargetService = doesTelemetryTargetService;
             this.syncApi = syncApi;
+            this.generateClient = generateClient;
+            this.generateServer = generateServer;
         }
 
         public string FileName { get => $"{this.serviceName}.g.cs"; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Service/t4/DotNetService.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Service/t4/DotNetService.tt
@@ -26,6 +26,7 @@ namespace <#=this.projectName#>.<#=this.genNamespace#>
 <# } #>
     public static partial class <#=this.serviceName#>
     {
+<# if (this.generateServer) { #>
 <# if (this.cmdServiceGroupId != null) { #>
         [ServiceGroupId("<#=this.cmdServiceGroupId#>")]
 <# } #>
@@ -133,7 +134,11 @@ namespace <#=this.projectName#>.<#=this.genNamespace#>
 <# } #>
             }
         }
+<# } #>
+<# if (this.generateServer && this.generateClient) { #>
 
+<# } #>
+<# if (this.generateClient) { #>
 <# if (this.telemServiceGroupId != null) { #>
         [ServiceGroupId("<#=this.telemServiceGroupId#>")]
 <# } #>
@@ -235,6 +240,7 @@ namespace <#=this.projectName#>.<#=this.genNamespace#>
 <# } #>
             }
         }
+<# } #>
     }
 }
 <#+

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/go/Service/code/GoService.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/go/Service/code/GoService.cs
@@ -15,6 +15,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly bool doesCommandTargetService;
         private readonly bool doesTelemetryTargetService;
         private readonly bool syncApi;
+        private readonly bool generateClient;
+        private readonly bool generateServer;
 
         public GoService(
             string genNamespace,
@@ -28,7 +30,9 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             List<string> telemSchemas,
             bool doesCommandTargetService,
             bool doesTelemetryTargetService,
-            bool syncApi)
+            bool syncApi,
+            bool generateClient,
+            bool generateServer)
         {
             this.genNamespace = genNamespace;
             this.modelId = modelId;
@@ -42,6 +46,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.doesCommandTargetService = doesCommandTargetService;
             this.doesTelemetryTargetService = doesTelemetryTargetService;
             this.syncApi = syncApi;
+            this.generateClient = generateClient;
+            this.generateServer = generateServer;
         }
 
         public string FileName { get => "wrapper.go"; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/go/Service/t4/GoService.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/go/Service/t4/GoService.tt
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/iot-operations-sdks/go/protocol"
 )
 
+<# if (this.generateServer) { #>
 type <#=this.serviceName#>Service struct {
 	protocol.Listeners
 <# foreach (var cmdNameReqResp in this.cmdNameReqResps) { #>
@@ -16,6 +17,8 @@ type <#=this.serviceName#>Service struct {
 <# } #>
 }
 
+<# } #>
+<# if (this.generateClient) { #>
 type <#=this.serviceName#>Client struct {
 	protocol.Listeners
 <# foreach (var cmdNameReqResp in this.cmdNameReqResps) { #>
@@ -26,6 +29,7 @@ type <#=this.serviceName#>Client struct {
 <# } #>
 }
 
+<# } #>
 const (
 <# if (this.doesCommandTargetService || this.doesTelemetryTargetService) { #>
 	ModelID = "<#=this.modelId#>"
@@ -37,6 +41,7 @@ const (
 	TelemetryTopic = "<#=this.telemetryTopic#>"
 <# } #>
 )
+<# if (this.generateServer) { #>
 
 func New<#=this.serviceName#>Service(
 	client protocol.MqttClient,
@@ -105,6 +110,8 @@ func New<#=this.serviceName#>Service(
 
 	return <#=this.AsLower(this.serviceName)#>Service, nil
 }
+<# } #>
+<# if (this.generateClient) { #>
 
 func New<#=this.serviceName#>Client(
 	client protocol.MqttClient,
@@ -171,6 +178,7 @@ func New<#=this.serviceName#>Client(
 
 	return <#=this.AsLower(this.serviceName)#>Client, nil
 }
+<# } #>
 <#+
     private string AsUpper(string name) => char.ToUpperInvariant(name[0]) + name.Substring(1);
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Service/code/RustService.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Service/code/RustService.cs
@@ -17,6 +17,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly bool doesCommandTargetExecutor;
         private readonly bool doesCommandTargetService;
         private readonly bool doesTelemetryTargetService;
+        private readonly bool generateClient;
+        private readonly bool generateServer;
         private readonly Regex sourceFileRegex;
         private readonly List<string> modules;
 
@@ -33,6 +35,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             bool doesCommandTargetExecutor,
             bool doesCommandTargetService,
             bool doesTelemetryTargetService,
+            bool generateClient,
+            bool generateServer,
             HashSet<string> sourceFilePaths)
         {
             this.genNamespace = genNamespace;
@@ -47,6 +51,8 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.doesCommandTargetExecutor = doesCommandTargetExecutor;
             this.doesCommandTargetService = doesCommandTargetService;
             this.doesTelemetryTargetService = doesTelemetryTargetService;
+            this.generateClient = generateClient;
+            this.generateServer = generateServer;
             this.sourceFileRegex = new($"[\\/\\\\]{genNamespace}[\\/\\\\][A-Za-z0-9_\\.]+\\.rs");
             this.modules = sourceFilePaths.Where(p => this.sourceFileRegex.IsMatch(p)).Select(p => Path.GetFileNameWithoutExtension(p)).Order().ToList();
         }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Service/t4/RustService.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Service/t4/RustService.tt
@@ -24,15 +24,19 @@ pub const COMMAND_SERVICE_GROUP_ID: &str = "<#=this.cmdServiceGroupId#>";
 <# if (this.telemServiceGroupId != null) { #>
 pub const TELEMETRY_SERVICE_GROUP_ID: &str = "<#=this.telemServiceGroupId#>";
 <# } #>
+<# if (this.generateClient) { #>
 
 pub mod client {
 <# foreach (string module in this.modules) { if (!module.EndsWith("_executor") && !module.EndsWith("_sender") && !module.EndsWith("_serialization")) { #>
     pub use super::<#=module#>::*;
 <# } } #>
 }
+<# } #>
+<# if (this.generateServer) { #>
 
 pub mod service {
 <# foreach (string module in this.modules) { if (!module.EndsWith("_invoker") && !module.EndsWith("_receiver") && !module.EndsWith("_serialization")) { #>
     pub use super::<#=module#>::*;
 <# } } #>
 }
+<# } #>

--- a/codegen/test/ProtocolCompiler.UnitTests/EnvoyGeneratorTests/EnvoyTransformFactoryTests.cs
+++ b/codegen/test/ProtocolCompiler.UnitTests/EnvoyGeneratorTests/EnvoyTransformFactoryTests.cs
@@ -51,7 +51,7 @@
                 {
                     HashSet<string> sourceFilePaths = new();
                     HashSet<SchemaKind> distinctSchemaKinds = new();
-                    EnvoyTransformFactory.GetTransforms("csharp", "TestProject", annexDoc, null, null, false, sourceFilePaths, distinctSchemaKinds).ToList();
+                    EnvoyTransformFactory.GetTransforms("csharp", "TestProject", annexDoc, null, null, false, true, true, sourceFilePaths, distinctSchemaKinds).ToList();
                 }
                 catch
                 {

--- a/codegen/test/samples/dotnet/gen.sh
+++ b/codegen/test/samples/dotnet/gen.sh
@@ -2,6 +2,8 @@
 ../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/CommandComplexSchemas.json --outDir ./CommandComplexSchemasSample --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol
 ../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/CommandRaw.json --outDir ./CommandRawSample --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol
 ../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSample --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol
+../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleClientOnly --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol --clientOnly
+../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleServerOnly --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol --serverOnly
 ../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/TelemetryComplexSchemas.json --outDir ./TelemetryComplexSchemasSample --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol
 ../../../src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net8.0/Azure.Iot.Operations.ProtocolCompiler --modelFile ../dtdl/TelemetryPrimitiveSchemas.json --outDir ./TelemetryPrimitiveSchemasSample --lang csharp --sdkPath ../../../../dotnet/src/Azure.Iot.Operations.Protocol
 
@@ -9,5 +11,7 @@ dotnet build ./CommandVariantsSample
 dotnet build ./CommandComplexSchemasSample
 dotnet build ./CommandRawSample
 dotnet build ./TelemetryAndCommandSample
+dotnet build ./TelemetryAndCommandSampleClientOnly
+dotnet build ./TelemetryAndCommandSampleServerOnly
 dotnet build ./TelemetryComplexSchemasSample
 dotnet build ./TelemetryPrimitiveSchemasSample

--- a/codegen/test/samples/go/gen.sh
+++ b/codegen/test/samples/go/gen.sh
@@ -6,6 +6,8 @@ $gen --modelFile ../dtdl/CommandVariants.json --outDir ./CommandVariantsSample -
 $gen --modelFile ../dtdl/CommandComplexSchemas.json --outDir ./CommandComplexSchemasSample --lang go
 $gen --modelFile ../dtdl/CommandRaw.json --outDir ./CommandRawSample --lang go
 $gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSample --lang go
+$gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleClientOnly --lang go --clientOnly
+$gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleServerOnly --lang go --serverOnly
 $gen --modelFile ../dtdl/TelemetryComplexSchemas.json --outDir ./TelemetryComplexSchemasSample --lang go
 $gen --modelFile ../dtdl/TelemetryPrimitiveSchemas.json --outDir ./TelemetryPrimitiveSchemasSample --lang go
 

--- a/codegen/test/samples/rust/gen.sh
+++ b/codegen/test/samples/rust/gen.sh
@@ -6,5 +6,7 @@ $gen --modelFile ../dtdl/CommandVariants.json --outDir ./CommandVariantsSample -
 $gen --modelFile ../dtdl/CommandComplexSchemas.json --outDir ./CommandComplexSchemasSample --lang rust --sdkPath ../../../../rust
 $gen --modelFile ../dtdl/CommandRaw.json --outDir ./CommandRawSample --lang rust --sdkPath ../../../../rust
 $gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSample --lang rust --sdkPath ../../../../rust
+$gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleClientOnly --lang rust --sdkPath ../../../../rust --clientOnly
+$gen --modelFile ../dtdl/TelemetryAndCommand.json --outDir ./TelemetryAndCommandSampleServerOnly --lang rust --sdkPath ../../../../rust --serverOnly
 $gen --modelFile ../dtdl/TelemetryComplexSchemas.json --outDir ./TelemetryComplexSchemasSample --lang rust --sdkPath ../../../../rust
 $gen --modelFile ../dtdl/TelemetryPrimitiveSchemas.json --outDir ./TelemetryPrimitiveSchemasSample --lang rust --sdkPath ../../../../rust


### PR DESCRIPTION
With these additions, the ProtocolCompiler now takes more than 8 CLI options, so the concise `System.CommandLine` API is no longer usable.  Changing to the unconstrained API (using `ArgBinder` and `OptionContainer`) increased the size of this change.