### PR TITLE
[.NET] Fix version of connector package

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>0.6.0-operator3</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This preview version was used while the code lived in a feature branch. Now that it is in main, it should be the same version as the other packages