### PR TITLE
Fix Cargo.toml for workspace in Windows

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,9 @@ members = [
   "azure_iot_operations_mqtt",
   "azure_iot_operations_protocol",
   "azure_iot_operations_services",
-  "sample_applications/counter/*",
+  "sample_applications/counter/envoy",
+  "sample_applications/counter/counter_client",
+  "sample_applications/counter/counter_server",
 ]
 
 resolver = "2"


### PR DESCRIPTION
For some time now, I have been unable to build the Rust project, in particular due to an error that suggests a problem with the workspace.  I finally figured out that by replacing the wildcard path in the workspace's Cargo.toml file with an explicit set of paths, I could get the build to work properly.

Presumably, this is not a problem in Linux, since everything seems to build fine in the pipeline.  So, it is perhaps a Windows-specific issue.  In any case, it is a trivial change, so long as it does not break the build in Linux.