### PR TITLE
[.NET] Build schema registry host before running it in a background thread

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -84,6 +84,9 @@ jobs:
     - name: Setup Faultable MQTT Broker
       run: RUNNER_TRACKING_ID="" && dotnet run --project eng/test/faultablemqttbroker/src/Azure.Iot.Operations.FaultableMqttBroker/Azure.Iot.Operations.FaultableMqttBroker.csproj &
 
+    - name: Build SchemaRegistry Host
+      run: dotnet build eng/test/schema-registry/src/Azure.Iot.Operations.Services.SchemaRegistry.Host/Azure.Iot.Operations.Services.SchemaRegistry.Host.csproj
+ 
     - name: Setup SchemaRegistry Host
       run: RUNNER_TRACKING_ID="" && dotnet run --project eng/test/schema-registry/src/Azure.Iot.Operations.Services.SchemaRegistry.Host/Azure.Iot.Operations.Services.SchemaRegistry.Host.csproj &
       


### PR DESCRIPTION
This will reveal any build errors in the schema registry service project. The next step runs that project in a background thread, so any errors encountered while building it were swallowed