### PR TITLE
[.NET] Make template projects target specific packages

### DIFF
--- a/dotnet/templates/EventDrivenTelemetryConnector/EventDrivenTelemetryConnector.csproj
+++ b/dotnet/templates/EventDrivenTelemetryConnector/EventDrivenTelemetryConnector.csproj
@@ -12,6 +12,5 @@
     <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.8.0" />
     <PackageReference Include="Azure.Iot.Operations.Connector" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-
   </ItemGroup>
 </Project>

--- a/dotnet/templates/PollingTelemetryConnector/PollingTelemetryConnector.csproj
+++ b/dotnet/templates/PollingTelemetryConnector/PollingTelemetryConnector.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="8.0.0"/>
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="8.0.0"/>
-    <PackageReference Include="Azure.Iot.Operations.Services" Version="8.0.0"/>
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="0.8.0" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.8.0" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="0.8.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Users will probably use the template outside of our solution, so don't use a local package reference to our connector/mqtt/services bits

Keeping this in draft until we have released versions 0.8.0