### PR TITLE
[StateStore CLI] Updated to use latest Rust SDK

### DIFF
--- a/tools/statestore-cli/src/main.rs
+++ b/tools/statestore-cli/src/main.rs
@@ -12,7 +12,7 @@ use azure_iot_operations_mqtt::session::{
     Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
 };
 use azure_iot_operations_mqtt::MqttConnectionSettingsBuilder;
-use azure_iot_operations_protocol::application::ApplicationContextBuilder;
+use azure_iot_operations_protocol::application::{ApplicationContext, ApplicationContextBuilder};
 use azure_iot_operations_services::state_store::{self, SetOptions};
 
 const TOOL_NAME: &str = "statestore-cli";


### PR DESCRIPTION
- Missing ApplicationContext import