### PR TITLE
[.Net] Apply Exponential Backoff Retry Policy to the leader election process 

### DIFF
--- a/dotnet/.editorconfig
+++ b/dotnet/.editorconfig
@@ -59,7 +59,6 @@ dotnet_style_readonly_field = true:warning
 dotnet_code_quality_unused_parameters = all:warning
 
 ## Naming rules ##
-dotnet_diagnostic.IDE1006.severity = warning
 
 # Private instance fields with underscore
 
@@ -94,7 +93,7 @@ dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers         = readonly
 
 # Defining the 'first_word_upper_case_style' naming style
-dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_upper
+dotnet_naming_style.first_word_upper_case_style.capitalization = pascal_case
 
 # Defining the 'public_members_must_be_capitalized' naming rule, by setting the
 # symbol group to the 'public symbols' symbol group,

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Retry/ExponentialBackoffRetryPolicy.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Retry/ExponentialBackoffRetryPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -6,33 +6,54 @@ using System;
 namespace Azure.Iot.Operations.Protocol.Retry
 {
     /// <summary>
-    /// Creates an instance of this class.
+    /// Implements Binary Exponential Backoff (BEB) retry policy as follows:
+    /// CurrentExponent = min(MaxExponent, baseExponent + currentRetryCount)
+    /// RetryDelay = min(pow(2, CurrentExponent), maxWait) milliseconds
     /// </summary>
-    /// <param name="maxRetries">The maximum number of retry attempts</param>
-    /// <param name="maxWait">The maximum amount of time to wait between retries.</param>
-    /// <param name="useJitter">Whether to add a small, random adjustment to the retry delay to avoid synchronicity in clients retrying.</param>
-    public class ExponentialBackoffRetryPolicy(uint maxRetries, TimeSpan maxWait, bool useJitter = true) : IRetryPolicy
+    public class ExponentialBackoffRetryPolicy : IRetryPolicy
     {
-        private readonly Random _rng = new();
-        private readonly object _rngLock = new();
+        // Default base exponent set equal 6, in this case first retry starts at 2^(6+1)=128 milliseconds, and exceed 1 second delay on retry #4.
+        private readonly uint _baseExponent = 6u;
 
-        // If we start with an exponent of 1 to calculate the number of millisecond delay, it starts too low and takes too long to get over 1 second.
-        // So we always add 6 to the retry count to start at 2^7=128 milliseconds, and exceed 1 second delay on retry #4.
-        private const uint MinExponent = 6u;
-
-        // Avoid integer overlow (max of 32) and clamp max delay.
+        // Avoid integer overflow (max of 32) and clamp max delay.
         private const uint MaxExponent = 32u;
 
         /// <summary>
         /// The maximum number of retries
         /// </summary>
-        private readonly uint _maxRetries = maxRetries;
+        private readonly uint _maxRetries;
 
-        private readonly TimeSpan _maxDelay = maxWait;
-        private readonly bool _useJitter = useJitter;
+        private readonly TimeSpan _maxDelay;
+        private readonly bool _useJitter;
+
+        /// <summary>
+        /// Creates an instance of this class with a default base exponent equals 6.
+        /// </summary>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="maxWait">The maximum amount of time to wait between retries.</param>
+        /// <param name="useJitter">Whether to add a small, random adjustment to the retry delay to avoid synchronicity in clients retrying.</param>
+        public ExponentialBackoffRetryPolicy(uint maxRetries, TimeSpan maxWait, bool useJitter = true)
+        {
+            _maxRetries = maxRetries;
+            _maxDelay = maxWait;
+            _useJitter = useJitter;
+        }
+
+        /// <summary>
+        /// Creates an instance of this class.
+        /// </summary>
+        /// <param name="maxRetries">The maximum number of retry attempts.</param>
+        /// <param name="baseExponent">The base exponent to start the backoff calculation (CurrentExponent(currentRetryCount) = baseExponent + currentRetryCount).</param>
+        /// <param name="maxWait">The maximum amount of time to wait between retries.</param>
+        /// <param name="useJitter">Whether to add a small, random adjustment to the retry delay to avoid synchronicity in clients retrying.</param>
+        public ExponentialBackoffRetryPolicy(uint maxRetries, uint baseExponent, TimeSpan maxWait, bool useJitter = true) :
+        this(maxRetries, maxWait, useJitter)
+        {
+            _baseExponent = baseExponent;
+        }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
+        public bool ShouldRetry(uint currentRetryCount, Exception? lastException, out TimeSpan retryDelay)
         {
             if (_maxRetries == 0 || currentRetryCount > _maxRetries)
             {
@@ -45,13 +66,13 @@ namespace Azure.Iot.Operations.Protocol.Retry
             // and decrease the value suddenly, so exponent gets capped before addition
             // Result: The delay stays at maximum instead of suddenly dropping.
             uint exponent;
-            if (currentRetryCount > uint.MaxValue - MinExponent)
+            if (currentRetryCount > uint.MaxValue - _baseExponent)
             {
                 exponent = MaxExponent;
             }
             else
             {
-                exponent = currentRetryCount + MinExponent;
+                exponent = currentRetryCount + _baseExponent;
                 exponent = Math.Min(MaxExponent, exponent);
             }
 
@@ -70,7 +91,7 @@ namespace Azure.Iot.Operations.Protocol.Retry
         /// <summary>
         /// Gets jitter between 95% and 105% of the base time.
         /// </summary>
-        protected TimeSpan UpdateWithJitter(double baseTimeMs)
+        private TimeSpan UpdateWithJitter(double baseTimeMs)
         {
             // Don't calculate jitter if the value is very small
             if (baseTimeMs < 50)
@@ -78,16 +99,7 @@ namespace Azure.Iot.Operations.Protocol.Retry
                 return TimeSpan.FromMilliseconds(baseTimeMs);
             }
 
-            double jitterMs;
-
-            // Because Random is not threadsafe
-            lock (_rngLock)
-            {
-                // A random double from 95% to 105% of the baseTimeMs
-                jitterMs = _rng.Next(95, 106);
-            }
-
-            jitterMs *= baseTimeMs / 100.0;
+            double jitterMs = Random.Shared.Next(95, 106) * baseTimeMs / 100.0;
 
             return TimeSpan.FromMilliseconds(jitterMs);
         }

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Retry/IRetryPolicy.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Retry/IRetryPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -26,6 +26,6 @@ namespace Azure.Iot.Operations.Protocol.Retry
         /// }
         /// </code>
         /// </example>
-        bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay);
+        bool ShouldRetry(uint currentRetryCount, Exception? lastException, out TimeSpan retryDelay);
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Retry/NoRetryPolicy.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Retry/NoRetryPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Protocol.Retry
         }
 
         /// <inheritdoc/>
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
+        public bool ShouldRetry(uint currentRetryCount, Exception? lastException, out TimeSpan retryDelay)
         {
             retryDelay = TimeSpan.Zero;
             return false;

--- a/dotnet/src/Azure.Iot.Operations.Services/LeasedLock/RetryPolicyWithAutoReset.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/LeasedLock/RetryPolicyWithAutoReset.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Protocol.Retry;
+
+namespace Azure.Iot.Operations.Services.LeasedLock;
+
+internal class RetryPolicyWithAutoReset
+{
+    private readonly IRetryPolicy _retryPolicy;
+    private readonly TimeSpan _expirationInterval;
+    private DateTime _lastRetryTime = DateTime.MaxValue;
+    private uint _currentRetryCount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryPolicyWithAutoReset"/> class.
+    /// </summary>
+    /// <param name="retryPolicy">The retry policy to be used.</param>
+    /// <param name="expirationInterval">The time interval since last call of the ShouldRetry after which it will reset policy retry counter
+    /// before next call of the <paramref name="retryPolicy"/>.ShouldRetry.</param>
+    public RetryPolicyWithAutoReset(IRetryPolicy retryPolicy, TimeSpan expirationInterval)
+    {
+        _retryPolicy = retryPolicy;
+        _expirationInterval = expirationInterval;
+        _currentRetryCount = 0;
+    }
+
+    /// <summary>
+    /// Determines whether the operation should be retried and returns the time interval to wait before the next retry.
+    /// </summary>
+    /// <param name="lastException">The exception that caused the operation to fail.</param>
+    /// <param name="retryDelay">The time interval to wait before the next retry.</param>
+    /// <returns>True if the operation should be retried; otherwise, false.</returns>
+    public bool ShouldRetry(Exception? lastException, out TimeSpan retryDelay)
+    {
+        var shouldResetCounter = DateTime.UtcNow - _lastRetryTime > _expirationInterval;
+        _lastRetryTime = DateTime.UtcNow;
+
+        if (shouldResetCounter)
+        {
+            Reset();
+        }
+        else
+        {
+            _currentRetryCount++;
+        }
+
+        return _retryPolicy.ShouldRetry(_currentRetryCount, lastException, out retryDelay);
+    }
+
+    public void Reset()
+    {
+        _currentRetryCount = 1;
+    }
+}

--- a/dotnet/test/Azure.Iot.Operations.Mqtt.UnitTests/Session/TestRetryPolicy.cs
+++ b/dotnet/test/Azure.Iot.Operations.Mqtt.UnitTests/Session/TestRetryPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Protocol.Retry;
@@ -13,7 +13,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
         public int CurrentRetryCount { get; private set; }
 
         public TestRetryPolicy(int maxRetryCount)
-        { 
+        {
             _maxRetryCount = maxRetryCount;
             _retryDelay = TimeSpan.Zero;
         }
@@ -24,7 +24,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests
             _retryDelay = retryDelay;
         }
 
-        public bool ShouldRetry(uint currentRetryCount, Exception lastException, out TimeSpan retryDelay)
+        public bool ShouldRetry(uint currentRetryCount, Exception? lastException, out TimeSpan retryDelay)
         {
             CurrentRetryCount++;
             retryDelay = _retryDelay;

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Retry/ExponentialBackoffRetryPolicyTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Retry/ExponentialBackoffRetryPolicyTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Protocol.Retry;
+
+namespace Azure.Iot.Operations.Protocol.UnitTests.Retry;
+
+public class ExponentialBackoffRetryPolicyTests
+{
+    [Fact]
+    public void ShouldRetry_ReturnsTrueOnFirstRetry()
+    {
+        // Arrange
+        var retryPolicy = new ExponentialBackoffRetryPolicy(10, TimeSpan.FromMilliseconds(200), false);
+
+        // Act
+        bool shouldRetry = retryPolicy.ShouldRetry(1, new Exception(), out TimeSpan retryDelay);
+
+        // Assert
+        Assert.True(shouldRetry);
+        Assert.Equal(TimeSpan.FromMilliseconds(128), retryDelay);
+    }
+
+    [Fact]
+    public void ShouldRetry_ReturnsFalseWhenMaxRetriesExceeded()
+    {
+        // Arrange
+        var retryPolicy = new ExponentialBackoffRetryPolicy(3, TimeSpan.FromMilliseconds(200), false);
+
+        // Act
+        bool shouldRetry = retryPolicy.ShouldRetry(4, new Exception(), out TimeSpan retryDelay);
+
+        // Assert
+        Assert.False(shouldRetry);
+        Assert.Equal(TimeSpan.Zero, retryDelay);
+    }
+
+    [Fact]
+    public void ShouldRetry_UsesJitterWhenEnabled()
+    {
+        // Arrange
+        var retryPolicy = new ExponentialBackoffRetryPolicy(10, TimeSpan.FromMilliseconds(200), true);
+
+        // Act
+        bool shouldRetry = retryPolicy.ShouldRetry(1, new Exception(), out TimeSpan retryDelay);
+
+        // Assert
+        Assert.True(shouldRetry);
+        Assert.InRange(retryDelay.TotalMilliseconds, 121.6, 134.4); // 128ms ± 5%
+    }
+
+    [Fact]
+    public void ShouldRetry_ClampsToMaxDelay()
+    {
+        // Arrange
+        var retryPolicy = new ExponentialBackoffRetryPolicy(10, TimeSpan.FromMilliseconds(150), false);
+
+        // Act
+        bool shouldRetry = retryPolicy.ShouldRetry(10, new Exception(), out TimeSpan retryDelay);
+
+        // Assert
+        Assert.True(shouldRetry);
+        Assert.Equal(TimeSpan.FromMilliseconds(150), retryDelay);
+    }
+
+    [Fact]
+    public void ShouldRetry_UsesBaseExponentForFirstRetry()
+    {
+        // Arrange
+        var retryPolicy = new ExponentialBackoffRetryPolicy(10, 1, TimeSpan.FromMilliseconds(200), false);
+
+        // Act
+        bool shouldRetry = retryPolicy.ShouldRetry(1, new Exception(), out TimeSpan retryDelay);
+
+        // Assert
+        Assert.True(shouldRetry);
+        Assert.Equal(TimeSpan.FromMilliseconds(4), retryDelay);
+    }
+}

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/RetryPolicyWithAutoResetTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/RetryPolicyWithAutoResetTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Iot.Operations.Protocol.Retry;
+using Azure.Iot.Operations.Services.LeasedLock;
+using Xunit;
+
+namespace Azure.Iot.Operations.Services.UnitTests.LeasedLock;
+
+public class RetryPolicyWithAutoResetTests
+{
+    [Fact]
+    public async Task ShouldRetry_ResetsRetryCounterAfterExpirationInterval()
+    {
+        // Arrange
+        var expirationInterval = TimeSpan.FromMilliseconds(100);
+
+        var retryPolicy = new ExponentialBackoffRetryPolicy(3, 1, TimeSpan.FromMilliseconds(500), false);
+
+        var retryPolicyWithAutoReset = new RetryPolicyWithAutoReset(retryPolicy, expirationInterval);
+
+        // Act
+        retryPolicyWithAutoReset.ShouldRetry(null, out var firstDelay);
+        await Task.Delay(expirationInterval * 2);
+        retryPolicyWithAutoReset.ShouldRetry(null, out var secondDelay);
+
+        // Assert
+        Assert.Equal(firstDelay, secondDelay);
+    }
+
+    [Fact]
+    public void ShouldRetry_DoesNotResetRetryCounterBeforeExpirationInterval()
+    {
+        // Arrange
+        var expirationInterval = TimeSpan.FromMilliseconds(100);
+
+        var retryPolicy = new ExponentialBackoffRetryPolicy(3, 1, TimeSpan.FromMilliseconds(500), false);
+
+        var retryPolicyWithAutoReset = new RetryPolicyWithAutoReset(retryPolicy, expirationInterval);
+
+        // Act
+        retryPolicyWithAutoReset.ShouldRetry(null, out var firstDelay);
+        retryPolicyWithAutoReset.ShouldRetry(null, out var secondDelay);
+
+        // Assert
+        Assert.True(firstDelay < secondDelay);
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to the retry policies and configurations in the Azure IoT Operations Protocol. The most significant changes involve enhancements to the `ExponentialBackoffRetryPolicy` class, the addition of a new `ExponentialBackoffRetryPolicyWithExpiration` class, and updates to the `LeaderElectionClient` and `LeasedLockClient` classes to incorporate these new retry policies.

### Enhancements to Retry Policies:

* [`dotnet/src/Azure.Iot.Operations.Protocol/Retry/ExponentialBackoffRetryPolicy.cs`](diffhunk://#diff-f97efe7b1b8369b0c8cf0c130e6a5f8e02f788713b58e0a4d7c6203324234914L9-R68): Updated the `ExponentialBackoffRetryPolicy` class to provide more detailed documentation, include a base exponent for backoff calculations, and add a new constructor to support different initialization parameters.
* [`dotnet/src/Azure.Iot.Operations.Protocol/Retry/ExponentialBackoffRetryPolicyWithExpiration.cs`](diffhunk://#diff-cd9a9e23429f22bac73113f528e307fca768712b71792f988b2bea57d9321923R1-R77): Added a new class `ExponentialBackoffRetryPolicyWithExpiration` that extends the `ExponentialBackoffRetryPolicy` to include an expiration interval after which retries will no longer be attempted.

### Updates to Client Classes:

* [`dotnet/src/Azure.Iot.Operations.Services/LeaderElection/LeaderElectionClient.cs`](diffhunk://#diff-b46aa354fb4a526ef315fb12f1df5c012b5f8b4c07dba330312faf8131892102R132-R149): Modified the `LeaderElectionClient` class to accept a retry policy parameter, with a default policy using the new `ExponentialBackoffRetryPolicyWithExpiration`.
* [`dotnet/src/Azure.Iot.Operations.Services/LeasedLock/LeasedLockClient.cs`](diffhunk://#diff-a0b2f6fa562e5bfc738f5b306f20770db57441e2c6d22cf2b59f28ca0a4b7cfbR110-R114): Updated the `LeasedLockClient` class to accept a retry policy parameter and implemented the retry logic to prioritize previous leader renewal. [[1]](diffhunk://#diff-a0b2f6fa562e5bfc738f5b306f20770db57441e2c6d22cf2b59f28ca0a4b7cfbR110-R114) [[2]](diffhunk://#diff-a0b2f6fa562e5bfc738f5b306f20770db57441e2c6d22cf2b59f28ca0a4b7cfbR338-R349)

### Minor Fixes and Improvements:

* [`dotnet/.editorconfig`](diffhunk://#diff-cfb867d5de3aaa02df169c9665b9d05d4f96b045d92063289b1e1e9b2d88b2cfL97-R96): Updated the naming style rule for `first_word_upper_case_style` to use `pascal_case` instead of `first_word_upper`.
* [`dotnet/src/Azure.Iot.Operations.Protocol/Retry/IRetryPolicy.cs`](diffhunk://#diff-67f012295c600254de059073df09536db6bd27bdcab31e0928464da4f692f315L29-R29): Updated the `IRetryPolicy` interface to allow a nullable `Exception` parameter in the `ShouldRetry` method.
* [`dotnet/src/Azure.Iot.Operations.Protocol/Retry/NoRetryPolicy.cs`](diffhunk://#diff-17927ab802afa78637340f4f2da88c81cdb45c2f3b224d2e4f1cd781480723f4L21-R21): Updated the `NoRetryPolicy` class to allow a nullable `Exception` parameter in the `ShouldRetry` method.
