### PR TITLE
[Rust][METL] re-enable METL test for rust around response topic

### DIFF
--- a/rust/azure_iot_operations_protocol/tests/metl/command_invoker_tester.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/command_invoker_tester.rs
@@ -193,13 +193,8 @@ where
 
         if let Some(request_topic) = tci.request_topic.as_ref() {
             invoker_options_builder.request_topic_pattern(request_topic);
-            if let Some(response_topic_map) = &tci.response_topic_map {
-                if let Some(response_topic) = response_topic_map.get(request_topic) {
-                    invoker_options_builder.response_topic_pattern(response_topic.clone());
-                }
-            }
         }
-
+        invoker_options_builder.response_topic_pattern(tci.response_topic_pattern.clone());
         invoker_options_builder.topic_namespace(tci.topic_namespace.clone());
         invoker_options_builder.response_topic_prefix(tci.response_topic_prefix.clone());
         invoker_options_builder.response_topic_suffix(tci.response_topic_suffix.clone());

--- a/rust/azure_iot_operations_protocol/tests/metl/test_case_invoker.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/test_case_invoker.rs
@@ -42,8 +42,8 @@ pub struct TestCaseInvoker<T: DefaultsType + Default> {
     #[serde(rename = "topic-token-map")]
     pub topic_token_map: Option<HashMap<String, String>>,
 
-    #[serde(rename = "response-topic-map")]
-    pub response_topic_map: Option<HashMap<String, Option<String>>>,
+    #[serde(rename = "response-topic-pattern")]
+    pub response_topic_pattern: Option<String>,
 }
 
 pub fn get_default_command_name<T: DefaultsType + Default>() -> Option<String> {

--- a/rust/azure_iot_operations_protocol/tests/protocol_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/protocol_tests.rs
@@ -39,7 +39,6 @@ const PROBLEMATIC_TEST_CASES: &[&str] = &[
     "CommandInvokerWithZeroTimeout_ThrowsException",
     "TelemetrySenderPubAckDroppedByDisconnection_ReconnectAndSuccess",
     "TelemetrySenderSendWithCloudEventSpecVersionNonNumeric_Success",
-    "CommandInvokerWithCustomResponseTopic_Success",
 ];
 
 /*


### PR DESCRIPTION
# Context
#517 commented out this test in Rust because of METL framework changes.

# This PR
Updates Rust's METL framework to work with the updated test
Re-enables the skipped test