### PR TITLE
Remove workaround for race condition issue in exit_handle.try_exit()

### DIFF
--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -199,22 +199,7 @@ async fn command_basic_invoke_response_network_tests() {
             // cleanup should be successful
             assert!(invoker.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -465,22 +450,7 @@ async fn command_complex_invoke_response_network_tests() {
             // cleanup should be successful
             assert!(invoker.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 

--- a/rust/azure_iot_operations_protocol/tests/telemetry_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/telemetry_network_tests.rs
@@ -207,22 +207,7 @@ async fn telemetry_basic_send_receive_network_tests() {
             // wait for the receive_telemetry_task to finish to ensure any failed asserts are captured.
             assert!(receive_telemetry_task.await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -444,22 +429,7 @@ async fn telemetry_complex_send_receive_network_tests() {
             // wait for the receive_telemetry_task to finish to ensure any failed asserts are captured.
             assert!(receive_telemetry_task.await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 

--- a/rust/azure_iot_operations_services/tests/state_store_client_test.rs
+++ b/rust/azure_iot_operations_services/tests/state_store_client_test.rs
@@ -190,22 +190,7 @@ async fn state_store_basic_set_delete_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -338,22 +323,7 @@ async fn state_store_fencing_token_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -417,22 +387,7 @@ async fn state_store_key_not_found_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -555,22 +510,7 @@ async fn state_store_set_conditions_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -656,22 +596,7 @@ async fn state_store_key_set_conditions_2_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -767,22 +692,7 @@ async fn state_store_set_key_notifications_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -876,22 +786,7 @@ async fn state_store_del_key_notifications_network_tests() {
             // Also validates that recv gets None after shutdown.
             assert!(receive_notifications_task.await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -998,22 +893,7 @@ async fn state_store_observe_unobserve_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 
@@ -1215,22 +1095,7 @@ async fn state_store_complicated_recv_key_notifications_network_tests() {
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
 
-            // exit_handle.try_exit().await.unwrap(); // TODO: uncomment once below race condition is fixed
-            match exit_handle.try_exit().await {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    match e {
-                        azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable { attempted } => {
-                            // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                            if !attempted {
-                                return Err(e.to_string());
-                            }
-                            Ok(())
-                        },
-                        _ => Err(e.to_string()),
-                    }
-                }
-            }
+            exit_handle.try_exit().await.unwrap();
         }
     });
 

--- a/rust/sample_applications/counter/counter_client/src/main.rs
+++ b/rust/sample_applications/counter/counter_client/src/main.rs
@@ -109,20 +109,7 @@ async fn counter_telemetry_check(
     counter_value_receiver.shutdown().await.unwrap();
 
     // Exit the session now that we're done
-    match exit_handle.try_exit().await {
-        Ok(()) => { /* Successfully exited */ }
-        Err(e) => {
-            if let azure_iot_operations_mqtt::session::SessionExitError::BrokerUnavailable {
-                attempted,
-            } = e
-            {
-                // Because of a current race condition, we need to ignore this as it isn't indicative of a real error
-                assert!(attempted, "{}", e.to_string());
-            } else {
-                panic!("{}", e.to_string())
-            }
-        }
-    }
+    exit_handle.try_exit().await.unwrap();
 }
 
 /// Send a read request, 15 increment requests, and another read request and wait for their responses.


### PR DESCRIPTION
These are no longer needed after 2222edb2fbb45fba45df0613ea13bab0397d4e08