### PR TITLE
add rust toolchain file for state store

### DIFF
--- a/tools/statestore-cli/rust-toolchain.toml
+++ b/tools/statestore-cli/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.85"
-components = ["clippy", "llvm-tools-preview", "rustfmt"]
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Building state store client in rust with my admittedly old rust (1.75) failed because of dependency issues.

This brings us to the current latest rust toolchain.  I've verified that build and run are successful after doing this.