### PR TITLE
add names to worfklow jobs to allow require for branch protection

### DIFF
--- a/.github/workflows/cd-go.yml
+++ b/.github/workflows/cd-go.yml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   release:
-
     runs-on: ubuntu-latest
+    name: CD-go
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -29,8 +29,8 @@ permissions:
     
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    name: CI-dotnet
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build:
-
+    name: CI-go
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -4,30 +4,40 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    - cron: '0 8 * * *' # Nightly at 1am PST
+    - cron: "0 8 * * *" # Nightly at 1am PST
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
 
 jobs:
-  check:
+  spellcheck:
+    name: CI-spelling
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
       - name: Spell check
         uses: streetsidesoftware/cspell-action@v6
+        continue-on-error: true
         with:
-          files: '**/*'
-          config: '.vscode/cspell.json'
-          strict: false
+          files: "**/*"
+          config: ".vscode/cspell.json"
           suggestions: true
           incremental_files_only: true
 
-      - name: Link check
+  linkcheck:
+    name: Ci-links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
         continue-on-error: true
-        run: |
-          npm install -g @umbrelladocs/linkspector
-          linkspector check -c ./.github/.linkspector.yml
+        with:
+          config_file: .github/.linkspector.yml
+          fail_on_error: true
+          filter_mode: nofilter
+          level: warning

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -43,7 +43,7 @@ env:
 jobs:
 
   build:
-    name: Build, Test, Lint
+    name: CI-rust
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -82,9 +82,9 @@ jobs:
     - name: Verify Tools
       working-directory: tools/statestore-cli
       run:
-         source ../../rust/ci/build-deps.sh
-         cargo clippy --all-features
-         cargo fmt --verbose --all
+        source ../../rust/ci/build-deps.sh
+        cargo clippy --all-features
+        cargo fmt --verbose --all
 
     # TODO: Enable and configure these once the codegen is ready
     # - name: CodeGen Rust TestEnvoys

--- a/.github/workflows/e2e-cross-language.yml
+++ b/.github/workflows/e2e-cross-language.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   cross-language:
+    name: CI-cross-language
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/run-codegen.yml
+++ b/.github/workflows/run-codegen.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   codegen:
+    name: CI-codegen
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
Currently no actions are required for branch protection of main. By adding names to the jobs,we can add them to the branch ruleset as a required passing action.