### PR TITLE
[.NET] remove hardcoded client Id from samples whose connection strings already include client ids

### DIFF
--- a/dotnet/samples/CounterClient/RpcCommandRunner.cs
+++ b/dotnet/samples/CounterClient/RpcCommandRunner.cs
@@ -14,7 +14,7 @@ public class RpcCommandRunner(MqttSessionClient mqttClient, CounterClient counte
     {
         try
         {
-            // MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration!.GetConnectionString("Default")! + ";ClientId=sampleClient-" + Environment.TickCount);
+            // MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration!.GetConnectionString("Default")!);
             MqttConnectionSettings mcs = MqttConnectionSettings.FromEnvVars();
 
             await mqttClient.ConnectAsync(mcs, stoppingToken);

--- a/dotnet/samples/SampleClient/RpcCommandRunner.cs
+++ b/dotnet/samples/SampleClient/RpcCommandRunner.cs
@@ -15,7 +15,7 @@ public class RpcCommandRunner(MqttSessionClient mqttClient, IServiceProvider ser
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration!.GetConnectionString("Default")! + ";ClientId=sampleClient-" + Environment.TickCount);
+        MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration!.GetConnectionString("Default")!);
 
         await mqttClient.ConnectAsync(mcs, stoppingToken);
         await Console.Out.WriteLineAsync($"Connected to: {mcs}");

--- a/dotnet/samples/SessionClientConnectionManagementSample/LibraryManagedConnectionWorker.cs
+++ b/dotnet/samples/SessionClientConnectionManagementSample/LibraryManagedConnectionWorker.cs
@@ -15,7 +15,7 @@ public class LibraryManagedConnectionWorker(MqttSessionClient sessionClient, ILo
     {
         sessionClient.SessionLostAsync += OnCrash;
         sessionClient.ApplicationMessageReceivedAsync += OnMessageReceived;
-        MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration.GetConnectionString("Default")! + ";ClientId=LibraryManagedConnectionClient-" + Guid.NewGuid());
+        MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration.GetConnectionString("Default")!);
 
         await sessionClient.ConnectAsync(mcs, cancellationToken);
 

--- a/dotnet/samples/UserManagedConnectionManagementSample/UserManagedConnectionWorker.cs
+++ b/dotnet/samples/UserManagedConnectionManagementSample/UserManagedConnectionWorker.cs
@@ -15,7 +15,7 @@ namespace ConnectionManagementSample
 
         protected override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration.GetConnectionString("Default")! + ";ClientId=UserManagedConnectionClient-" + Guid.NewGuid());
+            MqttConnectionSettings mcs = MqttConnectionSettings.FromConnectionString(configuration.GetConnectionString("Default")!);
 
             mqttClient.ApplicationMessageReceivedAsync += OnMessageReceived;
             mqttClient.DisconnectedAsync += OnDisconnect;


### PR DESCRIPTION
Specifying 2 different client Ids crashed the app