### PR TITLE
Fix StyleCop.Analyzers warnings in generated code

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Project/t4/DotNetProject.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/dotnet/Project/t4/DotNetProject.tt
@@ -5,6 +5,7 @@
     <TargetFramework><#=this.targetFramework#></TargetFramework>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <Nullable>enable</Nullable>
+    <NoWarn>SA0001,SA1101,SA1633</NoWarn>
   </PropertyGroup>
 <# if (this.packageVersions.Any()) { #>
 

--- a/dotnet/samples/Protocol/CloudEvents/BytesJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/DateJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/DecimalJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/DecimalString.cs
+++ b/dotnet/samples/Protocol/CloudEvents/DecimalString.cs
@@ -11,23 +11,9 @@ namespace CloudEvents
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace CloudEvents
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace CloudEvents
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace CloudEvents
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/samples/Protocol/CloudEvents/DurationJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/TimeJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/Utf8JsonSerializer.cs
+++ b/dotnet/samples/Protocol/CloudEvents/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace CloudEvents
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace CloudEvents
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace CloudEvents
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace CloudEvents
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/samples/Protocol/CloudEvents/UuidJsonConverter.cs
+++ b/dotnet/samples/Protocol/CloudEvents/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace CloudEvents
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/CloudEvents/ValueExtractor.cs
+++ b/dotnet/samples/Protocol/CloudEvents/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace CloudEvents
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/samples/Protocol/ReadCloudEvents/BytesJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/DateJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/DecimalJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/DecimalString.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/DecimalString.cs
@@ -11,23 +11,9 @@ namespace ReadCloudEvents
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace ReadCloudEvents
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace ReadCloudEvents
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace ReadCloudEvents
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/samples/Protocol/ReadCloudEvents/DurationJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/TimeJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/Utf8JsonSerializer.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace ReadCloudEvents
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace ReadCloudEvents
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace ReadCloudEvents
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace ReadCloudEvents
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/samples/Protocol/ReadCloudEvents/UuidJsonConverter.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace ReadCloudEvents
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/ReadCloudEvents/ValueExtractor.cs
+++ b/dotnet/samples/Protocol/ReadCloudEvents/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace ReadCloudEvents
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/samples/Protocol/TestEnvoys/AvroSerializer.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/AvroSerializer.cs
@@ -18,6 +18,10 @@ namespace TestEnvoys
         where T1 : class, ISpecificRecord, new()
         where T2 : class, ISpecificRecord, new()
     {
+        public const string ContentType = "application/avro";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.Unspecified;
+
         private readonly SpecificDatumReader<T1> datumReader1;
         private readonly SpecificDatumWriter<T1> datumWriter1;
 
@@ -34,10 +38,6 @@ namespace TestEnvoys
             datumReader2 = new SpecificDatumReader<T2>(schema2, schema2);
             datumWriter2 = new SpecificDatumWriter<T2>(schema2);
         }
-
-        public const string ContentType = "application/avro";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.Unspecified;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -63,7 +63,7 @@ namespace TestEnvoys
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyAvro() as T)!;
+                    return (new EmptyAvro() as T) !;
                 }
 
                 using (var stream = new MemoryStream(payload.ToArray()))
@@ -72,15 +72,15 @@ namespace TestEnvoys
 
                     if (typeof(T) == typeof(T1))
                     {
-                        T1 obj1 = new();
+                        T1 obj1 = new ();
                         datumReader1.Read(obj1, avroDecoder);
-                        return (obj1 as T)!;
+                        return (obj1 as T) !;
                     }
                     else if (typeof(T) == typeof(T2))
                     {
-                        T2 obj2 = new();
+                        T2 obj2 = new ();
                         datumReader2.Read(obj2, avroDecoder);
-                        return (obj2 as T)!;
+                        return (obj2 as T) !;
                     }
                     else
                     {
@@ -101,7 +101,7 @@ namespace TestEnvoys
             {
                 if (typeof(T) == typeof(EmptyAvro))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
                 using (var stream = new MemoryStream())
@@ -118,7 +118,7 @@ namespace TestEnvoys
                     }
                     else
                     {
-                        return new(ReadOnlySequence<byte>.Empty, null, 0);
+                        return new (ReadOnlySequence<byte>.Empty, null, 0);
                     }
 
                     stream.Flush();
@@ -127,7 +127,7 @@ namespace TestEnvoys
                     stream.Seek(0, SeekOrigin.Begin);
                     stream.Read(buffer, 0, (int)stream.Length);
 
-                    return new(new(buffer), ContentType, PayloadFormatIndicator);
+                    return new (new (buffer), ContentType, PayloadFormatIndicator);
                 }
             }
             catch (Exception)

--- a/dotnet/samples/Protocol/TestEnvoys/BytesJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/DateJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/DecimalJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/DecimalString.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/DecimalString.cs
@@ -11,23 +11,9 @@ namespace TestEnvoys
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace TestEnvoys
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace TestEnvoys
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace TestEnvoys
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/samples/Protocol/TestEnvoys/DurationJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/EmptyAvro.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/EmptyAvro.cs
@@ -10,8 +10,18 @@ namespace TestEnvoys
 
     public class EmptyAvro : ISpecificRecord
     {
-        public Schema Schema { get => PrimitiveSchema.Create(Schema.Type.Null); }
-        public object Get(int fieldPos) { return null!; }
-        public void Put(int fieldPos, object fieldValue) { }
+        public Schema Schema
+        {
+            get => PrimitiveSchema.Create(Schema.Type.Null);
+        }
+
+        public object Get(int fieldPos)
+        {
+            return null!;
+        }
+
+        public void Put(int fieldPos, object fieldValue)
+        {
+        }
     }
 }

--- a/dotnet/samples/Protocol/TestEnvoys/PassthroughSerializer.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/PassthroughSerializer.cs
@@ -21,11 +21,11 @@ namespace TestEnvoys
         {
             if (payload.IsEmpty)
             {
-                return (Array.Empty<byte>() as T)!;
+                return (Array.Empty<byte>() as T) !;
             }
             else if (typeof(T) == typeof(byte[]))
             {
-                return (payload.ToArray() as T)!;
+                return (payload.ToArray() as T) !;
             }
             else
             {
@@ -38,11 +38,11 @@ namespace TestEnvoys
         {
             if (payload is byte[] payload1)
             {
-                return new(new(payload1), ContentType, PayloadFormatIndicator);
+                return new (new (payload1), ContentType, PayloadFormatIndicator);
             }
             else
             {
-                return new(ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
+                return new (ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
             }
         }
     }

--- a/dotnet/samples/Protocol/TestEnvoys/TimeJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/Utf8JsonSerializer.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace TestEnvoys
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace TestEnvoys
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace TestEnvoys
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace TestEnvoys
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/samples/Protocol/TestEnvoys/UuidJsonConverter.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace TestEnvoys
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/samples/Protocol/TestEnvoys/ValueExtractor.cs
+++ b/dotnet/samples/Protocol/TestEnvoys/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace TestEnvoys
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/BytesJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DateJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DecimalJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DecimalString.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DecimalString.cs
@@ -11,23 +11,9 @@ namespace Azure.Iot.Operations.Services.Akri
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace Azure.Iot.Operations.Services.Akri
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace Azure.Iot.Operations.Services.Akri
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace Azure.Iot.Operations.Services.Akri
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DurationJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/TimeJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/Utf8JsonSerializer.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace Azure.Iot.Operations.Services.Akri
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace Azure.Iot.Operations.Services.Akri
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace Azure.Iot.Operations.Services.Akri
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace Azure.Iot.Operations.Services.Akri
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/UuidJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Services.Akri
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/ValueExtractor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/Akri/Common/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace Azure.Iot.Operations.Services.Akri
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/BytesJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DateJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DecimalJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DecimalString.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DecimalString.cs
@@ -11,23 +11,9 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DurationJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/TimeJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/Utf8JsonSerializer.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/UuidJsonConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/ValueExtractor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Common/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace Azure.Iot.Operations.Services.SchemaRegistry
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreGen/PassthroughSerializer.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStoreGen/PassthroughSerializer.cs
@@ -21,11 +21,11 @@ namespace Azure.Iot.Operations.Services.StateStore
         {
             if (payload.IsEmpty)
             {
-                return (Array.Empty<byte>() as T)!;
+                return (Array.Empty<byte>() as T) !;
             }
             else if (typeof(T) == typeof(byte[]))
             {
-                return (payload.ToArray() as T)!;
+                return (payload.ToArray() as T) !;
             }
             else
             {
@@ -38,11 +38,11 @@ namespace Azure.Iot.Operations.Services.StateStore
         {
             if (payload is byte[] payload1)
             {
-                return new(new(payload1), ContentType, PayloadFormatIndicator);
+                return new (new (payload1), ContentType, PayloadFormatIndicator);
             }
             else
             {
-                return new(ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
+                return new (ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
             }
         }
     }

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/AVRO/AvroSerializer.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/AVRO/AvroSerializer.cs
@@ -18,6 +18,10 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
         where T1 : class, ISpecificRecord, new()
         where T2 : class, ISpecificRecord, new()
     {
+        public const string ContentType = "application/avro";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.Unspecified;
+
         private readonly SpecificDatumReader<T1> datumReader1;
         private readonly SpecificDatumWriter<T1> datumWriter1;
 
@@ -34,10 +38,6 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
             datumReader2 = new SpecificDatumReader<T2>(schema2, schema2);
             datumWriter2 = new SpecificDatumWriter<T2>(schema2);
         }
-
-        public const string ContentType = "application/avro";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.Unspecified;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -63,7 +63,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyAvro() as T)!;
+                    return (new EmptyAvro() as T) !;
                 }
 
                 using (var stream = new MemoryStream(payload.ToArray()))
@@ -72,15 +72,15 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
 
                     if (typeof(T) == typeof(T1))
                     {
-                        T1 obj1 = new();
+                        T1 obj1 = new ();
                         datumReader1.Read(obj1, avroDecoder);
-                        return (obj1 as T)!;
+                        return (obj1 as T) !;
                     }
                     else if (typeof(T) == typeof(T2))
                     {
-                        T2 obj2 = new();
+                        T2 obj2 = new ();
                         datumReader2.Read(obj2, avroDecoder);
-                        return (obj2 as T)!;
+                        return (obj2 as T) !;
                     }
                     else
                     {
@@ -101,7 +101,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
             {
                 if (typeof(T) == typeof(EmptyAvro))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
                 using (var stream = new MemoryStream())
@@ -118,7 +118,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
                     }
                     else
                     {
-                        return new(ReadOnlySequence<byte>.Empty, null, 0);
+                        return new (ReadOnlySequence<byte>.Empty, null, 0);
                     }
 
                     stream.Flush();
@@ -127,7 +127,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
                     stream.Seek(0, SeekOrigin.Begin);
                     stream.Read(buffer, 0, (int)stream.Length);
 
-                    return new(new(buffer), ContentType, PayloadFormatIndicator);
+                    return new (new (buffer), ContentType, PayloadFormatIndicator);
                 }
             }
             catch (Exception)

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/AVRO/EmptyAvro.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/AVRO/EmptyAvro.cs
@@ -10,8 +10,18 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.AVRO
 
     public class EmptyAvro : ISpecificRecord
     {
-        public Schema Schema { get => PrimitiveSchema.Create(Schema.Type.Null); }
-        public object Get(int fieldPos) { return null!; }
-        public void Put(int fieldPos, object fieldValue) { }
+        public Schema Schema
+        {
+            get => PrimitiveSchema.Create(Schema.Type.Null);
+        }
+
+        public object Get(int fieldPos)
+        {
+            return null!;
+        }
+
+        public void Put(int fieldPos, object fieldValue)
+        {
+        }
     }
 }

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/BytesJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/BytesJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Convert.FromBase64String(reader.GetString()!);
+            return Convert.FromBase64String(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DateJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DateJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return DateOnly.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+            return DateOnly.Parse(reader.GetString() !, CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DecimalJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DecimalJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override DecimalString Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return new DecimalString(reader.GetString()!);
+            return new DecimalString(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DurationJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/DurationJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return XmlConvert.ToTimeSpan(reader.GetString()!);
+            return XmlConvert.ToTimeSpan(reader.GetString() !);
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/TimeJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/TimeJsonConverter.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
+            return TimeOnly.FromDateTime(DateTime.Parse(reader.GetString() !, CultureInfo.InvariantCulture, DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AdjustToUniversal));
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/Utf8JsonSerializer.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/Utf8JsonSerializer.cs
@@ -14,7 +14,11 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
 
     public class Utf8JsonSerializer : IPayloadSerializer
     {
-        protected static readonly JsonSerializerOptions jsonSerializerOptions = new()
+        public const string ContentType = "application/json";
+
+        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
+
+        protected static readonly JsonSerializerOptions JsonSerializerOptions = new ()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
@@ -25,12 +29,8 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
                 new UuidJsonConverter(),
                 new BytesJsonConverter(),
                 new DecimalJsonConverter(),
-            }
+            },
         };
-
-        public const string ContentType = "application/json";
-
-        public const MqttPayloadFormatIndicator PayloadFormatIndicator = MqttPayloadFormatIndicator.CharacterData;
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
@@ -56,11 +56,11 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
                         throw AkriMqttException.GetPayloadInvalidException();
                     }
 
-                    return (new EmptyJson() as T)!;
+                    return (new EmptyJson() as T) !;
                 }
 
-                Utf8JsonReader reader = new(payload);
-                return JsonSerializer.Deserialize<T>(ref reader, jsonSerializerOptions)!;
+                Utf8JsonReader reader = new (payload);
+                return JsonSerializer.Deserialize<T>(ref reader, JsonSerializerOptions) !;
             }
             catch (Exception)
             {
@@ -75,10 +75,10 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
             {
                 if (typeof(T) == typeof(EmptyJson))
                 {
-                    return new(ReadOnlySequence<byte>.Empty, null, 0);
+                    return new (ReadOnlySequence<byte>.Empty, null, 0);
                 }
 
-                return new(new(JsonSerializer.SerializeToUtf8Bytes(payload, jsonSerializerOptions)), ContentType, PayloadFormatIndicator);
+                return new (new (JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerOptions)), ContentType, PayloadFormatIndicator);
             }
             catch (Exception)
             {

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/UuidJsonConverter.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/JSON/UuidJsonConverter.cs
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.JSON
         /// <inheritdoc/>
         public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return Guid.ParseExact(reader.GetString()!, "D");
+            return Guid.ParseExact(reader.GetString() !, "D");
         }
 
         /// <inheritdoc/>

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/common/DecimalString.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/common/DecimalString.cs
@@ -11,23 +11,9 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.common
 
     public class DecimalString
     {
-        private static readonly Regex validationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
+        private static readonly Regex ValidationRegex = new Regex("^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$", RegexOptions.Compiled);
 
         private readonly string value;
-
-        public static bool TryParse(string value, out DecimalString? decimalString)
-        {
-            if (validationRegex.IsMatch(value))
-            {
-                decimalString = new DecimalString(value, skipValidation: true);
-                return true;
-            }
-            else
-            {
-                decimalString = null;
-                return false;
-            }
-        }
 
         public DecimalString()
             : this("0", skipValidation: false)
@@ -39,10 +25,22 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.common
         {
         }
 
+        private DecimalString(string value, bool skipValidation)
+        {
+            if (!skipValidation && !ValidationRegex.IsMatch(value))
+            {
+                throw new ArgumentException($"string {value} is not a valid decimal value");
+            }
+
+            this.value = value;
+        }
+
         public static implicit operator string(DecimalString decimalString) => decimalString.value;
+
         public static explicit operator DecimalString(string stringVal) => new DecimalString(stringVal);
 
         public static implicit operator double(DecimalString decimalString) => double.TryParse(decimalString.value, out double doubleVal) ? doubleVal : double.NaN;
+
         public static explicit operator DecimalString(double doubleVal) => new DecimalString(doubleVal.ToString("F", CultureInfo.InvariantCulture));
 
         public static bool operator !=(DecimalString? x, DecimalString? y)
@@ -65,6 +63,20 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.common
             return x.Equals(y);
         }
 
+        public static bool TryParse(string value, out DecimalString? decimalString)
+        {
+            if (ValidationRegex.IsMatch(value))
+            {
+                decimalString = new DecimalString(value, skipValidation: true);
+                return true;
+            }
+            else
+            {
+                decimalString = null;
+                return false;
+            }
+        }
+
         public virtual bool Equals(DecimalString? other)
         {
             return other?.value == this?.value;
@@ -74,19 +86,10 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.common
         {
             return obj is DecimalString other && Equals(other);
         }
+
         public override int GetHashCode()
         {
             return value.GetHashCode();
-        }
-
-        private DecimalString(string value, bool skipValidation)
-        {
-            if (!skipValidation && !validationRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"string {value} is not a valid decimal value");
-            }
-
-            this.value = value;
         }
 
         public override string ToString() => value;

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/common/ValueExtractor.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/common/ValueExtractor.cs
@@ -10,9 +10,11 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.common
     internal static class ValueExtractor
     {
 #pragma warning disable IDE0030 // Null check can be simplified
-        public static T Value<T>(this T obj) where T : class => obj;
+        public static T Value<T>(this T obj)
+            where T : class => obj;
 
-        public static T Value<T>(this Nullable<T> val) where T : struct => val.HasValue ? val.Value : default(T);
+        public static T Value<T>(this T? val)
+            where T : struct => val.HasValue ? val.Value : default(T);
 #pragma warning restore IDE0030 // Null check can be simplified
     }
 }

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/custom/CustomPayload.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/custom/CustomPayload.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Buffers;
-using Azure.Iot.Operations.Protocol;
-using Azure.Iot.Operations.Protocol.Models;
-
 namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.custom
 {
+    using System.Buffers;
+    using Azure.Iot.Operations.Protocol;
+    using Azure.Iot.Operations.Protocol.Models;
+
     public class CustomPayload : SerializedPayloadContext
     {
         public CustomPayload(ReadOnlySequence<byte> serializedPayload, string? contentType = "", MqttPayloadFormatIndicator payloadFormatIndicator = MqttPayloadFormatIndicator.Unspecified)

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/custom/ExternalSerializer.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/custom/ExternalSerializer.cs
@@ -12,18 +12,18 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.custom
 
     public class ExternalSerializer : IPayloadSerializer
     {
-        public static readonly CustomPayload EmptyValue = new(ReadOnlySequence<byte>.Empty);
+        public static readonly CustomPayload EmptyValue = new (ReadOnlySequence<byte>.Empty);
 
         public T FromBytes<T>(ReadOnlySequence<byte> payload, string? contentType, MqttPayloadFormatIndicator payloadFormatIndicator)
             where T : class
         {
             if (payload.IsEmpty)
             {
-                return (Array.Empty<byte>() as T)!;
+                return (Array.Empty<byte>() as T) !;
             }
             else if (typeof(T) == typeof(CustomPayload))
             {
-                return (new CustomPayload(payload, contentType, payloadFormatIndicator) as T)!;
+                return (new CustomPayload(payload, contentType, payloadFormatIndicator) as T) !;
             }
             else
             {

--- a/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/raw/PassthroughSerializer.cs
+++ b/dotnet/test/Azure.Iot.Operations.Protocol.UnitTests/Serializers/raw/PassthroughSerializer.cs
@@ -21,11 +21,11 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.raw
         {
             if (payload.IsEmpty)
             {
-                return (Array.Empty<byte>() as T)!;
+                return (Array.Empty<byte>() as T) !;
             }
             else if (typeof(T) == typeof(byte[]))
             {
-                return (payload.ToArray() as T)!;
+                return (payload.ToArray() as T) !;
             }
             else
             {
@@ -38,11 +38,11 @@ namespace Azure.Iot.Operations.Protocol.UnitTests.Serializers.raw
         {
             if (payload is byte[] payload1)
             {
-                return new(new(payload1), ContentType, PayloadFormatIndicator);
+                return new (new (payload1), ContentType, PayloadFormatIndicator);
             }
             else
             {
-                return new(ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
+                return new (ReadOnlySequence<byte>.Empty, ContentType, PayloadFormatIndicator);
             }
         }
     }


### PR DESCRIPTION
fixes #644

This addresses all of the StyleCop.Analyzers warnings I have observed other than the following three:

* [SA0001 XmlCommentAnalysisDisabled](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md) -- Our projects are not expected to be configured for producing XML documentation.
* [SA1101 PrefixLocalCallsWithThis](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md) -- Conflicts with .NET Code Analaysis rule [IDE0003 Remove this or Me qualification](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009).
* [SA1633 FileMustHaveHeader](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md) -- Generated files do not use XML style for their headers.
