### PR TITLE
[Rust][Codegen] Suppress clippy lint for struct field names

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Project/t4/RustLib.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Project/t4/RustLib.tt
@@ -5,6 +5,7 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(clippy::result_large_err)]
+#![allow(clippy::struct_field_names)]
 <# foreach (string module in this.modules) { #>
 pub mod <#=module#>;
 <# } #>


### PR DESCRIPTION
Struct fields come from DTDL - we cannot change them. Clippy should not complain