### PR TITLE
Dont cancel workflows run from forks

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -19,7 +19,7 @@ on:
 
 # only allow one run / branch at a time
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -25,7 +25,7 @@ on:
 
 # only allow one run / branch at a time
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - name: Spell check
         uses: streetsidesoftware/cspell-action@v6
         continue-on-error: true

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -24,7 +24,7 @@ on:
 
 # only allow one run / branch at a time
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -48,6 +48,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
+    - name: output
+      run: |
+        echo head_ref: ${{github.head_ref}}
+        echo ref: ${{github.ref}}
+        echo workflow: ${{github.workflow}}
+
     - uses: actions/checkout@v4
 
     - name: Install AIO

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -48,12 +48,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: output
-      run: |
-        echo head_ref: ${{github.head_ref}}
-        echo ref: ${{github.ref}}
-        echo workflow: ${{github.workflow}}
-
     - uses: actions/checkout@v4
 
     - name: Install AIO

--- a/.github/workflows/e2e-cross-language.yml
+++ b/.github/workflows/e2e-cross-language.yml
@@ -9,7 +9,7 @@ on:
 
 # Cancel old runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Workflows run from forks, show up with a github.ref as `refs/heads/main` which mean forks will collide with each other, and workflows running from main and will be cancelled.

Try using github.head_ref first (a PR value), and fallback to github.ref if it doesnt exist.