### PR TITLE
Instructions on adding secret to repository fork for running CI pipelines

### DIFF
--- a/.github/workflows/e2e-cross-language.yml
+++ b/.github/workflows/e2e-cross-language.yml
@@ -38,8 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: $GITHUB_CONTEXT.ref
 
       #=======================================================================
       # Install prerequisites

--- a/doc/dev/github.md
+++ b/doc/dev/github.md
@@ -43,3 +43,33 @@ By default, if you create a Codespace on a fork, you will quickly run out of fre
    git pull origin main
    ```
 
+## Adding secret to allow CI workflows to run on a fork
+
+Repository secrets are not passed to a fork, so the CI workflows will fail when run from the fork. The solution is to create the secret in your forked repository which the CI workflows will access when executing.
+
+If you create a PR from a branch of the main repository, no change is needed as the repository already contains the required secret.
+
+### Create a token
+
+1. Browse to [Fine-grained tokens](https://github.com/settings/personal-access-tokens)
+1. Click `Generate new token`
+1. Set the following:
+   * **Resource owner** - Azure
+   * **Expiration** - 180 days
+   * **Repository access** - only select repositories
+   * **Select repositories** - Azure/iot-operations-sdks-action
+   * **Repository permissions** - Contents: Read-only
+1. Create the token, and make a copy of the secret for next section
+
+### Create secret
+
+1. Go to your iot-operations-sdks fork
+1. Open **Settings**
+1. Go to **Secrets and variables > Actions**
+1. Click **New repository secret**
+1. Add the following details:
+   * **Name** - `AIO_SDKS_ACTION_TOKEN` 
+   * **Secret** - The contents of the secret from the previous section
+1. Click **Add secret**
+
+You can now run an iot-operations sdks workflow successfully from you repository fork.


### PR DESCRIPTION
A repository fork doesnt have access to the main repository secret, so will have to create the secret to be able to successfully execute the CI pipelines.