### PR TITLE
[.Net] Fix discrepancies between the nullability of some fields

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/Asset.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/Asset.cs
@@ -5,9 +5,9 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 public record Asset
 {
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
-    public AssetSpecification? Specification { get; set; }
+    public required AssetSpecification Specification { get; set; }
 
     public AssetStatus? Status { get; set; }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/AssetDatasetSchemaElement.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/AssetDatasetSchemaElement.cs
@@ -11,7 +11,7 @@ public record AssetDatasetSchemaElement
 
     public List<AssetDatasetDestinationSchemaElement>? Destinations { get; set; }
 
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
     public string? TypeRef { get; set; }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/AssetEventSchemaElement.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/AssetEventSchemaElement.cs
@@ -7,7 +7,7 @@ public record AssetEventSchemaElement
 {
     public string? EventConfiguration { get; set; }
 
-    public string? EventNotifier { get; set; }
+    public required string EventNotifier { get; set; }
 
     public required string Name { get; set; }
 

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ModelsConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ModelsConverter.cs
@@ -25,7 +25,7 @@ internal static class ModelsConverter
         return new Asset
         {
             Name = source.Name,
-            Specification = source.Specification?.ToModel(),
+            Specification = source.Specification.ToModel(),
             Status = source.Status?.ToModel()
         };
     }


### PR DESCRIPTION
* Use required C# keyword for `Name` and `Specification` fields in `Asset` class
* Use required C# keyword for `Name` field in `AssetDatasetSchemaElement` class
* Use required C# keyword for `EventNotifier` field in `AssetEventSchemaElement` class