### PR TITLE
Add ThingGenerator stage to ProtocolCompiler

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ArgBinder.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ArgBinder.cs
@@ -19,6 +19,7 @@
         private readonly Option<string?> sdkPath;
 #endif
         private readonly Option<string> lang;
+        private readonly Option<bool> thingOnly;
         private readonly Option<bool> clientOnly;
         private readonly Option<bool> serverOnly;
         private readonly Option<bool> noProj;
@@ -37,6 +38,7 @@
         /// <param name="sdkPath">Local path or feed URL for Azure.Iot.Operations.Protocol SDK.</param>
 #endif
         /// <param name="lang">Programming language for generated code.</param>
+        /// <param name="thingOnly">Generate only Thing Description.</param>
         /// <param name="clientOnly">Generate only client-side code.</param>
         /// <param name="serverOnly">Generate only server-side code.</param>
         public ArgBinder(
@@ -50,6 +52,7 @@
             Option<string?> sdkPath,
 #endif
             Option<string> lang,
+            Option<bool> thingOnly,
             Option<bool> clientOnly,
             Option<bool> serverOnly,
             Option<bool> noProj,
@@ -65,6 +68,7 @@
             this.sdkPath = sdkPath;
 #endif
             this.lang = lang;
+            this.thingOnly = thingOnly;
             this.clientOnly = clientOnly;
             this.serverOnly = serverOnly;
             this.noProj = noProj;
@@ -88,6 +92,7 @@
                 SdkPath = null,
 #endif
                 Lang = bindingContext.ParseResult.GetValueForOption(this.lang)!,
+                ThingOnly = bindingContext.ParseResult.GetValueForOption(this.thingOnly),
                 ClientOnly = bindingContext.ParseResult.GetValueForOption(this.clientOnly),
                 ServerOnly = bindingContext.ParseResult.GetValueForOption(this.serverOnly),
                 NoProj = bindingContext.ParseResult.GetValueForOption(this.noProj),

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Azure.Iot.Operations.ProtocolCompiler.csproj
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Azure.Iot.Operations.ProtocolCompiler.csproj
@@ -30,6 +30,7 @@
 		<PackAsTool>True</PackAsTool>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<TransformOnBuild>true</TransformOnBuild>
+		<TransformOutOfDateOnly>false</TransformOutOfDateOnly>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -799,6 +800,46 @@
 			<AutoGen>True</AutoGen>
 			<DependentUpon>TelemetryProto3.tt</DependentUpon>
 		</Compile>
+		<Compile Update="T4\translation\Array\t4\ArrayThingSchema.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>ArrayThingSchema.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Command\t4\CommandAffordance.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>CommandAffordance.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Enum\t4\EnumThingSchema.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>EnumThingSchema.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Interface\t4\InterfaceThing.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>InterfaceThing.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Map\t4\MapThingSchema.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>MapThingSchema.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Object\t4\ObjectThingSchema.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>ObjectThingSchema.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Telemetry\t4\TelemetriesAffordance.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>TelemetriesAffordance.tt</DependentUpon>
+		</Compile>
+		<Compile Update="T4\translation\Telemetry\t4\TelemetryAffordance.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		  <DependentUpon>TelemetryAffordance.tt</DependentUpon>
+		</Compile>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -819,6 +860,46 @@
 	<ItemGroup>
 		<None Update="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="T4\translation\Array\t4\ArrayThingSchema.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>ArrayThingSchema.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Command\t4\CommandAffordance.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>CommandAffordance.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Enum\t4\EnumThingSchema.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>EnumThingSchema.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Interface\t4\InterfaceThing.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>InterfaceThing.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Map\t4\MapThingSchema.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>MapThingSchema.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Object\t4\ObjectThingSchema.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>ObjectThingSchema.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Telemetry\t4\TelemetriesAffordance.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>TelemetriesAffordance.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
+		</None>
+		<None Update="T4\translation\Telemetry\t4\TelemetryAffordance.tt">
+		  <Generator>TextTemplatingFilePreprocessor</Generator>
+		  <LastGenOutput>TelemetryAffordance.cs</LastGenOutput>
+		  <CustomToolNamespace>Azure.Iot.Operations.ProtocolCompiler</CustomToolNamespace>
 		</None>
 	</ItemGroup>
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
@@ -111,7 +111,14 @@
                         genNamespace = new(contextualizedInterface.InterfaceId);
                     }
 
-                    var modelParser = new ModelParser();
+                    ThingGenerator thingGenerator = new ThingGenerator(contextualizedInterface.ModelDict!, contextualizedInterface.InterfaceId, contextualizedInterface.MqttVersion);
+
+                    if (options.ThingOnly)
+                    {
+                        return thingGenerator.GenerateThing(options.OutDir) ? 0 : 1;
+                    }
+
+                    thingGenerator.GenerateThing(workingDir);
 
                     if (!SchemaGenerator.GenerateSchemas(contextualizedInterface.ModelDict!, contextualizedInterface.InterfaceId, contextualizedInterface.MqttVersion, projectName, workingDir, genNamespace, sharedPrefix))
                     {

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/OptionContainer.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/OptionContainer.cs
@@ -31,6 +31,9 @@
         /// <summary>Gets or sets the programming language for generated code.</summary>
         public required string Lang { get; set; }
 
+        /// <summary>Gets or sets an indication of whether to generate only a Thing Description.</summary>
+        public bool ThingOnly { get; set; }
+
         /// <summary>Gets or sets an indication of whether to generate only client-side code.</summary>
         public bool ClientOnly { get; set; }
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
@@ -27,7 +27,7 @@ internal class Program
         var outDirOption = new Option<DirectoryInfo>(
             name: "--outDir",
             getDefaultValue: () => new DirectoryInfo(DefaultOutDir),
-            description: "Directory for receiving generated code")
+            description: "Directory for receiving generated code (or TD file if --thingOnly is specified)")
             { ArgumentHelpName = "DIRPATH" };
 
         var namespaceOption = new Option<string?>(
@@ -52,6 +52,10 @@ internal class Program
             getDefaultValue: () => DefaultLanguage,
             description: "Programming language for generated code")
             { ArgumentHelpName = string.Join('|', CommandHandler.SupportedLanguages) };
+
+        var thingOnlyOption = new Option<bool>(
+            name: "--thingOnly",
+            description: "Stop after generating Thing Description from DTDL model");
 
         var clientOnlyOption = new Option<bool>(
             name: "--clientOnly",
@@ -81,6 +85,7 @@ internal class Program
             sdkPathOption,
 #endif
             langOption,
+            thingOnlyOption,
             clientOnlyOption,
             serverOnlyOption,
             noProjOption,
@@ -98,6 +103,7 @@ internal class Program
             sdkPathOption,
 #endif
             langOption,
+            thingOnlyOption,
             clientOnlyOption,
             serverOnlyOption,
             noProjOption,

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/SchemaGenerator/SchemaGenerator.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/SchemaGenerator/SchemaGenerator.cs
@@ -302,8 +302,8 @@
 
         private (CodeName?, bool) GetErrorMessageSchema(DTObjectInfo dtObject, int mqttVersion)
         {
-            Dtmi errorMessageAjdunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
-            DTFieldInfo? messageField = dtObject.Fields.FirstOrDefault(f => f.SupplementalTypes.Contains(errorMessageAjdunctTypeId));
+            Dtmi errorMessageAdjunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
+            DTFieldInfo? messageField = dtObject.Fields.FirstOrDefault(f => f.SupplementalTypes.Contains(errorMessageAdjunctTypeId));
             return messageField != null ? (new CodeName(messageField.Id), !IsRequired(messageField)) : (null, false);
         }
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/SchemaGenerator/SchemaGenerator.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/SchemaGenerator/SchemaGenerator.cs
@@ -302,8 +302,8 @@
 
         private (CodeName?, bool) GetErrorMessageSchema(DTObjectInfo dtObject, int mqttVersion)
         {
-            Dtmi errorMessageAjduncTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
-            DTFieldInfo? messageField = dtObject.Fields.FirstOrDefault(f => f.SupplementalTypes.Contains(errorMessageAjduncTypeId));
+            Dtmi errorMessageAjdunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
+            DTFieldInfo? messageField = dtObject.Fields.FirstOrDefault(f => f.SupplementalTypes.Contains(errorMessageAjdunctTypeId));
             return messageField != null ? (new CodeName(messageField.Id), !IsRequired(messageField)) : (null, false);
         }
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Array/code/ArrayThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Array/code/ArrayThingSchema.cs
@@ -1,0 +1,22 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser.Models;
+
+    public partial class ArrayThingSchema : ITemplateTransform
+    {
+        private readonly DTArrayInfo dtArray;
+        private readonly int indent;
+        private readonly ThingDescriber thingDescriber;
+
+        public ArrayThingSchema(DTArrayInfo dtArray, int indent, ThingDescriber thingDescriber)
+        {
+            this.dtArray = dtArray;
+            this.indent = indent;
+            this.thingDescriber = thingDescriber;
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Array/t4/ArrayThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Array/t4/ArrayThingSchema.tt
@@ -1,0 +1,14 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser.Models" #>
+<# this.PushIndent(new string(' ', this.indent)); #>
+<# if (this.dtArray.Description.Any()) { #>
+"descriptions": {
+<# int ix = 1; foreach (KeyValuePair<string, string> kvp in this.dtArray.Description) { #>
+  "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix < this.dtArray.Description.Count ? "," : ""#>
+<# ix++; } #>
+},
+<# } #>
+"type": "array",
+"items": {
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtArray.ElementSchema, 2)#>
+}<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Command/code/CommandAffordance.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Command/code/CommandAffordance.cs
@@ -1,0 +1,49 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public partial class CommandAffordance : ITemplateTransform
+    {
+        private readonly DTCommandInfo dtCommand;
+        private readonly bool usesTypes;
+        private readonly string contentType;
+        private readonly string commandTopic;
+        private readonly string? serviceGroupId;
+        private readonly bool isResponseSchemaResult;
+        private readonly bool isRequestTransparent;
+        private readonly bool isResponseTransparent;
+        private readonly bool isCommandIdempotent;
+        private readonly string? responseName;
+        private readonly DTSchemaInfo? responseSchema;
+        private readonly string? errorSchemaName;
+        private readonly ThingDescriber thingDescriber;
+
+        public CommandAffordance(DTCommandInfo dtCommand, int mqttVersion, bool usesTypes, string contentType, string commandTopic, string? serviceGroupId, ThingDescriber thingDescriber)
+        {
+            this.dtCommand = dtCommand;
+            this.usesTypes = usesTypes;
+            this.contentType = contentType;
+            this.commandTopic = commandTopic;
+            this.serviceGroupId = serviceGroupId;
+
+            this.isResponseSchemaResult = dtCommand.Response?.Schema != null && dtCommand.Response.Schema.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.ResultAdjunctTypeFormat, mqttVersion)));
+            DTFieldInfo? normalField = (dtCommand.Response?.Schema as DTObjectInfo)?.Fields?.FirstOrDefault(f => f.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.NormalResultAdjunctTypeFormat, mqttVersion))));
+            DTFieldInfo? errorField = (dtCommand.Response?.Schema as DTObjectInfo)?.Fields?.FirstOrDefault(f => f.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorResultAdjunctTypeFormat, mqttVersion))));
+
+            this.isRequestTransparent = dtCommand.Request != null && dtCommand.Request.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.TransparentAdjunctTypeFormat, mqttVersion)));
+            this.isResponseTransparent = !isResponseSchemaResult && dtCommand.Response != null && dtCommand.Response.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.TransparentAdjunctTypeFormat, mqttVersion)));
+            this.isCommandIdempotent = dtCommand.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.IdempotentAdjunctTypeFormat, mqttVersion)));
+
+            this.responseName = isResponseSchemaResult ? normalField?.Name : dtCommand.Response?.Name;
+            this.responseSchema = isResponseSchemaResult ? normalField?.Schema : dtCommand.Response?.Schema;
+            this.errorSchemaName = errorField != null ? new CodeName(errorField.Schema.Id).AsGiven : null;
+
+            this.thingDescriber = thingDescriber;
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Command/t4/CommandAffordance.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Command/t4/CommandAffordance.tt
@@ -1,0 +1,78 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser" #>
+<#@ import namespace="DTDLParser.Models" #>
+    "<#=this.dtCommand.Name#>": {
+<# if (this.dtCommand.Description.Any()) { #>
+      "descriptions": {
+<# int ix = 1; foreach (KeyValuePair<string, string> kvp in this.dtCommand.Description) { #>
+        "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix < this.dtCommand.Description.Count ? "," : ""#>
+<# ix++; } #>
+      },
+<# } #>
+<# if (this.dtCommand.Request != null) { #>
+<# if (this.usesTypes) { #>
+      "input": {
+<# if (this.isRequestTransparent) { #>
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtCommand.Request.Schema, 8)#>
+<# } else { #>
+        "type": "object",
+        "additionalProperties": false,
+<# if (!this.dtCommand.Request.Nullable) { #>
+        "required": [ "<#=this.dtCommand.Request.Name#>" ],
+<# } #>
+        "properties": {
+          "<#=this.dtCommand.Request.Name#>": {
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtCommand.Request.Schema, 12)#>
+          }
+        }
+<# } #>
+      },
+<# } else { #>
+      "input": {},
+<# } #>
+<# } #>
+<# if (this.dtCommand.Response != null) { #>
+<# if (this.usesTypes) { #>
+      "output": {
+<# if (this.isResponseTransparent) { #>
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtCommand.Response.Schema, 8)#>
+<# } else { #>
+        "type": "object",
+        "additionalProperties": false,
+<# if (!this.dtCommand.Response.Nullable) { #>
+        "required": [ "<#=this.responseName#>" ],
+<# } #>
+        "properties": {
+          "<#=this.responseName#>": {
+<#=this.thingDescriber.GetTypeAndAddenda(this.responseSchema, 12)#>
+          }
+        }
+<# } #>
+      },
+<# } else { #>
+      "output": {},
+<# } #>
+<# } #>
+<# if (this.isCommandIdempotent) { #>
+      "idempotent": true,
+<# } #>
+      "forms": [
+        {
+          "href": "<#=this.dtCommand.Id#>",
+          "contentType": "<#=this.contentType#>",
+<# if (this.isResponseSchemaResult) { #>
+          "additionalResponses": [
+            {
+              "success": false,
+              "contentType": "<#=this.contentType#>",
+              "schema": "<#=this.errorSchemaName#>"
+            }
+          ],
+<# } #>
+<# if (this.serviceGroupId != null) { #>
+          "x-serviceGroupId": "<#=this.serviceGroupId#>",
+<# } #>
+          "x-topic": "<#=this.commandTopic#>"
+        }
+      ]
+    }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Enum/code/EnumThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Enum/code/EnumThingSchema.cs
@@ -1,0 +1,24 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser.Models;
+
+    public partial class EnumThingSchema : ITemplateTransform
+    {
+        private readonly DTEnumInfo dtEnum;
+        private readonly int indent;
+        private readonly string valueSchema;
+        private readonly bool allNamesMatchValues;
+
+        public EnumThingSchema(DTEnumInfo dtEnum, int indent)
+        {
+            this.dtEnum = dtEnum;
+            this.indent = indent;
+            this.valueSchema = ThingDescriber.GetPrimitiveType(dtEnum.ValueSchema.Id);
+            this.allNamesMatchValues = this.dtEnum.EnumValues.All(ev => ev.Name == (ev.EnumValue as string));
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Enum/t4/EnumThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Enum/t4/EnumThingSchema.tt
@@ -1,0 +1,26 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser.Models" #>
+<# this.PushIndent(new string(' ', this.indent)); #>
+<# if (this.dtEnum.Description.Any()) { #>
+"descriptions": {
+<# int ix = 1; foreach (KeyValuePair<string, string> kvp in this.dtEnum.Description) { #>
+  "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix < this.dtEnum.Description.Count ? "," : ""#>
+<# ix++; } #>
+},
+<# } #>
+"type": "<#=this.valueSchema#>",
+<# if (!this.allNamesMatchValues) { #>
+"x-enumNames": [
+<# int ix1 = 1; foreach (var enumValue in this.dtEnum.EnumValues) { #>
+  "<#=enumValue.Name#>"<#=ix1 < this.dtEnum.EnumValues.Count ? "," : ""#>
+<# ix1++; } #>
+],
+<# } #>
+"enum": [
+<# int ix2 = 1; foreach (var enumValue in this.dtEnum.EnumValues) { #>
+  <#=ConditionallyQuote(enumValue.EnumValue.ToString())#><#=ix2 < this.dtEnum.EnumValues.Count ? "," : ""#>
+<# ix2++; } #>
+]<# this.PopIndent(); #>
+<#+
+    private string ConditionallyQuote(string value) => this.valueSchema == "string" ? $"\"{value}\"" : value;
+#>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Interface/code/InterfaceThing.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Interface/code/InterfaceThing.cs
@@ -1,0 +1,63 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public partial class InterfaceThing : ITemplateTransform
+    {
+        private readonly DTInterfaceInfo dtInterface;
+        private readonly CodeName serviceName;
+        private readonly int mqttVersion;
+        private readonly string? telemetryTopic;
+        private readonly string? commandTopic;
+        private readonly string? telemServiceGroupId;
+        private readonly string? cmdServiceGroupId;
+        private readonly bool usesTypes;
+        private readonly string contentType;
+        private readonly Dictionary<string, DTSchemaInfo> errorSchemas;
+        private readonly ThingDescriber thingDescriber;
+
+        public InterfaceThing(DTInterfaceInfo dtInterface, int mqttVersion)
+        {
+            this.dtInterface = dtInterface;
+            this.serviceName = new CodeName(dtInterface.Id);
+            this.mqttVersion = mqttVersion;
+
+            this.telemetryTopic = dtInterface.SupplementalProperties.TryGetValue(string.Format(DtdlMqttExtensionValues.TelemTopicPropertyFormat, mqttVersion), out object? telemTopicObj) ? (string)telemTopicObj : null;
+            this.commandTopic = dtInterface.SupplementalProperties.TryGetValue(string.Format(DtdlMqttExtensionValues.CmdReqTopicPropertyFormat, mqttVersion), out object? cmdTopicObj) ? (string)cmdTopicObj : null;
+
+            this.telemServiceGroupId = dtInterface.SupplementalProperties.TryGetValue(string.Format(DtdlMqttExtensionValues.TelemServiceGroupIdPropertyFormat, mqttVersion), out object? telemServiceGroupIdObj) ? (string)telemServiceGroupIdObj : null;
+            this.cmdServiceGroupId = dtInterface.SupplementalProperties.TryGetValue(string.Format(DtdlMqttExtensionValues.CmdServiceGroupIdPropertyFormat, mqttVersion), out object? cmdServiceGroupIdObj) ? (string)cmdServiceGroupIdObj : null;
+
+            string payloadFormat = (string)dtInterface.SupplementalProperties[string.Format(DtdlMqttExtensionValues.PayloadFormatPropertyFormat, mqttVersion)];
+            this.usesTypes = payloadFormat != PayloadFormat.Raw && payloadFormat != PayloadFormat.Custom;
+            this.contentType = payloadFormat switch
+            {
+                PayloadFormat.Avro => "application/avro",
+                PayloadFormat.Cbor => "application/cbor",
+                PayloadFormat.Json => "application/json",
+                PayloadFormat.Proto2 => "application/protobuf",
+                PayloadFormat.Proto3 => "application/protobuf",
+                PayloadFormat.Raw => "application/octet-stream",
+                PayloadFormat.Custom => "",
+                _ => throw new InvalidOperationException($"InvalidOperationException \"{payloadFormat}\" not recognized"),
+            };
+
+            IEnumerable<DTFieldInfo> errorFields = dtInterface.Commands
+                .Where(c => c.Value.Response?.Schema != null && c.Value.Response.Schema.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.ResultAdjunctTypeFormat, mqttVersion))))
+                .Select(c => ((DTObjectInfo)c.Value.Response.Schema).Fields.First(f => f.SupplementalTypes.Contains(new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorResultAdjunctTypeFormat, mqttVersion)))));
+
+            this.errorSchemas = new Dictionary<string, DTSchemaInfo>();
+            foreach (DTFieldInfo errorField in errorFields)
+            {
+                this.errorSchemas[new CodeName(errorField.Schema.Id).AsGiven] = errorField.Schema;
+            }
+
+            this.thingDescriber = new ThingDescriber(mqttVersion);
+        }
+
+        public string FileName { get => $"{this.serviceName.GetFileName(TargetLanguage.Independent)}.TD.json"; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Interface/t4/InterfaceThing.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Interface/t4/InterfaceThing.tt
@@ -1,0 +1,41 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser" #>
+<#@ import namespace="DTDLParser.Models" #>
+{
+  "@context": "https://www.w3.org/2022/wot/td/v1.1",
+  "id": "<#=this.dtInterface.Id.ToString()#>",
+  "title": "<#=this.serviceName.AsGiven#>",
+  "securityDefinitions": {
+    "nosec_sc": {
+      "scheme": "nosec"
+    }
+  },
+  "security": [
+    "nosec_sc"
+  ],
+<# if (this.errorSchemas.Any()) { #>
+  "schemaDefinitions": {
+<# int ix1 = 1; foreach (KeyValuePair<string, DTSchemaInfo> errorSchema in this.errorSchemas) { #>
+    "<#=errorSchema.Key#>": {
+<#=this.thingDescriber.GetTypeAndAddenda(errorSchema.Value, 6)#>
+    }<#=ix1 < this.errorSchemas.Count ? "," : ""#>
+<# ix1++; } #>
+  },
+<# } #>
+  "actions": {
+<# int ix = 1; foreach (KeyValuePair<string, DTCommandInfo> dtCommand in this.dtInterface.Commands) { #>
+<#=this.thingDescriber.GetCommandAffordance(dtCommand.Value, this.usesTypes, this.contentType, this.commandTopic, this.cmdServiceGroupId)#><#=ix < this.dtInterface.Commands.Count ? "," : ""#>
+<# ix++; } #>
+  },
+  "events": {
+<# if (this.dtInterface.Telemetries.Any()) { #>
+<# if (this.telemetryTopic.Contains(MqttTopicTokens.TelemetryName)) { #>
+<# ix = 1; foreach (KeyValuePair<string, DTTelemetryInfo> dtTelemetry in this.dtInterface.Telemetries) { #>
+<#=this.thingDescriber.GetTelemetryAffordance(dtTelemetry.Value, this.usesTypes, this.contentType, this.telemetryTopic, this.telemServiceGroupId)#><#=ix < this.dtInterface.Telemetries.Count ? "," : ""#>
+<# ix++; } #>
+<# } else { #>
+<#=this.thingDescriber.GetTelemetriesAffordance(this.dtInterface.Telemetries, this.usesTypes, this.contentType, this.telemetryTopic, this.telemServiceGroupId, $"{this.dtInterface.Id.Versionless}:_telemetry;{this.dtInterface.Id.MajorVersion}")#>
+<# } #>
+<# } #>
+  }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Map/code/MapThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Map/code/MapThingSchema.cs
@@ -1,0 +1,22 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser.Models;
+
+    public partial class MapThingSchema : ITemplateTransform
+    {
+        private readonly DTMapInfo dtMap;
+        private readonly int indent;
+        private readonly ThingDescriber thingDescriber;
+
+        public MapThingSchema(DTMapInfo dtMap, int indent, ThingDescriber thingDescriber)
+        {
+            this.dtMap = dtMap;
+            this.indent = indent;
+            this.thingDescriber = thingDescriber;
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Map/t4/MapThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Map/t4/MapThingSchema.tt
@@ -1,0 +1,14 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser.Models" #>
+<# this.PushIndent(new string(' ', this.indent)); #>
+<# if (this.dtMap.Description.Any()) { #>
+"descriptions": {
+<# int ix = 1; foreach (KeyValuePair<string, string> kvp in this.dtMap.Description) { #>
+  "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix < this.dtMap.Description.Count ? "," : ""#>
+<# ix++; } #>
+},
+<# } #>
+"type": "object",
+"additionalProperties": {
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtMap.MapValue.Schema, 2)#>
+}<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
@@ -9,7 +9,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly int indent;
         private readonly int mqttVersion;
         private readonly ThingDescriber thingDescriber;
-        private readonly Dtmi errorMessageAjduncTypeId;
+        private readonly Dtmi errorMessageAjdunctTypeId;
 
         public ObjectThingSchema(DTObjectInfo dtObject, int indent, int mqttVersion, ThingDescriber thingDescriber)
         {
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.indent = indent;
             this.mqttVersion = mqttVersion;
             this.thingDescriber = thingDescriber;
-            this.errorMessageAjduncTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
+            this.errorMessageAjdunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
@@ -9,7 +9,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly int indent;
         private readonly int mqttVersion;
         private readonly ThingDescriber thingDescriber;
-        private readonly Dtmi errorMessageAjdunctTypeId;
+        private readonly Dtmi errorMessageAdjunctTypeId;
 
         public ObjectThingSchema(DTObjectInfo dtObject, int indent, int mqttVersion, ThingDescriber thingDescriber)
         {
@@ -17,7 +17,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.indent = indent;
             this.mqttVersion = mqttVersion;
             this.thingDescriber = thingDescriber;
-            this.errorMessageAjdunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
+            this.errorMessageAdjunctTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/code/ObjectThingSchema.cs
@@ -1,0 +1,27 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public partial class ObjectThingSchema : ITemplateTransform
+    {
+        private readonly DTObjectInfo dtObject;
+        private readonly int indent;
+        private readonly int mqttVersion;
+        private readonly ThingDescriber thingDescriber;
+        private readonly Dtmi errorMessageAjduncTypeId;
+
+        public ObjectThingSchema(DTObjectInfo dtObject, int indent, int mqttVersion, ThingDescriber thingDescriber)
+        {
+            this.dtObject = dtObject;
+            this.indent = indent;
+            this.mqttVersion = mqttVersion;
+            this.thingDescriber = thingDescriber;
+            this.errorMessageAjduncTypeId = new Dtmi(string.Format(DtdlMqttExtensionValues.ErrorMessageAdjunctTypeFormat, mqttVersion));
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
@@ -1,0 +1,30 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser.Models" #>
+<# this.PushIndent(new string(' ', this.indent)); #>
+<# if (this.dtObject.Description.Any()) { #>
+"descriptions": {
+<# int ix1 = 1; foreach (KeyValuePair<string, string> kvp in this.dtObject.Description) { #>
+  "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix1 < this.dtObject.Description.Count ? "," : ""#>
+<# ix1++; } #>
+},
+<# } #>
+"type": "object",
+"additionalProperties": false,
+<# if (this.dtObject.Fields.Any(f => IsFieldRequired(f))) { #>
+"required": [ <#=string.Join(", ", this.dtObject.Fields.Where(f => IsFieldRequired(f)).Select(f => $"\"{f.Name}\""))#> ],
+<# } #>
+<# if (this.dtObject.Fields.Any(f => IsFieldMessage(f))) { #>
+"x-message": "<#=this.dtObject.Fields.First(f => IsFieldMessage(f)).Name#>",
+<# } #>
+"properties": {
+<# int ix2 = 1; foreach (var dtField in this.dtObject.Fields) { #>
+  "<#=dtField.Name#>": {
+<#=this.thingDescriber.GetTypeAndAddenda(dtField.Schema, 4)#>
+  }<#=ix2 < this.dtObject.Fields.Count ? "," : ""#>
+<# ix2++; } #>
+}<# this.PopIndent(); #>
+<#+
+    private bool IsFieldRequired(DTFieldInfo dtField) => dtField.SupplementalTypes.Any(t => DtdlMqttExtensionValues.RequiredAdjunctTypeRegex.IsMatch(t.AbsoluteUri));
+
+    private bool IsFieldMessage(DTFieldInfo dtField) => dtField.SupplementalTypes.Contains(this.errorMessageAjduncTypeId);
+#>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
@@ -26,5 +26,5 @@
 <#+
     private bool IsFieldRequired(DTFieldInfo dtField) => dtField.SupplementalTypes.Any(t => DtdlMqttExtensionValues.RequiredAdjunctTypeRegex.IsMatch(t.AbsoluteUri));
 
-    private bool IsFieldMessage(DTFieldInfo dtField) => dtField.SupplementalTypes.Contains(this.errorMessageAjduncTypeId);
+    private bool IsFieldMessage(DTFieldInfo dtField) => dtField.SupplementalTypes.Contains(this.errorMessageAjdunctTypeId);
 #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Object/t4/ObjectThingSchema.tt
@@ -26,5 +26,5 @@
 <#+
     private bool IsFieldRequired(DTFieldInfo dtField) => dtField.SupplementalTypes.Any(t => DtdlMqttExtensionValues.RequiredAdjunctTypeRegex.IsMatch(t.AbsoluteUri));
 
-    private bool IsFieldMessage(DTFieldInfo dtField) => dtField.SupplementalTypes.Contains(this.errorMessageAjdunctTypeId);
+    private bool IsFieldMessage(DTFieldInfo dtField) => dtField.SupplementalTypes.Contains(this.errorMessageAdjunctTypeId);
 #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/code/TelemetriesAffordance.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/code/TelemetriesAffordance.cs
@@ -1,0 +1,32 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public partial class TelemetriesAffordance : ITemplateTransform
+    {
+        private readonly IReadOnlyDictionary<string, DTTelemetryInfo> dtTelemetries;
+        private readonly bool usesTypes;
+        private readonly string contentType;
+        private readonly string telemetryTopic;
+        private readonly string? serviceGroupId;
+        private readonly string telemetryId;
+        private readonly ThingDescriber thingDescriber;
+
+        public TelemetriesAffordance(IReadOnlyDictionary<string, DTTelemetryInfo> dtTelemetries, bool usesTypes, string contentType, string telemetryTopic, string? serviceGroupId, string telemetryId, ThingDescriber thingDescriber)
+        {
+            this.dtTelemetries = dtTelemetries;
+            this.usesTypes = usesTypes;
+            this.contentType = contentType;
+            this.telemetryTopic = telemetryTopic;
+            this.serviceGroupId = serviceGroupId;
+            this.telemetryId = telemetryId;
+
+            this.thingDescriber = thingDescriber;
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/code/TelemetryAffordance.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/code/TelemetryAffordance.cs
@@ -1,0 +1,30 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public partial class TelemetryAffordance : ITemplateTransform
+    {
+        private readonly DTTelemetryInfo dtTelemetry;
+        private readonly bool usesTypes;
+        private readonly string contentType;
+        private readonly string telemetryTopic;
+        private readonly string? serviceGroupId;
+        private readonly ThingDescriber thingDescriber;
+
+        public TelemetryAffordance(DTTelemetryInfo dtTelemetry, bool usesTypes, string contentType, string telemetryTopic, string? serviceGroupId, ThingDescriber thingDescriber)
+        {
+            this.dtTelemetry = dtTelemetry;
+            this.usesTypes = usesTypes;
+            this.contentType = contentType;
+            this.telemetryTopic = telemetryTopic;
+            this.serviceGroupId = serviceGroupId;
+
+            this.thingDescriber = thingDescriber;
+        }
+
+        public string FileName { get => string.Empty; }
+
+        public string FolderPath { get => string.Empty; }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/t4/TelemetriesAffordance.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/t4/TelemetriesAffordance.tt
@@ -1,0 +1,37 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser" #>
+<#@ import namespace="DTDLParser.Models" #>
+    "telemetry": {
+<# if (this.usesTypes) { #>
+      "data": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+<# int ix1 = 1; foreach (KeyValuePair<string, DTTelemetryInfo> dtTelemetry in this.dtTelemetries) { #>
+          "<#=dtTelemetry.Key#>": {
+<# if (dtTelemetry.Value.Description.Any()) { #>
+            "descriptions": {
+<# int ix2 = 1; foreach (KeyValuePair<string, string> kvp in dtTelemetry.Value.Description) { #>
+              "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix2 < dtTelemetry.Value.Description.Count ? "," : ""#>
+<# ix2++; } #>
+            },
+<# } #>
+<#=this.thingDescriber.GetTypeAndAddenda(dtTelemetry.Value.Schema, 12)#>
+          }<#=ix1 < dtTelemetries.Count ? "," : ""#>
+<# ix1++; } #>
+        }
+      },
+<# } else { #>
+      "data": {},
+<# } #>
+      "forms": [
+        {
+          "href": "<#=this.telemetryId#>",
+          "contentType": "<#=this.contentType#>",
+<# if (this.serviceGroupId != null) { #>
+          "x-serviceGroupId": "<#=this.serviceGroupId#>",
+<# } #>
+          "x-topic": "<#=this.telemetryTopic#>"
+        }
+      ]
+    }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/t4/TelemetryAffordance.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/Telemetry/t4/TelemetryAffordance.tt
@@ -1,0 +1,29 @@
+<#@ template language="C#" linePragmas="false" #>
+<#@ import namespace="DTDLParser" #>
+<#@ import namespace="DTDLParser.Models" #>
+    "<#=this.dtTelemetry.Name#>": {
+<# if (this.dtTelemetry.Description.Any()) { #>
+      "descriptions": {
+<# int ix = 1; foreach (KeyValuePair<string, string> kvp in this.dtTelemetry.Description) { #>
+        "<#=kvp.Key#>": "<#=kvp.Value#>"<#=ix < this.dtTelemetry.Description.Count ? "," : ""#>
+<# ix++; } #>
+      },
+<# } #>
+<# if (this.usesTypes) { #>
+      "data": {
+<#=this.thingDescriber.GetTypeAndAddenda(this.dtTelemetry.Schema, 8)#>
+      },
+<# } else { #>
+      "data": {},
+<# } #>
+      "forms": [
+        {
+          "href": "<#=this.dtTelemetry.Id#>",
+          "contentType": "<#=this.contentType#>",
+<# if (this.serviceGroupId != null) { #>
+          "x-serviceGroupId": "<#=this.serviceGroupId#>",
+<# } #>
+          "x-topic": "<#=this.telemetryTopic#>"
+        }
+      ]
+    }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/common/ThingDescriber.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/translation/common/ThingDescriber.cs
@@ -1,0 +1,132 @@
+namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using System;
+    using System.Collections.Generic;
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public class ThingDescriber
+    {
+        private readonly int mqttVersion;
+        private HashSet<Dtmi> ancestralSchemaIds;
+
+        public ThingDescriber(int mqttVersion)
+        {
+            this.mqttVersion = mqttVersion;
+            this.ancestralSchemaIds = new HashSet<Dtmi>();
+        }
+
+        public string GetTypeAndAddenda(DTSchemaInfo dtSchema, int indent)
+        {
+            if (dtSchema.EntityKind == DTEntityKind.Object)
+            {
+                var templateTransform = new ObjectThingSchema((DTObjectInfo)dtSchema, indent, this.mqttVersion, this);
+                return this.GetTransformedText(templateTransform, dtSchema.Id);
+            }
+
+            if (dtSchema.EntityKind == DTEntityKind.Enum)
+            {
+                var templateTransform = new EnumThingSchema((DTEnumInfo)dtSchema, indent);
+                return this.GetTransformedText(templateTransform, dtSchema.Id);
+            }
+
+            if (dtSchema.EntityKind == DTEntityKind.Array)
+            {
+                var templateTransform = new ArrayThingSchema((DTArrayInfo)dtSchema, indent, this);
+                return this.GetTransformedText(templateTransform, dtSchema.Id);
+            }
+
+            if (dtSchema.EntityKind == DTEntityKind.Map)
+            {
+                var templateTransform = new MapThingSchema((DTMapInfo)dtSchema, indent, this);
+                return this.GetTransformedText(templateTransform, dtSchema.Id);
+            }
+
+            string it = new string(' ', indent);
+            string nl = $"{Environment.NewLine}{it}";
+
+            return dtSchema.Id.AbsoluteUri switch
+            {
+                "dtmi:dtdl:instance:Schema:boolean;2" => $"{it}\"type\": \"boolean\"",
+                "dtmi:dtdl:instance:Schema:double;2" => $"{it}\"type\": \"number\",{nl}\"format\": \"double\"",
+                "dtmi:dtdl:instance:Schema:float;2" => $"{it}\"type\": \"number\",{nl}\"format\": \"float\"",
+                "dtmi:dtdl:instance:Schema:integer;2" => $"{it}\"type\": \"integer\",{nl}\"minimum\": -2147483648,{nl}\"maximum\": 2147483647",
+                "dtmi:dtdl:instance:Schema:long;2" => $"{it}\"type\": \"integer\",{nl}\"minimum\": -9223372036854775808,{nl}\"maximum\": 9223372036854775807",
+                "dtmi:dtdl:instance:Schema:byte;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": -128,{nl}\"maximum\": 127",
+                "dtmi:dtdl:instance:Schema:short;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": -32768,{nl}\"maximum\": 32767",
+                "dtmi:dtdl:instance:Schema:unsignedInteger;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": 0,{nl}\"maximum\": 4294967295",
+                "dtmi:dtdl:instance:Schema:unsignedLong;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": 0,{nl}\"maximum\": 18446744073709551615",
+                "dtmi:dtdl:instance:Schema:unsignedByte;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": 0,{nl}\"maximum\": 255",
+                "dtmi:dtdl:instance:Schema:unsignedShort;4" => $"{it}\"type\": \"integer\",{nl}\"minimum\": 0,{nl}\"maximum\": 65535",
+                "dtmi:dtdl:instance:Schema:date;2" => $"{it}\"type\": \"string\",{nl}\"format\": \"date\"",
+                "dtmi:dtdl:instance:Schema:dateTime;2" => $"{it}\"type\": \"string\",{nl}\"format\": \"date-time\"",
+                "dtmi:dtdl:instance:Schema:time;2" => $"{it}\"type\": \"string\",{nl}\"format\": \"time\"",
+                "dtmi:dtdl:instance:Schema:duration;2" => $"{it}\"type\": \"string\",{nl}\"format\": \"duration\"",
+                "dtmi:dtdl:instance:Schema:string;2" => $"{it}\"type\": \"string\"",
+                "dtmi:dtdl:instance:Schema:uuid;4" => $"{it}\"type\": \"string\",{nl}\"format\": \"uuid\"",
+                "dtmi:dtdl:instance:Schema:bytes;4" => $"{it}\"type\": \"string\",{nl}\"contentEncoding\": \"base64\"",
+                "dtmi:dtdl:instance:Schema:decimal;4" => $"{it}\"type\": \"string\",{nl}\"x-pattern\": " + @"""^(?:\\+|-)?(?:[1-9][0-9]*|0)(?:\\.[0-9]*)?$""",
+                _ => string.Empty,
+            };
+        }
+
+        public string GetCommandAffordance(DTCommandInfo dtCommand, bool usesTypes, string contentType, string commandTopic, string serviceGroupId)
+        {
+            var templateTransform = new CommandAffordance(dtCommand, this.mqttVersion, usesTypes, contentType, commandTopic, serviceGroupId, this);
+            return templateTransform.TransformText();
+        }
+
+        public string GetTelemetryAffordance(DTTelemetryInfo dtTelemetry, bool usesTypes, string contentType, string telemetryTopic, string serviceGroupId)
+        {
+            var templateTransform = new TelemetryAffordance(dtTelemetry, usesTypes, contentType, telemetryTopic, serviceGroupId, this);
+            return templateTransform.TransformText();
+        }
+
+        public string GetTelemetriesAffordance(IReadOnlyDictionary<string, DTTelemetryInfo> dtTelemetries, bool usesTypes, string contentType, string telemetryTopic, string serviceGroupId, string telemetryId)
+        {
+            var templateTransform = new TelemetriesAffordance(dtTelemetries, usesTypes, contentType, telemetryTopic, serviceGroupId, telemetryId, this);
+            return templateTransform.TransformText();
+        }
+
+        public static string GetPrimitiveType(Dtmi primitiveSchemaId)
+        {
+            return primitiveSchemaId.AbsoluteUri switch
+            {
+                "dtmi:dtdl:instance:Schema:boolean;2" => "boolean",
+                "dtmi:dtdl:instance:Schema:double;2" => "number",
+                "dtmi:dtdl:instance:Schema:float;2" => "number",
+                "dtmi:dtdl:instance:Schema:integer;2" => "integer",
+                "dtmi:dtdl:instance:Schema:long;2" => "integer",
+                "dtmi:dtdl:instance:Schema:byte;4" => "integer",
+                "dtmi:dtdl:instance:Schema:short;4" => "integer",
+                "dtmi:dtdl:instance:Schema:unsignedInteger;4" => "integer",
+                "dtmi:dtdl:instance:Schema:unsignedLong;4" => "integer",
+                "dtmi:dtdl:instance:Schema:unsignedByte;4" => "integer",
+                "dtmi:dtdl:instance:Schema:unsignedShort;4" => "integer",
+                "dtmi:dtdl:instance:Schema:date;2" => "string",
+                "dtmi:dtdl:instance:Schema:dateTime;2" => "string",
+                "dtmi:dtdl:instance:Schema:time;2" => "string",
+                "dtmi:dtdl:instance:Schema:duration;2" => "string",
+                "dtmi:dtdl:instance:Schema:string;2" => "string",
+                "dtmi:dtdl:instance:Schema:uuid;4" => "string",
+                "dtmi:dtdl:instance:Schema:bytes;4" => "string",
+                "dtmi:dtdl:instance:Schema:decimal;4" => "string",
+                _ => "null",
+            };
+        }
+
+        private string GetTransformedText(ITemplateTransform templateTransform, Dtmi schemaId)
+        {
+            if (this.ancestralSchemaIds.Contains(schemaId))
+            {
+                throw new RecursionException(schemaId);
+            }
+
+            this.ancestralSchemaIds.Add(schemaId);
+            string text = templateTransform.TransformText();
+            this.ancestralSchemaIds.Remove(schemaId);
+
+            return text;
+        }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ThingGenerator/RecursionException.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ThingGenerator/RecursionException.cs
@@ -1,0 +1,16 @@
+﻿namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using System;
+    using DTDLParser;
+
+    public class RecursionException : Exception
+    {
+        public Dtmi SchemaId { get; }
+
+        public RecursionException(Dtmi schemaId)
+            : base($"Schema {schemaId} refers to itself")
+        {
+            SchemaId = schemaId;
+        }
+    }
+}

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ThingGenerator/ThingGenerator.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/ThingGenerator/ThingGenerator.cs
@@ -1,0 +1,49 @@
+﻿namespace Azure.Iot.Operations.ProtocolCompiler
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+
+    public class ThingGenerator
+    {
+        private readonly IReadOnlyDictionary<Dtmi, DTEntityInfo> modelDict;
+        private readonly Dtmi interfaceId;
+        private readonly int mqttVersion;
+
+        public ThingGenerator(IReadOnlyDictionary<Dtmi, DTEntityInfo> modelDict, Dtmi interfaceId, int mqttVersion)
+        {
+            this.modelDict = modelDict;
+            this.interfaceId = interfaceId;
+            this.mqttVersion = mqttVersion;
+        }
+
+        public bool GenerateThing(DirectoryInfo outDir)
+        {
+            DTInterfaceInfo dtInterface = (DTInterfaceInfo)modelDict[interfaceId];
+
+            ITemplateTransform interfaceThingTransform = new InterfaceThing(dtInterface, this.mqttVersion);
+
+            string interfaceThingText;
+            try
+            {
+                interfaceThingText = interfaceThingTransform.TransformText();
+            }
+            catch (RecursionException rex)
+            {
+                Console.WriteLine($"Unable to generate Thing Description {interfaceThingTransform.FileName} because {rex.SchemaId} has a self-referential definition");
+                return false;
+            }
+
+            if (!outDir.Exists)
+            {
+                outDir.Create();
+            }
+
+            string filePath = Path.Combine(outDir.FullName, interfaceThingTransform.FileName);
+            File.WriteAllText(filePath, interfaceThingText);
+
+            Console.WriteLine($"  generated {filePath}");
+
+            return true;
+        }
+    }
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandRaw.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandRaw.json
@@ -1,0 +1,24 @@
+﻿{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "raw/0",
+  "commandTopic": "samples/command/{commandName}/{executorId}",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "post",
+      "request": {
+        "name": "postData",
+        "schema": "bytes"
+      },
+      "response": {
+        "name": "replyData",
+        "schema": "bytes"
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandWithResponseResult.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandWithResponseResult.json
@@ -1,0 +1,77 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "commandTopic": "rpc/samples/{modelId}/{executorId}/{commandName}",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "getConfig",
+      "response": {
+        "name": "getConfigResponse",
+        "schema": {
+          "@type": [ "Object", "Result" ],
+          "fields": [
+            {
+              "@type": [ "Field", "NormalResult" ],
+              "name": "currentConfiguration",
+              "schema": {
+                "@type": "Object",
+                "fields": [
+                  {
+                    "name": "version",
+                    "schema": "double"
+                  },
+                  {
+                    "name": "releaseNotes",
+                    "schema": "string"
+                  },
+                  {
+                    "name": "lastUpdated",
+                    "schema": "dateTime"
+                  }
+                ]
+              }
+            },
+            {
+              "@type": [ "Field", "ErrorResult" ],
+              "name": "incrementError",
+              "schema": {
+                "@type": [ "Object", "Error" ],
+                "description": "The requested operation could not be completed.",
+                "fields": [
+                  {
+                    "@type": [ "Field", "ErrorMessage" ],
+                    "name": "explanation",
+                    "schema": "string"
+                  },
+                  {
+                    "name": "condition",
+                    "schema": {
+                      "@type": "Enum",
+                      "valueSchema": "integer",
+                      "enumValues": [
+                        {
+                          "name": "configTemporarilyAvailable",
+                          "enumValue": 1
+                        },
+                        {
+                          "name": "configCorrupt",
+                          "enumValue": 2
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandWithServiceGroupId.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/CommandWithServiceGroupId.json
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "commandTopic": "rpc/samples/{modelId}/{executorId}/{commandName}",
+  "cmdServiceGroupId": "TestServiceGroup",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "signal",
+      "request": {
+        "name": "info",
+        "schema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "type",
+              "schema": "integer"
+            },
+            {
+              "name": "value",
+              "schema": "double"
+            },
+            {
+              "name": "notes",
+              "schema": "string"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryRawSeparate.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryRawSeparate.json
@@ -1,0 +1,22 @@
+﻿{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "raw/0",
+  "telemetryTopic": "sample/{senderId}/telemetry/{telemetryName}",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "foo",
+      "schema": "bytes"
+    },
+    {
+      "@type": "Telemetry",
+      "name": "bar",
+      "schema": "bytes"
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryRawSingle.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryRawSingle.json
@@ -1,0 +1,17 @@
+﻿{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "raw/0",
+  "telemetryTopic": "sample/{modelId}/{senderId}/telemetry",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "data",
+      "schema": "bytes"
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryWithServiceGroupId.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/SchemaGeneratorTests/models/TelemetryWithServiceGroupId.json
@@ -1,0 +1,30 @@
+﻿{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "telemetryTopic": "rpc/samples/{modelId}/{senderId}/{telemetryName}",
+  "telemServiceGroupId": "TestServiceGroup",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "coordinates",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "latitude",
+            "schema": "double"
+          },
+          {
+            "name": "longitude",
+            "schema": "double"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/ThingGeneratorTests.cs
+++ b/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/ThingGeneratorTests.cs
@@ -1,0 +1,105 @@
+﻿namespace Azure.Iot.Operations.ProtocolCompiler.UnitTests.ThingGeneratorTests
+{
+    using DTDLParser;
+    using DTDLParser.Models;
+    using NJsonSchema;
+    using NJsonSchema.Validation;
+    using Azure.Iot.Operations.ProtocolCompiler;
+
+    public class ThingGeneratorTests
+    {
+        private const string modelsPath = $"../../../SchemaGeneratorTests/models";
+        private const string problematicModelsPath = $"../../../ThingGeneratorTests/problematicModels";
+        private const string schemaPath = $"../../../ThingGeneratorTests/schemas/td-json-schema-validation.json";
+        private const int mqttDtdlVersionOffset = 2;
+        private const int maxDtdlVersion = 4;
+
+        private static readonly int[] mqttVersions = { 1, 2, 3 };
+        private static readonly int[] noMqttVersion = { 0 };
+        private static readonly string[] typedFormats = { PayloadFormat.Avro, PayloadFormat.Cbor, PayloadFormat.Json, PayloadFormat.Proto2, PayloadFormat.Proto3 };
+        private static readonly string[] noTypedformat = { string.Empty };
+        private static readonly Dtmi testInterfaceId = new Dtmi("dtmi:akri:DTDL:SchemaGenerator:testInterface;1");
+        private static readonly Dtmi faultyId = new Dtmi("dtmi:akri:DTDL:ThingGenerator:recursiveObject;1");
+
+        private readonly JsonSchema tdSchema;
+        private readonly ModelParser modelParser;
+
+        public static IEnumerable<object[]> GetTestCases()
+        {
+            return GetTestCasesInt(modelsPath);
+        }
+
+        public static IEnumerable<object[]> GetProblematicTestCases()
+        {
+            return GetTestCasesInt(problematicModelsPath);
+        }
+
+        public ThingGeneratorTests()
+        {
+            tdSchema = JsonSchema.FromFileAsync(schemaPath).Result;
+            modelParser = new ModelParser();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCases))]
+        public void ValidateGeneratedThingDescription(string fileName, string modelText, int mqttVersion)
+        {
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> modelDict = modelParser.Parse(modelText);
+            DTInterfaceInfo dtInterface = (DTInterfaceInfo)modelDict[testInterfaceId];
+
+            ITemplateTransform interfaceThingTransform = new InterfaceThing(dtInterface, mqttVersion);
+
+            string thingDescription = interfaceThingTransform.TransformText();
+
+            ICollection<ValidationError> errors = tdSchema.Validate(thingDescription);
+            Assert.False(errors.Any(), $"{fileName} yields an invalid Thing Description");
+        }
+
+        [Theory]
+        [MemberData(nameof(GetProblematicTestCases))]
+        public void ConfirmThingGenerationFailure(string _, string modelText, int mqttVersion)
+        {
+            IReadOnlyDictionary<Dtmi, DTEntityInfo> modelDict = modelParser.Parse(modelText);
+
+            DTInterfaceInfo dtInterface = (DTInterfaceInfo)modelDict[testInterfaceId];
+
+            ITemplateTransform interfaceThingTransform = new InterfaceThing(dtInterface, mqttVersion);
+
+            RecursionException rex = Assert.Throws<RecursionException>(interfaceThingTransform.TransformText);
+            Assert.Equal(faultyId, rex.SchemaId);
+        }
+
+        private static IEnumerable<object[]> GetTestCasesInt(string path)
+        {
+            foreach (string modelPath in Directory.GetFiles(path, @"*.json"))
+            {
+                string modelTemplate = File.OpenText(modelPath).ReadToEnd();
+                if (modelTemplate.Contains("<[ID]>"))
+                {
+                    continue;
+                }
+
+                foreach (int mqttVersion in modelTemplate.Contains("<[MVER]>") ? mqttVersions : noMqttVersion)
+                {
+                    string versionedModel = modelTemplate;
+                    if (mqttVersion > 0)
+                    {
+                        int dtdlVersion = int.Min(mqttVersion + mqttDtdlVersionOffset, maxDtdlVersion);
+                        versionedModel = modelTemplate.Replace("<[DVER]>", dtdlVersion.ToString()).Replace("<[MVER]>", mqttVersion.ToString());
+                    }
+
+                    foreach (string format in versionedModel.Contains("<[FORMAT]>") ? typedFormats : noTypedformat)
+                    {
+                        string formattedModel = versionedModel;
+                        if (format != string.Empty)
+                        {
+                            formattedModel = versionedModel.Replace("<[FORMAT]>", format);
+                        }
+
+                        yield return new object[] { Path.GetFileName(modelPath), formattedModel, mqttVersion > 0 ? mqttVersion : mqttVersions.Last() };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/CommandWithRecursiveRequestObject.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/CommandWithRecursiveRequestObject.json
@@ -1,0 +1,32 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "commandTopic": "rpc/samples/{modelId}/{executorId}/{commandName}",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "signal",
+      "request": {
+        "name": "info",
+        "schema": {
+          "@id": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1",
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "children",
+              "schema": {
+                "@type": "Array",
+                "elementSchema": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/CommandWithRecursiveResponseObject.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/CommandWithRecursiveResponseObject.json
@@ -1,0 +1,32 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "commandTopic": "rpc/samples/{modelId}/{executorId}/{commandName}",
+  "contents": [
+    {
+      "@type": "Command",
+      "name": "getConfig",
+      "response": {
+        "name": "currentConfiguration",
+        "schema": {
+          "@id": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1",
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "children",
+              "schema": {
+                "@type": "Array",
+                "elementSchema": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/TelemetryWithRecursiveObject.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/problematicModels/TelemetryWithRecursiveObject.json
@@ -1,0 +1,29 @@
+﻿{
+  "@context": [
+    "dtmi:dtdl:context;4",
+    "dtmi:dtdl:extension:mqtt;3"
+  ],
+  "@id": "dtmi:akri:DTDL:SchemaGenerator:testInterface;1",
+  "@type": [ "Interface", "Mqtt" ],
+  "payloadFormat": "<[FORMAT]>",
+  "telemetryTopic": "rpc/samples/{modelId}/{senderId}/{telemetryName}",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "coordinates",
+      "schema": {
+        "@id": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1",
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "children",
+            "schema": {
+              "@type": "Array",
+              "elementSchema": "dtmi:akri:DTDL:ThingGenerator:recursiveObject;1"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/schemas/td-json-schema-validation.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/ThingGeneratorTests/schemas/td-json-schema-validation.json
@@ -1,0 +1,1318 @@
+{
+  "title": "Thing Description",
+  "version": "1.1-12-March-2025",
+  "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
+  "definitions": {
+    "anyUri": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "descriptions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "title": {
+      "type": "string"
+    },
+    "titles": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "security": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "scopes": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "subprotocol": {
+      "type": "string",
+      "examples": ["longpoll", "websub", "sse"]
+    },
+    "thing-context-td-uri-v1": {
+      "type": "string",
+      "const": "https://www.w3.org/2019/wot/td/v1"
+    },
+    "thing-context-td-uri-v1.1": {
+      "type": "string",
+      "const": "https://www.w3.org/2022/wot/td/v1.1"
+    },
+    "thing-context-td-uri-temp": {
+      "type": "string",
+      "const": "http://www.w3.org/ns/td"
+    },
+    "thing-context": {
+      "anyOf": [
+        {
+          "$comment": "New context URI with other vocabularies after it but not the old one",
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
+            }
+          ],
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ],
+            "not": {
+              "$ref": "#/definitions/thing-context-td-uri-v1"
+            }
+          }
+        },
+        {
+          "$comment": "Only the new context URI",
+          "$ref": "#/definitions/thing-context-td-uri-v1.1"
+        },
+        {
+          "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/thing-context-td-uri-v1"
+            },
+            {
+              "$ref": "#/definitions/thing-context-td-uri-v1.1"
+            }
+          ],
+          "minItems": 2,
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "$comment": "Old context URI, followed by possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/thing-context-td-uri-v1"
+            }
+          ],
+          "minItems": 1,
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "$comment": "Only the old context URI",
+          "$ref": "#/definitions/thing-context-td-uri-v1"
+        }
+      ]
+    },
+    "bcp47_string": {
+      "type": "string",
+      "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+    },
+    "type_declaration": {
+      "oneOf": [
+        {
+          "type": "string",
+          "not": {
+            "const": "tm:ThingModel"
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "not": {
+              "const": "tm:ThingModel"
+            }
+          }
+        }
+      ]
+    },
+    "dataSchema-type": {
+      "type": "string",
+      "enum": ["boolean", "integer", "number", "string", "object", "array", "null"]
+    },
+    "dataSchema": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "titles": {
+          "$ref": "#/definitions/titles"
+        },
+        "writeOnly": {
+          "type": "boolean"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "unit": {
+          "type": "string"
+        },
+        "enum": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "format": {
+          "type": "string"
+        },
+        "const": {},
+        "default": {},
+        "contentEncoding": {
+          "type": "string"
+        },
+        "contentMediaType": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/dataSchema-type"
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dataSchema"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dataSchema"
+              }
+            }
+          ]
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOfDefinition"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "additionalResponsesDefinition": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "contentType": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "multipleOfDefinition": {
+      "type": ["integer", "number"],
+      "exclusiveMinimum": 0
+    },
+    "expectedResponse": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        }
+      },
+      "required": ["contentType"]
+    },
+    "form_element_base": {
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "href": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "contentCoding": {
+          "type": "string"
+        },
+        "subprotocol": {
+          "$ref": "#/definitions/subprotocol"
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        },
+        "scopes": {
+          "$ref": "#/definitions/scopes"
+        },
+        "response": {
+          "$ref": "#/definitions/expectedResponse"
+        },
+        "additionalResponses": {
+          "$ref": "#/definitions/additionalResponsesDefinition"
+        }
+      },
+      "required": ["href"],
+      "additionalProperties": true
+    },
+    "form_element_property": {
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["readproperty", "writeproperty", "observeproperty", "unobserveproperty"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["readproperty", "writeproperty", "observeproperty", "unobserveproperty"]
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "form_element_action": {
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["invokeaction", "queryaction", "cancelaction"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["invokeaction", "queryaction", "cancelaction"]
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "form_element_event": {
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["subscribeevent", "unsubscribeevent"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["subscribeevent", "unsubscribeevent"]
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "form_element_root": {
+      "allOf": [{ "$ref": "#/definitions/form_element_base" }],
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "readallproperties",
+                "writeallproperties",
+                "readmultipleproperties",
+                "writemultipleproperties",
+                "observeallproperties",
+                "unobserveallproperties",
+                "queryallactions",
+                "subscribeallevents",
+                "unsubscribeallevents"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "readallproperties",
+                  "writeallproperties",
+                  "readmultipleproperties",
+                  "writemultipleproperties",
+                  "observeallproperties",
+                  "unobserveallproperties",
+                  "queryallactions",
+                  "subscribeallevents",
+                  "unsubscribeallevents"
+                ]
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": true,
+      "required": ["op"]
+    },
+    "form": {
+      "$comment": "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
+      "oneOf": [
+        { "$ref": "#/definitions/form_element_property" },
+        { "$ref": "#/definitions/form_element_action" },
+        { "$ref": "#/definitions/form_element_event" },
+        { "$ref": "#/definitions/form_element_root" }
+      ]
+    },
+    "property_element": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "titles": {
+          "$ref": "#/definitions/titles"
+        },
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/form_element_property"
+          }
+        },
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "observable": {
+          "type": "boolean"
+        },
+        "writeOnly": {
+          "type": "boolean"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "unit": {
+          "type": "string"
+        },
+        "enum": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "format": {
+          "type": "string"
+        },
+        "const": {},
+        "default": {},
+        "type": {
+          "$ref": "#/definitions/dataSchema-type"
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dataSchema"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dataSchema"
+              }
+            }
+          ]
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOfDefinition"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["forms"],
+      "additionalProperties": true
+    },
+    "action_element": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "titles": {
+          "$ref": "#/definitions/titles"
+        },
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/form_element_action"
+          }
+        },
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "input": {
+          "$ref": "#/definitions/dataSchema"
+        },
+        "output": {
+          "$ref": "#/definitions/dataSchema"
+        },
+        "safe": {
+          "type": "boolean"
+        },
+        "idempotent": {
+          "type": "boolean"
+        },
+        "synchronous": {
+          "type": "boolean"
+        }
+      },
+      "required": ["forms"],
+      "additionalProperties": true
+    },
+    "event_element": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "titles": {
+          "$ref": "#/definitions/titles"
+        },
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/form_element_event"
+          }
+        },
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/dataSchema"
+          }
+        },
+        "subscription": {
+          "$ref": "#/definitions/dataSchema"
+        },
+        "data": {
+          "$ref": "#/definitions/dataSchema"
+        },
+        "dataResponse": {
+          "$ref": "#/definitions/dataSchema"
+        },
+        "cancellation": {
+          "$ref": "#/definitions/dataSchema"
+        }
+      },
+      "required": ["forms"],
+      "additionalProperties": true
+    },
+    "base_link_element": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "type": {
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "anchor": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "hreflang": {
+          "anyOf": [
+            { "$ref": "#/definitions/bcp47_string" },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/bcp47_string"
+              }
+            }
+          ]
+        }
+      },
+      "required": ["href"],
+      "additionalProperties": true
+    },
+    "link_element": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_link_element"
+        },
+        {
+          "not": {
+            "description": "A basic link element should not contain sizes",
+            "type": "object",
+            "properties": {
+              "sizes": {}
+            },
+            "required": ["sizes"]
+          }
+        },
+        {
+          "not": {
+            "description": "A basic link element should not contain icon or tm:extends",
+            "properties": {
+              "rel": {
+                "enum": ["icon", "tm:extends"]
+              }
+            },
+            "required": ["rel"]
+          }
+        }
+      ]
+    },
+    "icon_link_element": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_link_element"
+        },
+        {
+          "properties": {
+            "rel": {
+              "const": "icon"
+            },
+            "sizes": {
+              "type": "string",
+              "pattern": "[0-9]*x[0-9]+"
+            }
+          },
+          "required": ["rel"]
+        }
+      ]
+    },
+    "additionalSecurityScheme": {
+      "description": "Applies to additional SecuritySchemes not defined in the WoT TD specification.",
+      "$comment": "Additional SecuritySchemes should always be defined via a context extension, using a prefixed value for the scheme. This prefix (e.g. 'ace', see the example below) must contain at least one character in order to reference a valid JSON-LD context extension.",
+      "examples": [
+        {
+          "scheme": "ace:ACESecurityScheme",
+          "ace:as": "coaps://as.example.com/token",
+          "ace:audience": "coaps://rs.example.com",
+          "ace:scopes": ["limited", "special"],
+          "ace:cnonce": true
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "pattern": ".+:.*"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "noSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["nosec"]
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "autoSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["auto"]
+        }
+      },
+      "not": {
+        "required": ["name"]
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "comboSecurityScheme": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "$ref": "#/definitions/type_declaration"
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            },
+            "descriptions": {
+              "$ref": "#/definitions/descriptions"
+            },
+            "proxy": {
+              "$ref": "#/definitions/anyUri"
+            },
+            "scheme": {
+              "type": "string",
+              "enum": ["combo"]
+            },
+            "oneOf": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["scheme", "oneOf"],
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "properties": {
+            "@type": {
+              "$ref": "#/definitions/type_declaration"
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            },
+            "descriptions": {
+              "$ref": "#/definitions/descriptions"
+            },
+            "proxy": {
+              "$ref": "#/definitions/anyUri"
+            },
+            "scheme": {
+              "type": "string",
+              "enum": ["combo"]
+            },
+            "allOf": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["scheme", "allOf"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "basicSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["basic"]
+        },
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "digestSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["digest"]
+        },
+        "qop": {
+          "type": "string",
+          "enum": ["auth", "auth-int"]
+        },
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "apiKeySecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["apikey"]
+        },
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "uri", "auto"]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "bearerSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["bearer"]
+        },
+        "authorization": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "alg": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "pskSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["psk"]
+        },
+        "identity": {
+          "type": "string"
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "oAuth2SecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "$ref": "#/definitions/type_declaration"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "descriptions": {
+          "$ref": "#/definitions/descriptions"
+        },
+        "proxy": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scheme": {
+          "type": "string",
+          "enum": ["oauth2"]
+        },
+        "authorization": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "token": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "refresh": {
+          "$ref": "#/definitions/anyUri"
+        },
+        "scopes": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "flow": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "enum": ["code", "client"]
+            }
+          ]
+        }
+      },
+      "required": ["scheme"],
+      "additionalProperties": true
+    },
+    "securityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/noSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/autoSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/comboSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/basicSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/digestSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/apiKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/bearerSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/pskSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/oAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/additionalSecurityScheme"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "titles": {
+      "$ref": "#/definitions/titles"
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/property_element"
+      }
+    },
+    "actions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/action_element"
+      }
+    },
+    "events": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/event_element"
+      }
+    },
+    "description": {
+      "$ref": "#/definitions/description"
+    },
+    "descriptions": {
+      "$ref": "#/definitions/descriptions"
+    },
+    "version": {
+      "type": "object",
+      "properties": {
+        "instance": {
+          "type": "string"
+        }
+      },
+      "required": ["instance"]
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/link_element"
+          },
+          {
+            "$ref": "#/definitions/icon_link_element"
+          }
+        ]
+      }
+    },
+    "forms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/form_element_root"
+      }
+    },
+    "base": {
+      "$ref": "#/definitions/anyUri"
+    },
+    "securityDefinitions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/securityScheme"
+      }
+    },
+    "schemaDefinitions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/dataSchema"
+      }
+    },
+    "support": {
+      "$ref": "#/definitions/anyUri"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "profile": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/anyUri"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/anyUri"
+          }
+        }
+      ]
+    },
+    "security": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "uriVariables": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/dataSchema"
+      }
+    },
+    "@type": {
+      "$ref": "#/definitions/type_declaration"
+    },
+    "@context": {
+      "$ref": "#/definitions/thing-context"
+    }
+  },
+  "required": ["title", "security", "securityDefinitions", "@context"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
This change enables the ProtocolCompiler to generate a [WoT Thing Description](https://www.w3.org/TR/2023/REC-wot-thing-description11-20231205/) (TD) from the DTDL model it ingests.  So far, the resulting TD is not used in any later stages of the ProtocolCompiler.

The change includes a comprehensive set of tests that validate the generated TD against the official [Thing Description JSON Schema](https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json).