### PR TITLE
Fix filemount test files to use UTF-8

### DIFF
--- a/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/AIO_METADATA
+++ b/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/AIO_METADATA
@@ -1,4 +1,4 @@
-﻿{
+{
     "aioMinVersion": "1.0",
     "aioMaxVersion": "2.0"
 }

--- a/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/DIAGNOSTICS
+++ b/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/DIAGNOSTICS
@@ -1,4 +1,4 @@
-﻿{
+{
     "logs": {
         "level": "trace"
     }

--- a/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/MQTT_CONNECTION_CONFIGURATION
+++ b/eng/test/test-connector-mount-files/connector-config-no-auth-no-tls/MQTT_CONNECTION_CONFIGURATION
@@ -1,4 +1,4 @@
-﻿{
+{
     "host": "someHostName:1234",
     "keepAliveSeconds": 10,
     "maxInflightMessages": 10,

--- a/eng/test/test-connector-mount-files/connector-config/AIO_METADATA
+++ b/eng/test/test-connector-mount-files/connector-config/AIO_METADATA
@@ -1,4 +1,4 @@
-﻿{
+{
     "aioMinVersion": "1.0",
     "aioMaxVersion": "2.0"
 }

--- a/eng/test/test-connector-mount-files/connector-config/DIAGNOSTICS
+++ b/eng/test/test-connector-mount-files/connector-config/DIAGNOSTICS
@@ -1,4 +1,4 @@
-﻿{
+{
     "logs": {
         "level": "trace"
     }

--- a/eng/test/test-connector-mount-files/connector-config/MQTT_CONNECTION_CONFIGURATION
+++ b/eng/test/test-connector-mount-files/connector-config/MQTT_CONNECTION_CONFIGURATION
@@ -1,4 +1,4 @@
-﻿{
+{
     "host": "someHostName:1234",
     "keepAliveSeconds": 10,
     "maxInflightMessages": 10,
@@ -11,6 +11,6 @@
     },
     "sessionExpirySeconds": 20,
     "tls": {
-        "mode": "enabled"
+        "mode": "Enabled"
     }
 }


### PR DESCRIPTION
Previously they used UTF-8 BOM which was unnecessary and problematic.
Also fixed incorrect capitalization on an enum