### PR TITLE
Add Debug target for docfx otherwise it wont find dependencies for the Connector package

### DIFF
--- a/.github/pages/docfx.json
+++ b/.github/pages/docfx.json
@@ -8,7 +8,10 @@
       "dest": "api",
       "filter": "filterConfig.yml",
       "namespaceLayout": "nested",
-      "memberLayout": "samePage"
+      "memberLayout": "samePage",
+      "properties": {
+          "Configuration": "Debug"
+      }
     }
   ],
   "build": {

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
-    </ItemGroup>
+    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
+  </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Azure.Iot.Operations.Protocol\Azure.Iot.Operations.Protocol.csproj" />

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
-  </ItemGroup>
+        <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
+    </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Azure.Iot.Operations.Protocol\Azure.Iot.Operations.Protocol.csproj" />


### PR DESCRIPTION
The csproj file for the Connector package will only include dependencies if the "Configuration" is set to Debug or Release.

Add Debug configuration target to the docfx.json file.