### PR TITLE
[Rust][Services] Split leased_lock client (ADR 20) and add lease & lock auto-renewal

### DIFF
--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -61,7 +61,7 @@ name = "schema_registry_client"
 required-features = ["schema_registry"]
 
 [[example]]
-name = "leased_lock_client"
+name = "lock_client"
 required-features = ["leased_lock"]
 
 [package.metadata.docs.rs]

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -34,6 +34,7 @@ derive_builder.workspace = true
 log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 data-encoding = "2.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.105", optional = true }

--- a/rust/azure_iot_operations_services/examples/leased_lock_client.rs
+++ b/rust/azure_iot_operations_services/examples/leased_lock_client.rs
@@ -4,7 +4,6 @@
 use std::{sync::Arc, time::Duration};
 
 use env_logger::Builder;
-use tokio::sync::Notify;
 
 use azure_iot_operations_mqtt::MqttConnectionSettingsBuilder;
 use azure_iot_operations_mqtt::session::{
@@ -20,7 +19,7 @@ use azure_iot_operations_services::state_store;
 async fn main() {
     let client_id1 = "someClientId1";
     let client_id2 = "someClientId2";
-    let lock_name = "someLock";
+    let key_name = "someLock";
 
     Builder::new()
         .filter_level(log::LevelFilter::Info)
@@ -29,32 +28,19 @@ async fn main() {
         .init();
 
     let (session1, exit_handle1, state_store_client_arc1, leased_lock_client1) =
-        create_clients(client_id1, lock_name);
+        create_clients(client_id1, key_name);
 
     let (session2, exit_handle2, state_store_client_arc2, leased_lock_client2) =
-        create_clients(client_id2, lock_name);
-
-    let client_1_notify = Arc::new(Notify::new());
-    let client_2_notify = client_1_notify.clone();
+        create_clients(client_id2, key_name);
 
     let client_1_task = tokio::task::spawn(async move {
-        leased_lock_client_1_operations(
-            state_store_client_arc1,
-            leased_lock_client1,
-            exit_handle1,
-            client_1_notify,
-        )
-        .await;
+        leased_lock_client_1_operations(state_store_client_arc1, leased_lock_client1, exit_handle1)
+            .await;
     });
 
     let client_2_task = tokio::task::spawn(async move {
-        leased_lock_client_2_operations(
-            state_store_client_arc2,
-            leased_lock_client2,
-            exit_handle2,
-            client_2_notify,
-        )
-        .await;
+        leased_lock_client_2_operations(state_store_client_arc2, leased_lock_client2, exit_handle2)
+            .await;
     });
 
     let _ = tokio::try_join!(
@@ -67,7 +53,7 @@ async fn main() {
 
 fn create_clients(
     client_id: &str,
-    lock_name: &str,
+    key_name: &str,
 ) -> (
     Session,
     SessionExitHandle,
@@ -107,7 +93,7 @@ fn create_clients(
 
     let leased_lock_client = leased_lock::Client::new(
         state_store_client_arc.clone(),
-        lock_name.as_bytes().to_vec(),
+        key_name.as_bytes().to_vec(),
         client_id.as_bytes().to_vec(),
     )
     .unwrap();
@@ -125,7 +111,7 @@ fn create_clients(
 /// make all these calls, but they do show all that can be done with this client.
 ///
 /// In `leased_lock_client_1_operations` you will find the following examples:
-/// 1. Acquire a lock using `acquire_lock()`
+/// 1. Acquire a lock using `acquire()`
 /// 2. Sets a key in the State Store using the `fencing_token` obtained from the lock.
 /// 3. Gets the current lock holder name.
 /// 4. Releases a lock.
@@ -133,7 +119,6 @@ async fn leased_lock_client_1_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
     leased_lock_client: leased_lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
-    notify: Arc<Notify>,
 ) {
     let lock_expiry = Duration::from_secs(10);
     let request_timeout = Duration::from_secs(120);
@@ -145,17 +130,11 @@ async fn leased_lock_client_1_operations(
         expires: Some(Duration::from_secs(15)),
     };
 
-    notify.notified().await; // Wait for Client 2 to observe lock.
-    log::info!("Client 1 notified that Client 2 is observing lock.");
-
     // 1.
-    let fencing_token = match leased_lock_client
-        .acquire_lock(lock_expiry, request_timeout)
-        .await
-    {
-        Ok(acquire_lock_result) => {
+    let fencing_token = match leased_lock_client.lock(lock_expiry, request_timeout).await {
+        Ok(acquire_result) => {
             log::info!("Lock acquired successfully");
-            acquire_lock_result // a.k.a., the fencing token.
+            acquire_result // a.k.a., the fencing token.
         }
         Err(e) => {
             log::error!("Failed acquiring lock {e}");
@@ -190,10 +169,9 @@ async fn leased_lock_client_1_operations(
     };
 
     // 3.
-    get_lock_holder(&leased_lock_client, request_timeout).await;
 
     // 4.
-    match leased_lock_client.release_lock(request_timeout).await {
+    match leased_lock_client.unlock(request_timeout).await {
         Ok(()) => {
             log::info!("Lock released successfully");
         }
@@ -211,13 +189,12 @@ async fn leased_lock_client_1_operations(
 /// In `leased_lock_client_2_operations` you will find the following examples:
 /// 5. Start observing a lock, waiting for it to be released.
 /// 6. Stop observing a lock.
-/// 7. Make a call to `acquire_lock_and_update_value()` to set a key.
-/// 8. Make a call to `acquire_lock_and_update_value()` to delete a key.
+/// 7. Make a call to `lock_and_update_value()` to set a key.
+/// 8. Make a call to `lock_and_update_value()` to delete a key.
 async fn leased_lock_client_2_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
     leased_lock_client: leased_lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
-    notify: Arc<Notify>,
 ) {
     let lock_expiry = Duration::from_secs(10);
     let request_timeout = Duration::from_secs(10);
@@ -230,46 +207,9 @@ async fn leased_lock_client_2_operations(
         expires: Some(Duration::from_secs(15)),
     };
 
-    // 5.
-    let mut received_lock_free_notification = false;
-    while !received_lock_free_notification {
-        let mut observe_response = leased_lock_client
-            .observe_lock(request_timeout)
-            .await
-            .unwrap();
-
-        notify.notify_one();
-
-        loop {
-            let Some((notification, _)) = observe_response.response.recv_notification().await
-            else {
-                log::warn!(
-                    "Received None for lock notification. Client probably disconnected. observe_lock() must be called again."
-                );
-                break;
-            };
-
-            log::info!(
-                "Client2 received lock notification: {:?}",
-                notification.operation
-            );
-
-            if notification.operation == state_store::Operation::Del {
-                received_lock_free_notification = true;
-                break;
-            }
-        }
-    }
-
-    // 6.
-    leased_lock_client
-        .unobserve_lock(request_timeout)
-        .await
-        .unwrap();
-
     // 7.
     match leased_lock_client
-        .acquire_lock_and_update_value(
+        .lock_and_update_value(
             lock_expiry,
             request_timeout,
             shared_resource_key_name.to_vec(),
@@ -288,11 +228,11 @@ async fn leased_lock_client_2_operations(
         )
         .await
     {
-        Ok(acquire_lock_and_update_value_result) => {
-            if acquire_lock_and_update_value_result.response {
+        Ok(lock_and_update_value_result) => {
+            if lock_and_update_value_result.response {
                 log::info!("Key successfully set");
             } else {
-                log::error!("Could not set key {acquire_lock_and_update_value_result:?}");
+                log::error!("Could not set key {lock_and_update_value_result:?}");
                 return;
             }
         }
@@ -306,7 +246,7 @@ async fn leased_lock_client_2_operations(
 
     // 8.
     match leased_lock_client
-        .acquire_lock_and_update_value(
+        .lock_and_update_value(
             lock_expiry,
             request_timeout,
             shared_resource_key_name.to_vec(),
@@ -317,11 +257,11 @@ async fn leased_lock_client_2_operations(
         )
         .await
     {
-        Ok(acquire_lock_and_update_value_result) => {
-            if acquire_lock_and_update_value_result.response {
+        Ok(lock_and_update_value_result) => {
+            if lock_and_update_value_result.response {
                 log::info!("Key successfully deleted");
             } else {
-                log::error!("Could not delete key {acquire_lock_and_update_value_result:?}",);
+                log::error!("Could not delete key {lock_and_update_value_result:?}",);
                 return;
             }
         }
@@ -334,26 +274,4 @@ async fn leased_lock_client_2_operations(
     state_store_client_arc.shutdown().await.unwrap();
 
     exit_handle.try_exit().await.unwrap();
-}
-
-async fn get_lock_holder(
-    leased_lock_client: &azure_iot_operations_services::leased_lock::Client<SessionManagedClient>,
-    request_timeout: Duration,
-) {
-    match leased_lock_client.get_lock_holder(request_timeout).await {
-        Ok(lock_holder_response) => match lock_holder_response.response {
-            Some(holder_name) => {
-                log::info!(
-                    "Lock being held by {}",
-                    String::from_utf8(holder_name).unwrap()
-                );
-            }
-            None => {
-                log::info!("Lock is currently free");
-            }
-        },
-        Err(e) => {
-            log::error!("Failed getting lock holder: {e}");
-        }
-    };
 }

--- a/rust/azure_iot_operations_services/examples/leased_lock_client.rs
+++ b/rust/azure_iot_operations_services/examples/leased_lock_client.rs
@@ -10,9 +10,7 @@ use azure_iot_operations_mqtt::session::{
     Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
 };
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
-use azure_iot_operations_services::leased_lock::{
-    self, AcquireAndUpdateKeyOption, SetCondition, SetOptions,
-};
+use azure_iot_operations_services::leased_lock::{SetCondition, SetOptions, lock};
 use azure_iot_operations_services::state_store;
 
 #[tokio::main(flavor = "current_thread")]
@@ -27,20 +25,18 @@ async fn main() {
         .filter_module("rumqttc", log::LevelFilter::Warn)
         .init();
 
-    let (session1, exit_handle1, state_store_client_arc1, leased_lock_client1) =
+    let (session1, exit_handle1, state_store_client_arc1, lock_client1) =
         create_clients(client_id1, key_name);
 
-    let (session2, exit_handle2, state_store_client_arc2, leased_lock_client2) =
+    let (session2, exit_handle2, state_store_client_arc2, lock_client2) =
         create_clients(client_id2, key_name);
 
     let client_1_task = tokio::task::spawn(async move {
-        leased_lock_client_1_operations(state_store_client_arc1, leased_lock_client1, exit_handle1)
-            .await;
+        lock_client_1_operations(state_store_client_arc1, lock_client1, exit_handle1).await;
     });
 
     let client_2_task = tokio::task::spawn(async move {
-        leased_lock_client_2_operations(state_store_client_arc2, leased_lock_client2, exit_handle2)
-            .await;
+        lock_client_2_operations(state_store_client_arc2, lock_client2, exit_handle2).await;
     });
 
     let _ = tokio::try_join!(
@@ -58,7 +54,7 @@ fn create_clients(
     Session,
     SessionExitHandle,
     Arc<state_store::Client<SessionManagedClient>>,
-    leased_lock::Client<SessionManagedClient>,
+    lock::Client<SessionManagedClient>,
 ) {
     let application_context = ApplicationContextBuilder::default().build().unwrap();
 
@@ -91,33 +87,27 @@ fn create_clients(
 
     let state_store_client_arc = Arc::new(state_store_client);
 
-    let leased_lock_client = leased_lock::Client::new(
+    let lock_client = lock::Client::new(
         state_store_client_arc.clone(),
         key_name.as_bytes().to_vec(),
         client_id.as_bytes().to_vec(),
     )
     .unwrap();
 
-    (
-        session,
-        exit_handle,
-        state_store_client_arc,
-        leased_lock_client,
-    )
+    (session, exit_handle, state_store_client_arc, lock_client)
 }
 
 /// In the functions below we show different calls that an application could make
 /// into the `leased_lock::Client`. Not necessarily an application would need to
 /// make all these calls, but they do show all that can be done with this client.
 ///
-/// In `leased_lock_client_1_operations` you will find the following examples:
-/// 1. Acquire a lock using `acquire()`
+/// In `lock_client_1_operations` you will find the following examples:
+/// 1. Acquire a lock using `lock()`
 /// 2. Sets a key in the State Store using the `fencing_token` obtained from the lock.
-/// 3. Gets the current lock holder name.
-/// 4. Releases a lock.
-async fn leased_lock_client_1_operations(
+/// 3. Releases a lock.
+async fn lock_client_1_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    mut leased_lock_client: leased_lock::Client<SessionManagedClient>,
+    mut lock_client: lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);
@@ -131,10 +121,7 @@ async fn leased_lock_client_1_operations(
     };
 
     // 1.
-    let fencing_token = match leased_lock_client
-        .lock(lock_expiry, request_timeout, None)
-        .await
-    {
+    let fencing_token = match lock_client.lock(lock_expiry, request_timeout, None).await {
         Ok(acquire_result) => {
             log::info!("Lock acquired successfully");
             acquire_result // a.k.a., the fencing token.
@@ -174,7 +161,7 @@ async fn leased_lock_client_1_operations(
     // 3.
 
     // 4.
-    match leased_lock_client.unlock(request_timeout).await {
+    match lock_client.unlock(request_timeout).await {
         Ok(()) => {
             log::info!("Lock released successfully");
         }
@@ -189,87 +176,70 @@ async fn leased_lock_client_1_operations(
     exit_handle.try_exit().await.unwrap();
 }
 
-/// In `leased_lock_client_2_operations` you will find the following examples:
-/// 5. Start observing a lock, waiting for it to be released.
-/// 6. Stop observing a lock.
-/// 7. Make a call to `lock_and_update_value()` to set a key.
-/// 8. Make a call to `lock_and_update_value()` to delete a key.
-async fn leased_lock_client_2_operations(
+/// In `lock_client_2_operations` you will find the following examples:
+/// 4. Waits until lock the lock is acquired.
+/// 5. Sets a key in the State Store using the `fencing_token` obtained from the lock.
+/// 6. Releases the lock.
+async fn lock_client_2_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    mut leased_lock_client: leased_lock::Client<SessionManagedClient>,
+    mut lock_client: lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);
-    let request_timeout = Duration::from_secs(10);
+    let request_timeout = Duration::from_secs(120);
 
     let shared_resource_key_name = b"someKey";
-    let shared_resource_key_value1 = b"someValue1";
     let shared_resource_key_value2 = b"someValue2";
     let shared_resource_key_set_options = SetOptions {
         set_condition: SetCondition::Unconditional,
         expires: Some(Duration::from_secs(15)),
     };
 
-    // 7.
-    match leased_lock_client
-        .lock_and_update_value(
-            lock_expiry,
-            request_timeout,
-            shared_resource_key_name.to_vec(),
-            &|key_current_value: Option<Vec<u8>>| {
-                // Perform some check on `key_current_value`...
-                if key_current_value.unwrap() == shared_resource_key_value1.to_vec() {
-                    AcquireAndUpdateKeyOption::Update(
-                        shared_resource_key_value2.to_vec(),
-                        shared_resource_key_set_options.clone(),
-                    )
-                } else {
-                    AcquireAndUpdateKeyOption::DoNotUpdate
-                    // Handle unexpected value...
-                }
-            },
-        )
-        .await
-    {
-        Ok(lock_and_update_value_result) => {
-            if lock_and_update_value_result.response {
-                log::info!("Key successfully set");
-            } else {
-                log::error!("Could not set key {lock_and_update_value_result:?}");
-                return;
-            }
+    // 4.
+    let fencing_token = match lock_client.lock(lock_expiry, request_timeout, None).await {
+        Ok(acquire_result) => {
+            log::info!("Lock acquired successfully");
+            acquire_result // a.k.a., the fencing token.
         }
         Err(e) => {
-            log::error!("Failed setting key: {e}");
+            log::error!("Failed acquiring lock {e}");
             return;
         }
     };
 
-    // Perform any application-logic and when done, delete key...
-
-    // 8.
-    match leased_lock_client
-        .lock_and_update_value(
-            lock_expiry,
-            request_timeout,
+    // The purpose of the lock is to protect setting a shared key in the state store.
+    // 5.
+    match state_store_client_arc
+        .set(
             shared_resource_key_name.to_vec(),
-            &|_key_current_value| {
-                // Perform some check on `key_current_value`...
-                AcquireAndUpdateKeyOption::Delete
-            },
+            shared_resource_key_value2.to_vec(),
+            request_timeout,
+            Some(fencing_token),
+            shared_resource_key_set_options.clone(),
         )
         .await
     {
-        Ok(lock_and_update_value_result) => {
-            if lock_and_update_value_result.response {
-                log::info!("Key successfully deleted");
+        Ok(set_response) => {
+            if set_response.response {
+                log::info!("Key set successfully");
             } else {
-                log::error!("Could not delete key {lock_and_update_value_result:?}",);
+                log::error!("Could not set key {set_response:?}");
                 return;
             }
         }
         Err(e) => {
-            log::error!("Failed deleting key: {e}");
+            log::error!("Failed setting key {e}");
+            return;
+        }
+    };
+
+    // 6.
+    match lock_client.unlock(request_timeout).await {
+        Ok(()) => {
+            log::info!("Lock released successfully");
+        }
+        Err(e) => {
+            log::error!("Failed releasing lock {e}");
             return;
         }
     };

--- a/rust/azure_iot_operations_services/examples/leased_lock_client.rs
+++ b/rust/azure_iot_operations_services/examples/leased_lock_client.rs
@@ -117,7 +117,7 @@ fn create_clients(
 /// 4. Releases a lock.
 async fn leased_lock_client_1_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    leased_lock_client: leased_lock::Client<SessionManagedClient>,
+    mut leased_lock_client: leased_lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);
@@ -131,7 +131,10 @@ async fn leased_lock_client_1_operations(
     };
 
     // 1.
-    let fencing_token = match leased_lock_client.lock(lock_expiry, request_timeout).await {
+    let fencing_token = match leased_lock_client
+        .lock(lock_expiry, request_timeout, None)
+        .await
+    {
         Ok(acquire_result) => {
             log::info!("Lock acquired successfully");
             acquire_result // a.k.a., the fencing token.
@@ -193,7 +196,7 @@ async fn leased_lock_client_1_operations(
 /// 8. Make a call to `lock_and_update_value()` to delete a key.
 async fn leased_lock_client_2_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    leased_lock_client: leased_lock::Client<SessionManagedClient>,
+    mut leased_lock_client: leased_lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);

--- a/rust/azure_iot_operations_services/examples/lock_client.rs
+++ b/rust/azure_iot_operations_services/examples/lock_client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/// This example shows the how to use lock::Client for locking/unlocking operations.
+/// This example shows the how to use `lock::Client` for locking/unlocking operations.
 use std::{sync::Arc, time::Duration};
 
 use env_logger::Builder;

--- a/rust/azure_iot_operations_services/examples/lock_client.rs
+++ b/rust/azure_iot_operations_services/examples/lock_client.rs
@@ -108,7 +108,7 @@ fn create_clients(
 /// 3. Releases a lock.
 async fn lock_client_1_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    mut lock_client: lock::Client<SessionManagedClient>,
+    lock_client: lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);
@@ -183,7 +183,7 @@ async fn lock_client_1_operations(
 /// 6. Releases the lock.
 async fn lock_client_2_operations(
     state_store_client_arc: Arc<state_store::Client<SessionManagedClient>>,
-    mut lock_client: lock::Client<SessionManagedClient>,
+    lock_client: lock::Client<SessionManagedClient>,
     exit_handle: SessionExitHandle,
 ) {
     let lock_expiry = Duration::from_secs(10);

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -17,12 +17,10 @@ pub type LeaseObservation = KeyObservation;
 /// Represents the errors that occur in the Azure IoT Operations State Store Service.
 pub type ServiceError = StateStoreServiceError;
 
-/// Leased Lock Client implementation
-mod client;
-/// Key Lease Client implementation
+/// Lease Client implementation
 pub mod lease;
-
-pub use client::Client;
+/// Lock Client implementation
+pub mod lock;
 
 /// Represents an error that occurred in the Azure IoT Operations Key Lease implementation.
 #[derive(Debug, Error)]
@@ -102,15 +100,4 @@ impl From<state_store::ErrorKind> for ErrorKind {
             state_store::ErrorKind::DuplicateObserve => ErrorKind::DuplicateObserve,
         }
     }
-}
-
-/// Enumeration used as a response for `leased_lock::Client::lock_and_update_value`.
-pub enum AcquireAndUpdateKeyOption {
-    /// Indicates a State Store key shall be updated.
-    /// The first argument is new value for the State Store key.
-    Update(Vec<u8>, SetOptions),
-    /// Indicates the State Store key shall not be updated nor deleted.
-    DoNotUpdate,
-    /// Indicates the State Store key shall be deleted.
-    Delete,
 }

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Types for Key Lease operations.
+//! Types for Lease and Lock operations.
 
 use core::fmt::Debug;
 
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::state_store::{self, KeyObservation, ServiceError as StateStoreServiceError};
 pub use crate::state_store::{Response, SetCondition, SetOptions};
 
-/// A struct to manage receiving notifications for a lock
+/// A struct to manage receiving notifications for a lease
 pub type LeaseObservation = KeyObservation;
 
 /// Represents the errors that occur in the Azure IoT Operations State Store Service.
@@ -22,7 +22,7 @@ pub mod lease;
 /// Lock Client implementation
 pub mod lock;
 
-/// Represents an error that occurred in the Azure IoT Operations Key Lease implementation.
+/// Represents an error that occurred in the Azure IoT Operations Lease and Lock implementation.
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct Error(#[from] ErrorKind);
@@ -42,13 +42,13 @@ impl From<state_store::Error> for Error {
     }
 }
 
-/// Represents the kinds of errors that occur in the Azure IoT Operations Key Lease implementation.
+/// Represents the kinds of errors that occur in the Azure IoT Operations Lease and Lock implementation.
 #[derive(Error, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ErrorKind {
-    /// The lock is already in use by another holder.
-    #[error("lock is already held by another holder")]
-    KeyAlreadyLeased,
+    /// The lease is already in use by another holder.
+    #[error("lease is already held by another holder")]
+    LeaseAlreadyHeld,
     /// An error occurred in the AIO Protocol. See [`AIOProtocolError`] for more information.
     #[error(transparent)]
     AIOProtocolError(#[from] AIOProtocolError),
@@ -58,18 +58,6 @@ pub enum ErrorKind {
     /// The key length must not be zero.
     #[error("key length must not be zero")]
     KeyLengthZero,
-    /// The lease name length must not be zero.
-    #[error("lease name length must not be zero")]
-    LeaseNameLengthZero,
-    /// The lock name length must not be zero.
-    #[error("lock name length must not be zero")]
-    LockNameLengthZero,
-    /// The lease holder name length must not be zero.
-    #[error("lease holder name length must not be zero")]
-    LeaseHolderNameLengthZero,
-    /// The lock holder name length must not be zero.
-    #[error("lock holder name length must not be zero")]
-    LockHolderNameLengthZero,
     /// Fencing token not received from service.
     #[error("Fencing token not received from service")]
     MissingFencingToken,

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -58,12 +58,18 @@ pub enum ErrorKind {
     /// The key length must not be zero.
     #[error("key length must not be zero")]
     KeyLengthZero,
+    /// The lease name length must not be zero.
+    #[error("lease name length must not be zero")]
+    LeaseNameLengthZero,
     /// The lock name length must not be zero.
     #[error("lock name length must not be zero")]
     LockNameLengthZero,
+    /// The lease holder name length must not be zero.
+    #[error("lease holder name length must not be zero")]
+    LeaseHolderNameLengthZero,
     /// The lock holder name length must not be zero.
     #[error("lock holder name length must not be zero")]
-    LeaseHolderNameLengthZero,
+    LockHolderNameLengthZero,
     /// An error occurred during serialization of a request.
     #[error("{0}")]
     SerializationError(String),

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -67,8 +67,8 @@ pub enum ErrorKind {
     /// The payload of the response does not match the expected type for the request.
     #[error("Unexpected response payload for the request type: {0}")]
     UnexpectedPayload(String),
-    /// A lock may only have one [`LeaseObservation`] at a time.
-    #[error("lock may only be observed once at a time")]
+    /// A lease may only have one [`LeaseObservation`] at a time.
+    #[error("lease may only be observed once at a time")]
     DuplicateObserve,
 }
 

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -70,6 +70,9 @@ pub enum ErrorKind {
     /// The lock holder name length must not be zero.
     #[error("lock holder name length must not be zero")]
     LockHolderNameLengthZero,
+    /// Fencing token not received from service.
+    #[error("Fencing token not received from service")]
+    MissingFencingToken,
     /// An error occurred during serialization of a request.
     #[error("{0}")]
     SerializationError(String),

--- a/rust/azure_iot_operations_services/src/leased_lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock.rs
@@ -55,9 +55,6 @@ pub enum ErrorKind {
     /// An error occurred from the State Store Service. See [`ServiceError`] for more information.
     #[error(transparent)]
     ServiceError(#[from] ServiceError),
-    /// The key length must not be zero.
-    #[error("key length must not be zero")]
-    KeyLengthZero,
     /// Fencing token not received from service.
     #[error("Fencing token not received from service")]
     MissingFencingToken,
@@ -84,7 +81,6 @@ impl From<state_store::ErrorKind> for ErrorKind {
             state_store::ErrorKind::ServiceError(service_error) => {
                 ErrorKind::ServiceError(service_error)
             }
-            state_store::ErrorKind::KeyLengthZero => ErrorKind::KeyLengthZero,
             state_store::ErrorKind::SerializationError(error_string) => {
                 ErrorKind::SerializationError(error_string)
             }

--- a/rust/azure_iot_operations_services/src/leased_lock/client.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/client.rs
@@ -6,25 +6,23 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::leased_lock::{
-    AcquireAndUpdateKeyOption, Error, ErrorKind, LockObservation, Response, SetCondition,
-    SetOptions,
+    AcquireAndUpdateKeyOption, Error, ErrorKind, Response, lease::Client as LeaseClient,
 };
 use crate::state_store::{self};
 use azure_iot_operations_mqtt::interface::ManagedClient;
 use azure_iot_operations_protocol::common::hybrid_logical_clock::HybridLogicalClock;
 
-/// Leased Lock client struct.
+/// Key Lease client struct.
 pub struct Client<C>
 where
     C: ManagedClient + Clone + Send + Sync + 'static,
     C::PubReceiver: Send + Sync,
 {
     state_store: Arc<state_store::Client<C>>,
-    lock_name: Vec<u8>,
-    lock_holder_name: Vec<u8>,
+    lease_client: LeaseClient<C>,
 }
 
-/// Leased Lock client implementation
+/// Lock client implementation
 ///
 /// Notes:
 /// Do not call any of the methods of this client after the `state_store` parameter is shutdown.
@@ -34,7 +32,7 @@ where
     C: ManagedClient + Clone + Send + Sync,
     C::PubReceiver: Send + Sync,
 {
-    /// Create a new Leased Lock Client.
+    /// Create a new Lock Client.
     ///
     /// Notes:
     /// - `lock_holder_name` is expected to be the client ID used in the underlying MQTT connection settings.
@@ -43,7 +41,7 @@ where
     /// # Errors
     /// [`struct@Error`] of kind [`LockNameLengthZero`](ErrorKind::LockNameLengthZero) if the `lock_name` is empty
     ///
-    /// [`struct@Error`] of kind [`LockHolderNameLengthZero`](ErrorKind::LockHolderNameLengthZero) if the `lock_holder_name` is empty
+    /// [`struct@Error`] of kind [`LeaseHolderNameLengthZero`](ErrorKind::LeaseHolderNameLengthZero) if the `lock_holder_name` is empty
     pub fn new(
         state_store: Arc<state_store::Client<C>>,
         lock_name: Vec<u8>,
@@ -54,60 +52,15 @@ where
         }
 
         if lock_holder_name.is_empty() {
-            return Err(Error(ErrorKind::LockHolderNameLengthZero));
+            return Err(Error(ErrorKind::LeaseHolderNameLengthZero));
         }
+
+        let lease_client = LeaseClient::new(state_store.clone(), lock_name, lock_holder_name)?;
 
         Ok(Self {
             state_store,
-            lock_name,
-            lock_holder_name,
+            lease_client,
         })
-    }
-
-    /// Attempts to acquire a lock, returning if it cannot be acquired after one attempt.
-    ///
-    /// `lock_expiration` is how long the lock will remain held in the State Store after acquired, if not released before then.
-    /// `request_timeout` is the maximum time the function will wait for receiving a response from the State Store service, it is rounded up to the nearest second.
-    ///
-    /// Returns Ok with a fencing token (`HybridLogicalClock`) if completed successfully, or `Error(LockAlreadyHeld)` if lock is not acquired.
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
-    ///
-    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `Set` request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
-    ///
-    /// [`struct@Error`] of kind [`LockAlreadyHeld`](ErrorKind::LockAlreadyHeld) if the `lock` is already in use by another holder
-    /// # Panics
-    /// Possible panic if, for some error, the fencing token (a.k.a. `version`) of the acquired lock is None.
-    pub async fn try_acquire_lock(
-        &self,
-        lock_expiration: Duration,
-        request_timeout: Duration,
-    ) -> Result<HybridLogicalClock, Error> {
-        let state_store_response = self
-            .state_store
-            .set(
-                self.lock_name.clone(),
-                self.lock_holder_name.clone(),
-                request_timeout,
-                None,
-                SetOptions {
-                    set_condition: SetCondition::OnlyIfEqualOrDoesNotExist,
-                    expires: Some(lock_expiration),
-                },
-            )
-            .await?;
-
-        if state_store_response.response {
-            Ok(state_store_response
-                .version
-                .expect("Got None for fencing token. A lock without a fencing token is of no use."))
-        } else {
-            Err(Error(ErrorKind::LockAlreadyHeld))
-        }
     }
 
     /// Waits until a lock is available (if not already) and attempts to acquire it.
@@ -124,59 +77,32 @@ where
     ///
     /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
     /// # Panics
-    /// Possible panic if, for some error, the fencing token (a.k.a. `version`) of the acquired lock is None.
-    pub async fn acquire_lock(
+    /// Possible panic if, for some error, the fencing token (a.k.a. `version`) of the acquired lease is None.
+    pub async fn lock(
         &self,
         lock_expiration: Duration,
         request_timeout: Duration,
     ) -> Result<HybridLogicalClock, Error> {
-        // Logic:
-        // a. Start observing lock within this function.
-        // b. Try acquiring the lock and return if acquired or got an error other than `LockAlreadyHeld`.
-        // c. If got `LockAlreadyHeld`, wait until `Del` notification for the lock. If notification is None, re-observe (start from a. again).
-        // d. Loop back starting from b. above.
-        // e. Unobserve lock before exiting.
+        self.lease_client
+            .acquire(lock_expiration, request_timeout)
+            .await
+    }
 
-        let mut observe_response = self.observe_lock(request_timeout).await?;
-        let mut acquire_result;
-
-        loop {
-            acquire_result = self
-                .try_acquire_lock(lock_expiration, request_timeout)
-                .await;
-
-            match acquire_result {
-                Ok(_) => {
-                    break; /* Lock acquired */
-                }
-                Err(ref acquire_error) => match acquire_error.kind() {
-                    ErrorKind::LockAlreadyHeld => { /* Must wait for lock to be released. */ }
-                    _ => {
-                        break;
-                    }
-                },
-            };
-
-            // Lock being held by another client. Wait for delete notification.
-            loop {
-                let Some((notification, _)) = observe_response.response.recv_notification().await
-                else {
-                    // If the state_store client gets disconnected (or shutdown), all the observation channels receive a None.
-                    // In such case, as per design, we must re-observe the lock.
-                    observe_response = self.observe_lock(request_timeout).await?;
-                    break;
-                };
-
-                if notification.operation == state_store::Operation::Del {
-                    break;
-                };
-            }
-        }
-
-        match self.unobserve_lock(request_timeout).await {
-            Ok(_) => acquire_result,
-            Err(unobserve_error) => Err(unobserve_error),
-        }
+    /// Releases a lock.
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns `Ok()` if lease is no longer held by this `lock holder`, or `Error` otherwise.
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
+    ///
+    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `V Delete` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
+    pub async fn unlock(&self, request_timeout: Duration) -> Result<(), Error> {
+        self.lease_client.release(request_timeout).await
     }
 
     /// Waits until a lock is acquired, sets/updates/deletes a key in the State Store (depending on `update_value_function` result) and releases the lock.
@@ -188,7 +114,7 @@ where
     /// Where `key_current_value` is the current value of `key` in the State Store (right after the lock is acquired).
     /// If the return is `AcquireAndUpdateKeyOption::Update(key_new_value)` it must contain the new value of the State Store key.
     ///
-    /// The same `request_timeout` is used for all the individual network calls within `acquire_lock_and_update_value`.
+    /// The same `request_timeout` is used for all the individual network calls within `lock_and_update_value`.
     ///
     /// Note: `request_timeout` is rounded up to the nearest second.
     ///
@@ -201,14 +127,17 @@ where
     /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for the request
     ///
     /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
-    pub async fn acquire_lock_and_update_value(
+    pub async fn lock_and_update_value(
         &self,
         lock_expiration: Duration,
         request_timeout: Duration,
         key: Vec<u8>,
         update_value_function: impl Fn(Option<Vec<u8>>) -> AcquireAndUpdateKeyOption,
     ) -> Result<Response<bool>, Error> {
-        let fencing_token = self.acquire_lock(lock_expiration, request_timeout).await?;
+        let fencing_token = self
+            .lease_client
+            .acquire(lock_expiration, request_timeout)
+            .await?;
 
         /* lock acquired, let's proceed. */
         let get_result = self.state_store.get(key.clone(), request_timeout).await?;
@@ -226,12 +155,12 @@ where
                     )
                     .await;
 
-                let _ = self.release_lock(request_timeout).await;
+                let _ = self.lease_client.release(request_timeout).await;
 
                 Ok(set_response?)
             }
             AcquireAndUpdateKeyOption::DoNotUpdate => {
-                let _ = self.release_lock(request_timeout).await;
+                let _ = self.lease_client.release(request_timeout).await;
                 Ok(Response {
                     response: true,
                     version: None,
@@ -244,127 +173,18 @@ where
                     .await
                 {
                     Ok(delete_response) => {
-                        let _ = self.release_lock(request_timeout).await;
+                        let _ = self.lease_client.release(request_timeout).await;
                         Ok(Response {
                             response: (delete_response.response > 0),
                             version: delete_response.version,
                         })
                     }
                     Err(delete_error) => {
-                        let _ = self.release_lock(request_timeout).await;
+                        let _ = self.lease_client.release(request_timeout).await;
                         Err(delete_error.into())
                     }
                 }
             }
         }
-    }
-
-    /// Releases a lock if and only if requested by the lock holder (same client id).
-    ///
-    /// Note: `request_timeout` is rounded up to the nearest second.
-    ///
-    /// Returns `Ok()` if lock is no longer held by this `lock_holder`, or `Error` otherwise.
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
-    ///
-    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `V Delete` request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
-    pub async fn release_lock(&self, request_timeout: Duration) -> Result<(), Error> {
-        match self
-            .state_store
-            .vdel(
-                self.lock_name.clone(),
-                self.lock_holder_name.clone(),
-                None,
-                request_timeout,
-            )
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(state_store_error) => Err(state_store_error.into()),
-        }
-    }
-
-    /// Starts observation of any changes on a lock
-    ///
-    /// Note: `request_timeout` is rounded up to the nearest second.
-    ///
-    /// Returns OK([`Response<LockObservation>`]) if the lock is now being observed.
-    /// The [`LockObservation`] can be used to receive lock notifications for this lock
-    ///
-    /// <div class="warning">
-    ///
-    /// If a client disconnects, `observe_lock` must be called again by the user.
-    ///
-    /// </div>
-    ///
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
-    /// - the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if
-    /// - the State Store returns an Error response
-    /// - the State Store returns a response that isn't valid for an `Observe` request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if
-    /// - there are any underlying errors from the command invoker
-    pub async fn observe_lock(
-        &self,
-        request_timeout: Duration,
-    ) -> Result<Response<LockObservation>, Error> {
-        Ok(self
-            .state_store
-            .observe(self.lock_name.clone(), request_timeout)
-            .await?)
-    }
-
-    /// Stops observation of any changes on a lock.
-    ///
-    /// Note: `request_timeout` is rounded up to the nearest second.
-    ///
-    /// Returns `true` if the lock is no longer being observed or `false` if the lock wasn't being observed
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
-    /// - the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if
-    /// - the State Store returns an Error response
-    /// - the State Store returns a response that isn't valid for an `Unobserve` request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if
-    /// - there are any underlying errors from the command invoker
-    pub async fn unobserve_lock(&self, request_timeout: Duration) -> Result<Response<bool>, Error> {
-        Ok(self
-            .state_store
-            .unobserve(self.lock_name.clone(), request_timeout)
-            .await?)
-    }
-
-    /// Gets the name of the holder of a lock
-    ///
-    /// Note: `request_timeout` is rounded up to the nearest second.
-    ///
-    /// Returns `Some(<holder of the lock>)` if the lock is found or `None`
-    /// if the lock was not found (i.e., was not acquired by anyone, already released or expired).
-    ///
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
-    ///
-    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `Get` request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
-    pub async fn get_lock_holder(
-        &self,
-        request_timeout: Duration,
-    ) -> Result<Response<Option<Vec<u8>>>, Error> {
-        Ok(self
-            .state_store
-            .get(self.lock_name.clone(), request_timeout)
-            .await?)
     }
 }

--- a/rust/azure_iot_operations_services/src/leased_lock/lease.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/lease.rs
@@ -56,7 +56,7 @@ where
     /// - There must be one instance of `leased_lock::Client` per lease.
     ///
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `lease_name` is empty
+    /// [`struct@Error`] of kind [`LeaseNameLengthZero`](ErrorKind::LeaseNameLengthZero) if the `lease_name` is empty
     ///
     /// [`struct@Error`] of kind [`LeaseHolderNameLengthZero`](ErrorKind::LeaseHolderNameLengthZero) if the `lease_holder_name` is empty
     pub fn new(
@@ -65,7 +65,7 @@ where
         lease_holder_name: Vec<u8>,
     ) -> Result<Self, Error> {
         if lease_name.is_empty() {
-            return Err(Error(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::LeaseNameLengthZero));
         }
 
         if lease_holder_name.is_empty() {

--- a/rust/azure_iot_operations_services/src/leased_lock/lease.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/lease.rs
@@ -148,7 +148,7 @@ where
     ///
     /// [`struct@Error`] of kind [`MissingFencingToken`](ErrorKind::MissingFencingToken) if the fencing token in the service response is empty.
     pub async fn acquire(
-        &mut self,
+        &self,
         lease_expiration: Duration,
         request_timeout: Duration,
         renewal_period: Option<Duration>,

--- a/rust/azure_iot_operations_services/src/leased_lock/lease.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/lease.rs
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Client for Key Lease operations.
+
+use std::{sync::Arc, time::Duration};
+
+use crate::leased_lock::{Error, ErrorKind, LeaseObservation, Response, SetCondition, SetOptions};
+use crate::state_store::{self};
+use azure_iot_operations_mqtt::interface::ManagedClient;
+use azure_iot_operations_protocol::common::hybrid_logical_clock::HybridLogicalClock;
+
+/// Key Lease client struct.
+pub struct Client<C>
+where
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync,
+{
+    state_store: Arc<state_store::Client<C>>,
+    key_name: Vec<u8>,
+    lease_holder_name: Vec<u8>,
+}
+
+/// Key Lease client implementation
+///
+/// Notes:
+/// Do not call any of the methods of this client after the `state_store` parameter is shutdown.
+/// Calling any of the methods in this implementation after the `state_store` is shutdown results in undefined behavior.
+impl<C> Client<C>
+where
+    C: ManagedClient + Clone + Send + Sync,
+    C::PubReceiver: Send + Sync,
+{
+    /// Create a new Key Lease Client.
+    ///
+    /// Notes:
+    /// - `lease_holder_name` is expected to be the client ID used in the underlying MQTT connection settings.
+    /// - There must be one instance of `leased_lock::Client` per lease.
+    ///
+    /// # Errors
+    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `key_name` is empty
+    ///
+    /// [`struct@Error`] of kind [`LeaseHolderNameLengthZero`](ErrorKind::LeaseHolderNameLengthZero) if the `lease_holder_name` is empty
+    pub fn new(
+        state_store: Arc<state_store::Client<C>>,
+        key_name: Vec<u8>,
+        lease_holder_name: Vec<u8>,
+    ) -> Result<Self, Error> {
+        if key_name.is_empty() {
+            return Err(Error(ErrorKind::KeyLengthZero));
+        }
+
+        if lease_holder_name.is_empty() {
+            return Err(Error(ErrorKind::LeaseHolderNameLengthZero));
+        }
+
+        Ok(Self {
+            state_store,
+            key_name,
+            lease_holder_name,
+        })
+    }
+
+    /// Attempts to acquire a lease, returning if it cannot be acquired after one attempt.
+    ///
+    /// `lease_expiration` is how long the lease will remain held in the State Store after acquired, if not released before then.
+    /// `request_timeout` is the maximum time the function will wait for receiving a response from the State Store service, it is rounded up to the nearest second.
+    ///
+    /// Returns Ok with a fencing token (`HybridLogicalClock`) if completed successfully, or `Error(KeyAlreadyLeased)` if lease is not acquired.
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
+    ///
+    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `Set` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
+    ///
+    /// [`struct@Error`] of kind [`KeyAlreadyLeased`](ErrorKind::KeyAlreadyLeased) if the `lease` is already in use by another holder
+    /// # Panics
+    /// Possible panic if, for some error, the fencing token (a.k.a. `version`) of the acquired lease is None.
+    pub async fn try_acquire(
+        &self,
+        lease_expiration: Duration,
+        request_timeout: Duration,
+    ) -> Result<HybridLogicalClock, Error> {
+        let state_store_response = self
+            .state_store
+            .set(
+                self.key_name.clone(),
+                self.lease_holder_name.clone(),
+                request_timeout,
+                None,
+                SetOptions {
+                    set_condition: SetCondition::OnlyIfEqualOrDoesNotExist,
+                    expires: Some(lease_expiration),
+                },
+            )
+            .await?;
+
+        if state_store_response.response {
+            Ok(state_store_response.version.expect(
+                "Got None for fencing token. A lease without a fencing token is of no use.",
+            ))
+        } else {
+            Err(Error(ErrorKind::KeyAlreadyLeased))
+        }
+    }
+
+    /// Waits until a lease is available (if not already) and attempts to acquire it.
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns Ok with a fencing token (`HybridLogicalClock`) if completed successfully, or an Error if any failure occurs.
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
+    ///
+    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for the request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
+    /// # Panics
+    /// Possible panic if, for some error, the fencing token (a.k.a. `version`) of the acquired lease is None.
+    pub async fn acquire(
+        &self,
+        lease_expiration: Duration,
+        request_timeout: Duration,
+    ) -> Result<HybridLogicalClock, Error> {
+        // Logic:
+        // a. Start observing lease within this function.
+        // b. Try acquiring the lease and return if acquired or got an error other than `KeyAlreadyLeased`.
+        // c. If got `KeyAlreadyLeased`, wait until `Del` notification for the lease. If notification is None, re-observe (start from a. again).
+        // d. Loop back starting from b. above.
+        // e. Unobserve lease before exiting.
+
+        let mut observe_response = self.observe(request_timeout).await?;
+        let mut acquire_result;
+
+        loop {
+            acquire_result = self.try_acquire(lease_expiration, request_timeout).await;
+
+            match acquire_result {
+                Ok(_) => {
+                    break; /* lease acquired */
+                }
+                Err(ref acquire_error) => match acquire_error.kind() {
+                    ErrorKind::KeyAlreadyLeased => { /* Must wait for lease to be released. */ }
+                    _ => {
+                        break;
+                    }
+                },
+            };
+
+            // Lease being held by another client. Wait for delete notification.
+            loop {
+                let Some((notification, _)) = observe_response.response.recv_notification().await
+                else {
+                    // If the state_store client gets disconnected (or shutdown), all the observation channels receive a None.
+                    // In such case, as per design, we must re-observe the lease.
+                    observe_response = self.observe(request_timeout).await?;
+                    break;
+                };
+
+                if notification.operation == state_store::Operation::Del {
+                    break;
+                };
+            }
+        }
+
+        match self.unobserve(request_timeout).await {
+            Ok(_) => acquire_result,
+            Err(unobserve_error) => Err(unobserve_error),
+        }
+    }
+
+    /// Releases a lease if and only if requested by the lease holder (same client id).
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns `Ok()` if lease is no longer held by this `lease_holder`, or `Error` otherwise.
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
+    ///
+    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `V Delete` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
+    pub async fn release(&self, request_timeout: Duration) -> Result<(), Error> {
+        match self
+            .state_store
+            .vdel(
+                self.key_name.clone(),
+                self.lease_holder_name.clone(),
+                None,
+                request_timeout,
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(state_store_error) => Err(state_store_error.into()),
+        }
+    }
+
+    /// Starts observation of any changes on a lease
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns OK([`Response<LeaseObservation>`]) if the lease is now being observed.
+    /// The [`LeaseObservation`] can be used to receive lease notifications for this lease
+    ///
+    /// <div class="warning">
+    ///
+    /// If a client disconnects, `observe` must be called again by the user.
+    ///
+    /// </div>
+    ///
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
+    /// - the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if
+    /// - the State Store returns an Error response
+    /// - the State Store returns a response that isn't valid for an `Observe` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if
+    /// - there are any underlying errors from the command invoker
+    pub async fn observe(
+        &self,
+        request_timeout: Duration,
+    ) -> Result<Response<LeaseObservation>, Error> {
+        Ok(self
+            .state_store
+            .observe(self.key_name.clone(), request_timeout)
+            .await?)
+    }
+
+    /// Stops observation of any changes on a lease.
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns `true` if the lease is no longer being observed or `false` if the lease wasn't being observed
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
+    /// - the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if
+    /// - the State Store returns an Error response
+    /// - the State Store returns a response that isn't valid for an `Unobserve` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if
+    /// - there are any underlying errors from the command invoker
+    pub async fn unobserve(&self, request_timeout: Duration) -> Result<Response<bool>, Error> {
+        Ok(self
+            .state_store
+            .unobserve(self.key_name.clone(), request_timeout)
+            .await?)
+    }
+
+    /// Gets the name of the holder of a lease
+    ///
+    /// Note: `request_timeout` is rounded up to the nearest second.
+    ///
+    /// Returns `Some(<holder of the lease>)` if the lease is found or `None`
+    /// if the lease was not found (i.e., was not acquired by anyone, already released or expired).
+    ///
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
+    ///
+    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for a `Get` request
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
+    pub async fn get_holder(
+        &self,
+        request_timeout: Duration,
+    ) -> Result<Response<Option<Vec<u8>>>, Error> {
+        Ok(self
+            .state_store
+            .get(self.key_name.clone(), request_timeout)
+            .await?)
+    }
+}

--- a/rust/azure_iot_operations_services/src/leased_lock/lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/lock.rs
@@ -3,11 +3,11 @@
 
 //! Client for Lease Lock operations.
 
+// TODO: move client.rs to lock.rs; pub mod for both and no import ... (see comment in leased_lock.rs)
+
 use std::{sync::Arc, time::Duration};
 
-use crate::leased_lock::{
-    AcquireAndUpdateKeyOption, Error, ErrorKind, Response, lease::Client as LeaseClient,
-};
+use crate::leased_lock::{Error, ErrorKind, lease::Client as LeaseClient};
 use crate::state_store::{self};
 use azure_iot_operations_mqtt::interface::ManagedClient;
 use azure_iot_operations_protocol::common::hybrid_logical_clock::HybridLogicalClock;
@@ -18,7 +18,6 @@ where
     C: ManagedClient + Clone + Send + Sync + 'static,
     C::PubReceiver: Send + Sync,
 {
-    state_store: Arc<state_store::Client<C>>,
     lease_client: LeaseClient<C>,
 }
 
@@ -55,12 +54,9 @@ where
             return Err(Error(ErrorKind::LeaseHolderNameLengthZero));
         }
 
-        let lease_client = LeaseClient::new(state_store.clone(), lock_name, lock_holder_name)?;
+        let lease_client = LeaseClient::new(state_store, lock_name, lock_holder_name)?;
 
-        Ok(Self {
-            state_store,
-            lease_client,
-        })
+        Ok(Self { lease_client })
     }
 
     /// Waits until a lock is available (if not already) and attempts to acquire it.
@@ -112,89 +108,6 @@ where
         self.lease_client.release(request_timeout).await
     }
 
-    /// Waits until a lock is acquired, sets/updates/deletes a key in the State Store (depending on `update_value_function` result) and releases the lock.
-    ///
-    /// `lock_expiration` should be long enough to last through underlying key operations, otherwise it's possible for updating the value to fail if the lock is no longer held.
-    ///
-    /// `update_value_function` is a function with signature:
-    ///     fn `should_update_key(key_current_value`: `Vec<u8>`) -> `AcquireAndUpdateKeyOption`
-    /// Where `key_current_value` is the current value of `key` in the State Store (right after the lock is acquired).
-    /// If the return is `AcquireAndUpdateKeyOption::Update(key_new_value)` it must contain the new value of the State Store key.
-    ///
-    /// The same `request_timeout` is used for all the individual network calls within `lock_and_update_value`.
-    ///
-    /// Note: `request_timeout` is rounded up to the nearest second.
-    ///
-    /// Returns `true` if the key is successfully set or deleted, or `false` if it is not.
-    /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `request_timeout` is zero or > `u32::max`
-    ///
-    /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
-    ///
-    /// [`struct@Error`] of kind [`UnexpectedPayload`](ErrorKind::UnexpectedPayload) if the State Store returns a response that isn't valid for the request
-    ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
-    pub async fn lock_and_update_value(
-        &mut self,
-        lock_expiration: Duration,
-        request_timeout: Duration,
-        key: Vec<u8>,
-        update_value_function: impl Fn(Option<Vec<u8>>) -> AcquireAndUpdateKeyOption,
-    ) -> Result<Response<bool>, Error> {
-        let fencing_token = self
-            .lease_client
-            .acquire(lock_expiration, request_timeout, None)
-            .await?;
-
-        /* lock acquired, let's proceed. */
-        let get_result = self.state_store.get(key.clone(), request_timeout).await?;
-
-        match update_value_function(get_result.response) {
-            AcquireAndUpdateKeyOption::Update(new_value, set_options) => {
-                let set_response = self
-                    .state_store
-                    .set(
-                        key,
-                        new_value,
-                        request_timeout,
-                        Some(fencing_token),
-                        set_options,
-                    )
-                    .await;
-
-                let _ = self.lease_client.release(request_timeout).await;
-
-                Ok(set_response?)
-            }
-            AcquireAndUpdateKeyOption::DoNotUpdate => {
-                let _ = self.lease_client.release(request_timeout).await;
-                Ok(Response {
-                    response: true,
-                    version: None,
-                })
-            }
-            AcquireAndUpdateKeyOption::Delete => {
-                match self
-                    .state_store
-                    .del(key, Some(fencing_token), request_timeout)
-                    .await
-                {
-                    Ok(delete_response) => {
-                        let _ = self.lease_client.release(request_timeout).await;
-                        Ok(Response {
-                            response: (delete_response.response > 0),
-                            version: delete_response.version,
-                        })
-                    }
-                    Err(delete_error) => {
-                        let _ = self.lease_client.release(request_timeout).await;
-                        Err(delete_error.into())
-                    }
-                }
-            }
-        }
-    }
-
     /// Gets the latest fencing token related to the most recent lock.
     ///
     /// Returns either None or an actual Fencing Token (`HybridLogicalClock`).
@@ -203,7 +116,7 @@ where
     /// does not mean that it is the most recent (and thus valid) Fencing Token - in case
     /// auto-renewal has not been used and the lock has already expired.
     #[must_use]
-    pub async fn get_current_lock_fencing_token(&self) -> Option<HybridLogicalClock> {
-        self.lease_client.get_current_lease_fencing_token().await
+    pub fn get_current_lock_fencing_token(&self) -> Option<HybridLogicalClock> {
+        self.lease_client.get_current_lease_fencing_token()
     }
 }

--- a/rust/azure_iot_operations_services/src/leased_lock/lock.rs
+++ b/rust/azure_iot_operations_services/src/leased_lock/lock.rs
@@ -74,7 +74,7 @@ where
     /// If lock auto-renewal is used, an auto-renewal task is spawned.
     /// To terminate this task and stop the lock auto-renewal, `lock::Client::unlock()` must be called.
     /// Simply dropping the `lock::Client` instance will not terminate the auto-renewal task.
-    /// This logic is intended for a scenario where the `lock::Client` is cloned and a lease is acquired with auto-renewal by the original instance.
+    /// This logic is intended for a scenario where the `lock::Client` is cloned and a lock is acquired with auto-renewal by the original instance.
     /// If the original instance is dropped, its clone remains in control of the lock (through the auto-renewal task that remains active).
     /// Special attention must be used to avoid a memory leak if `lock::Client::unlock()` is never called in this scenario.
     ///
@@ -89,7 +89,7 @@ where
     ///
     /// [`struct@Error`] of kind [`AIOProtocolError`](ErrorKind::AIOProtocolError) if there are any underlying errors from the command invoker
     pub async fn lock(
-        &mut self,
+        &self,
         lock_expiration: Duration,
         request_timeout: Duration,
         renewal_period: Option<Duration>,

--- a/rust/azure_iot_operations_services/src/lib.rs
+++ b/rust/azure_iot_operations_services/src/lib.rs
@@ -11,7 +11,7 @@
 //! - `all`: Enables all features.
 //! - `schema_registry`: Enabled the Schema Registry Client.
 //! - `state_store`: Enabled the State Store Client.
-//! - `leased_lock`: Enables the Leased Lock Client.
+//! - `leased_lock`: Enables the Key Lease Client.
 //!
 //! This example shows how you could import features for only the Schema Registry Client:
 //!

--- a/rust/azure_iot_operations_services/src/lib.rs
+++ b/rust/azure_iot_operations_services/src/lib.rs
@@ -9,9 +9,9 @@
 //! using the following feature flags:
 //!
 //! - `all`: Enables all features.
-//! - `schema_registry`: Enabled the Schema Registry Client.
-//! - `state_store`: Enabled the State Store Client.
-//! - `leased_lock`: Enables the Key Lease Client.
+//! - `schema_registry`: Enables the Schema Registry Client.
+//! - `state_store`: Enables the State Store Client.
+//! - `leased_lock`: Enables the Lease and Lock Clients.
 //!
 //! This example shows how you could import features for only the Schema Registry Client:
 //!

--- a/rust/azure_iot_operations_services/src/state_store.rs
+++ b/rust/azure_iot_operations_services/src/state_store.rs
@@ -52,9 +52,6 @@ pub enum ErrorKind {
     /// An error occurred from the State Store Service. See [`ServiceError`] for more information.
     #[error(transparent)]
     ServiceError(#[from] ServiceError),
-    /// The key length must not be zero.
-    #[error("key length must not be zero")]
-    KeyLengthZero,
     /// An error occurred during serialization of a request.
     #[error("{0}")]
     SerializationError(String),
@@ -134,7 +131,6 @@ impl From<Vec<u8>> for ServiceError {
             b"wrong number of arguments" => ServiceError::WrongNumberOfArguments,
             b"missing timestamp" => ServiceError::TimestampMissing,
             b"malformed timestamp" => ServiceError::TimestampMalformed,
-            b"the key length is zero" => ServiceError::KeyLengthZero,
             other => ServiceError::Unknown(std::str::from_utf8(other).unwrap_or_default().to_string()),
         }
     }

--- a/rust/azure_iot_operations_services/src/state_store/client.rs
+++ b/rust/azure_iot_operations_services/src/state_store/client.rs
@@ -192,7 +192,7 @@ where
     ///
     /// Returns `true` if the `Set` completed successfully, or `false` if the `Set` did not occur because of values specified in `SetOptions`
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `key` is empty
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
     ///
@@ -210,7 +210,7 @@ where
         options: SetOptions,
     ) -> Result<state_store::Response<bool>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
         let mut request_builder = rpc_command::invoker::RequestBuilder::default();
         request_builder
@@ -251,7 +251,7 @@ where
     ///
     /// Returns `Some(<value of the key>)` if the key is found or `None` if the key was not found
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `key` is empty
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
     ///
@@ -266,7 +266,7 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<Option<Vec<u8>>>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
         let request = rpc_command::invoker::RequestBuilder::default()
             .payload(state_store::resp3::Request::Get { key })
@@ -295,7 +295,7 @@ where
     ///
     /// Returns the number of keys deleted. Will be `0` if the key was not found, otherwise `1`
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `key` is empty
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
     ///
@@ -311,7 +311,7 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<i64>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
         self.del_internal(
             state_store::resp3::Request::Del { key },
@@ -329,7 +329,7 @@ where
     ///
     /// Returns the number of keys deleted. Will be `0` if the key was not found, `-1` if the value did not match, otherwise `1`
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if the `key` is empty
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
     ///
@@ -346,7 +346,7 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<i64>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
         self.del_internal(
             state_store::resp3::Request::VDel { key, value },
@@ -438,7 +438,7 @@ where
     /// </div>
     ///
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
     /// - the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
@@ -459,7 +459,7 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<KeyObservation>, Error> {
         if key.is_empty() {
-            return Err(std::convert::Into::into(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
 
         // add to observed keys before sending command to prevent missing any notifications.
@@ -498,7 +498,7 @@ where
     ///
     /// Returns `true` if the key is no longer being observed or `false` if the key wasn't being observed
     /// # Errors
-    /// [`struct@Error`] of kind [`KeyLengthZero`](ErrorKind::KeyLengthZero) if
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
     /// - the `key` is empty
     ///
     /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
@@ -516,7 +516,7 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<bool>, Error> {
         if key.is_empty() {
-            return Err(std::convert::Into::into(ErrorKind::KeyLengthZero));
+            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
         }
         // Send invoke request for unobserve
         let request = rpc_command::invoker::RequestBuilder::default()
@@ -709,7 +709,7 @@ mod tests {
             .await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 
@@ -728,7 +728,7 @@ mod tests {
         let response = state_store_client.get(vec![], Duration::from_secs(1)).await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 
@@ -749,7 +749,7 @@ mod tests {
             .await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 
@@ -770,7 +770,7 @@ mod tests {
             .await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 
@@ -791,7 +791,7 @@ mod tests {
             .await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 
@@ -812,7 +812,7 @@ mod tests {
             .await;
         assert!(matches!(
             response.unwrap_err(),
-            Error(ErrorKind::KeyLengthZero)
+            Error(ErrorKind::InvalidArgument(_))
         ));
     }
 

--- a/rust/azure_iot_operations_services/src/state_store/client.rs
+++ b/rust/azure_iot_operations_services/src/state_store/client.rs
@@ -210,7 +210,9 @@ where
         options: SetOptions,
     ) -> Result<state_store::Response<bool>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
         let mut request_builder = rpc_command::invoker::RequestBuilder::default();
         request_builder
@@ -266,7 +268,9 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<Option<Vec<u8>>>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
         let request = rpc_command::invoker::RequestBuilder::default()
             .payload(state_store::resp3::Request::Get { key })
@@ -311,7 +315,9 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<i64>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
         self.del_internal(
             state_store::resp3::Request::Del { key },
@@ -346,7 +352,9 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<i64>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
         self.del_internal(
             state_store::resp3::Request::VDel { key, value },
@@ -459,7 +467,9 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<KeyObservation>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
 
         // add to observed keys before sending command to prevent missing any notifications.
@@ -516,7 +526,9 @@ where
         timeout: Duration,
     ) -> Result<state_store::Response<bool>, Error> {
         if key.is_empty() {
-            return Err(Error(ErrorKind::InvalidArgument("key is empty".to_string())));
+            return Err(Error(ErrorKind::InvalidArgument(
+                "key is empty".to_string(),
+            )));
         }
         // Send invoke request for unobserve
         let request = rpc_command::invoker::RequestBuilder::default()

--- a/rust/azure_iot_operations_services/src/state_store/client.rs
+++ b/rust/azure_iot_operations_services/src/state_store/client.rs
@@ -192,9 +192,9 @@ where
     ///
     /// Returns `true` if the `Set` completed successfully, or `false` if the `Set` did not occur because of values specified in `SetOptions`
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
+    /// - the `key` is empty
+    /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
     ///
@@ -253,9 +253,9 @@ where
     ///
     /// Returns `Some(<value of the key>)` if the key is found or `None` if the key was not found
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
+    /// - the `key` is empty
+    /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
     ///
@@ -299,9 +299,9 @@ where
     ///
     /// Returns the number of keys deleted. Will be `0` if the key was not found, otherwise `1`
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
+    /// - the `key` is empty
+    /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
     ///
@@ -335,9 +335,9 @@ where
     ///
     /// Returns the number of keys deleted. Will be `0` if the key was not found, `-1` if the value did not match, otherwise `1`
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if the `timeout` is zero or > `u32::max`
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
+    /// - the `key` is empty
+    /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if the State Store returns an Error response
     ///
@@ -446,10 +446,8 @@ where
     /// </div>
     ///
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
     /// - the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
     /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`DuplicateObserve`](ErrorKind::DuplicateObserve) if
@@ -508,10 +506,8 @@ where
     ///
     /// Returns `true` if the key is no longer being observed or `false` if the key wasn't being observed
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
+    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if:
     /// - the `key` is empty
-    ///
-    /// [`struct@Error`] of kind [`InvalidArgument`](ErrorKind::InvalidArgument) if
     /// - the `timeout` is zero or > `u32::max`
     ///
     /// [`struct@Error`] of kind [`ServiceError`](ErrorKind::ServiceError) if

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -231,7 +231,7 @@ async fn lease_two_holders_attempt_to_acquire_with_release_network_tests() {
                     .acquire(lock_expiry, request_timeout, None)
                     .await
                     .is_err()
-            ); // Error(KeyAlreadyLeased)
+            ); // Error(LeaseAlreadyHeld)
 
             task2_notify.notify_one(); // Tell task1 we checked holder name, tried to acquire.
             task2_notify.notified().await; // Wait task1 release.
@@ -557,7 +557,7 @@ async fn lease_shutdown_state_store_while_observing_lease_network_tests() {
             let mut observe_response = lease_client1.observe(request_timeout).await.unwrap();
 
             let receive_notifications_task =
-                tokio::task::spawn({ async move { observe_response.recv_notification().await } });
+                tokio::task::spawn(async move { observe_response.recv_notification().await });
 
             assert!(state_store_client1.shutdown().await.is_ok());
 

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -14,32 +14,26 @@ use azure_iot_operations_mqtt::session::{
     Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
 };
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
-use azure_iot_operations_services::leased_lock::{
-    self, AcquireAndUpdateKeyOption, SetCondition, SetOptions,
-};
+use azure_iot_operations_services::leased_lock::{self};
 use azure_iot_operations_services::state_store::{self};
 
 // API:
-// try_acquire_lock
-// acquire_lock
-// release_lock
-// observe_lock/unobserve_lock
-// acquire_lock_and_update_value
-// acquire_lock_and_delete_value
-// get_lock_holder
+// try_acquire
+// acquire
+// release
+// observe/unobserve
+// get_holder
 
 // Test Scenarios:
-// basic try lock
-// single holder acquires a lock
-// two holders attempt to acquire a lock simultaneously, with release
-// two holders attempt to acquire a lock, first renews lease
-// second holder acquires non-released expired lock.
-// second holder observes until lock released
-// second holder observes until lock expires
-// single holder do acquire_lock_and_update_value to set and delete a key
-// two holders do acquire_lock_and_update_value to set and delete a key
-// single holder attempts to release a lock twice
-// attempt to observe lock that does not exist
+// basic try acquire
+// single holder acquires a lease
+// two holders attempt to acquire a lease simultaneously, with release
+// two holders attempt to acquire a lease, first renews lease
+// second holder acquires non-released expired lease.
+// second holder observes until lease released
+// second holder observes until lease expires
+// single holder attempts to release a lease twice
+// attempt to observe lease that does not exist
 
 fn setup_test(test_name: &str) -> bool {
     let _ = Builder::new()
@@ -59,11 +53,11 @@ fn setup_test(test_name: &str) -> bool {
 
 fn initialize_client(
     client_id: &str,
-    lock_name: &str,
+    key_name: &str,
 ) -> (
     Session,
     Arc<state_store::Client<SessionManagedClient>>,
-    leased_lock::Client<SessionManagedClient>,
+    leased_lock::lease::Client<SessionManagedClient>,
     SessionExitHandle,
 ) {
     let connection_settings = MqttConnectionSettingsBuilder::default()
@@ -97,24 +91,24 @@ fn initialize_client(
 
     let exit_handle: SessionExitHandle = session.create_exit_handle();
 
-    let leased_lock_client = leased_lock::Client::new(
+    let lease_client = leased_lock::lease::Client::new(
         state_store_client.clone(),
-        lock_name.into(),
+        key_name.into(),
         client_id.into(),
     )
     .unwrap();
 
-    (session, state_store_client, leased_lock_client, exit_handle)
+    (session, state_store_client, lease_client, exit_handle)
 }
 
 #[tokio::test]
-async fn leased_lock_basic_try_acquire_network_tests() {
-    let test_id = "leased_lock_basic_try_acquire_network_tests";
+async fn lease_basic_try_acquire_network_tests() {
+    let test_id = "lease_basic_try_acquire_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let (session, state_store_client, leased_lock_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(test_id, &format!("{test_id}-lock"));
 
     let test_task = tokio::task::spawn({
@@ -122,8 +116,8 @@ async fn leased_lock_basic_try_acquire_network_tests() {
             let lock_expiry = Duration::from_secs(3);
             let request_timeout = Duration::from_secs(5);
 
-            let _ = leased_lock_client
-                .try_acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client
+                .try_acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -146,34 +140,31 @@ async fn leased_lock_basic_try_acquire_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_single_holder_acquires_a_lock_network_tests() {
-    let test_id = "leased_lock_single_holder_acquires_a_lock_network_tests";
+async fn lease_single_holder_acquires_a_lock_network_tests() {
+    let test_id = "lease_single_holder_acquires_a_lock_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
     let holder_name1 = format!("{test_id}1");
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
 
-    let (session, state_store_client, leased_lock_client, exit_handle) =
-        initialize_client(&holder_name1, &lock_name1);
+    let (session, state_store_client, lease_client, exit_handle) =
+        initialize_client(&holder_name1, &key_name1);
 
     let test_task = tokio::task::spawn({
         async move {
             let lock_expiry = Duration::from_secs(3);
             let request_timeout = Duration::from_secs(5);
 
-            let _ = leased_lock_client
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
-            let get_lock_holder_response = leased_lock_client
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response = lease_client.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response.response.unwrap(),
+                get_holder_response.response.unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
 
@@ -196,23 +187,21 @@ async fn leased_lock_single_holder_acquires_a_lock_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_network_tests()
-{
-    let test_id =
-        "leased_lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_network_tests";
+async fn lease_two_holders_attempt_to_acquire_simultaneously_with_release_network_tests() {
+    let test_id = "lease_two_holders_attempt_to_acquire_simultaneously_with_release_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
 
     let task1_notify = Arc::new(Notify::new());
     let task2_notify = task1_notify.clone();
@@ -223,25 +212,22 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_simultaneously_with_rel
             let lock_expiry = Duration::from_secs(5);
             let request_timeout = Duration::from_secs(50);
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
             task1_notify.notify_one(); // Let task2 get holder name.
             task1_notify.notified().await; // Wait task2 get holder name.
 
-            let release_result = leased_lock_client1.release_lock(request_timeout).await;
+            let release_result = lease_client1.release(request_timeout).await;
             assert!(release_result.is_ok());
 
             sleep(Duration::from_secs(1)).await; // Wait task2 acquire.
 
-            let get_lock_holder_response = leased_lock_client1
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response = lease_client1.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response.response.unwrap(),
+                get_holder_response.response.unwrap(),
                 test_task1_holder_name2.into_bytes()
             );
 
@@ -260,17 +246,14 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_simultaneously_with_rel
 
             task2_notify.notified().await; // Wait task1 acquire.
 
-            let get_lock_holder_response = leased_lock_client2
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response.response.unwrap(),
+                get_holder_response.response.unwrap(),
                 test_task1_holder_name1.into_bytes()
             );
 
-            let _ = leased_lock_client2
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client2
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -297,21 +280,21 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_simultaneously_with_rel
 }
 
 #[tokio::test]
-async fn leased_lock_two_holders_attempt_to_acquire_lock_first_renews_network_tests() {
-    let test_id = "leased_lock_two_holders_attempt_to_acquire_lock_first_renews_network_tests";
+async fn lease_two_holders_attempt_to_acquire_first_renews_network_tests() {
+    let test_id = "lease_two_holders_attempt_to_acquire_first_renews_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
 
     let task1_notify = Arc::new(Notify::new());
     let task2_notify = task1_notify.clone();
@@ -322,32 +305,29 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_first_renews_network_te
             let lock_expiry = Duration::from_secs(5);
             let request_timeout = Duration::from_secs(50);
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
             sleep(Duration::from_secs(2)).await;
             task1_notify.notify_one(); // [A] Tell task2 lock was acquired by task1.
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
             task1_notify.notified().await; // [B] Wait task2 get holder name.
 
-            let release_result = leased_lock_client1.release_lock(request_timeout).await;
+            let release_result = lease_client1.release(request_timeout).await;
             assert!(release_result.is_ok());
 
             task1_notify.notified().await; // [C] Wait task2 acquire.
 
-            let get_lock_holder_response = leased_lock_client1
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response = lease_client1.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response.response.unwrap(),
+                get_holder_response.response.unwrap(),
                 test_task1_holder_name2.into_bytes()
             );
 
@@ -366,30 +346,24 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_first_renews_network_te
 
             task2_notify.notified().await; // [A] Wait task1 acquire.
 
-            let get_lock_holder_response = leased_lock_client2
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response.response.unwrap(),
+                get_holder_response.response.unwrap(),
                 test_task1_holder_name1.clone().into_bytes()
             );
 
             sleep(Duration::from_secs(2)).await;
 
-            let get_lock_holder_response2 = leased_lock_client2
-                .get_lock_holder(request_timeout)
-                .await
-                .unwrap();
+            let get_holder_response2 = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_lock_holder_response2.response.unwrap(),
+                get_holder_response2.response.unwrap(),
                 test_task1_holder_name1.into_bytes()
             );
 
             task2_notify.notify_one(); // [B] Tell task1 to releasee lock.
 
-            let _ = leased_lock_client2
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client2
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -416,29 +390,29 @@ async fn leased_lock_two_holders_attempt_to_acquire_lock_first_renews_network_te
 }
 
 #[tokio::test]
-async fn leased_lock_second_holder_acquires_non_released_expired_lock_network_tests() {
-    let test_id = "leased_lock_second_holder_acquires_non_released_expired_lock_network_tests";
+async fn lease_second_holder_acquires_non_released_expired_lock_network_tests() {
+    let test_id = "lease_second_holder_acquires_non_released_expired_lock_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
 
     let test_task1 = tokio::task::spawn({
         async move {
             let lock_expiry = Duration::from_secs(3);
             let request_timeout = Duration::from_secs(50);
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -458,8 +432,8 @@ async fn leased_lock_second_holder_acquires_non_released_expired_lock_network_te
 
             sleep(Duration::from_secs(5)).await;
 
-            let _ = leased_lock_client2
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client2
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -484,21 +458,21 @@ async fn leased_lock_second_holder_acquires_non_released_expired_lock_network_te
 }
 
 #[tokio::test]
-async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests() {
-    let test_id = "leased_lock_second_holder_observes_until_lock_is_released_network_tests";
+async fn lease_second_holder_observes_until_lock_is_released_network_tests() {
+    let test_id = "lease_second_holder_observes_until_lock_is_released_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
 
     let task1_notify = Arc::new(Notify::new());
     let task2_notify = task1_notify.clone();
@@ -508,8 +482,8 @@ async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests
             let lock_expiry = Duration::from_secs(4);
             let request_timeout = Duration::from_secs(50);
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -517,7 +491,7 @@ async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests
 
             sleep(Duration::from_secs(2)).await; // [B] Wait task2 observe lock.
 
-            let release_result = leased_lock_client1.release_lock(request_timeout).await;
+            let release_result = lease_client1.release(request_timeout).await;
             assert!(release_result.is_ok());
 
             // Shutdown state store client and underlying resources
@@ -527,17 +501,14 @@ async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests
         }
     });
 
-    let test_task2_lock_name1 = lock_name1.clone();
+    let test_task2_key_name1 = key_name1.clone();
     let test_task2 = tokio::task::spawn({
         async move {
             let request_timeout = Duration::from_secs(50);
 
             task2_notify.notified().await; // [A] Wait task1 acquire.
 
-            let mut observe_response = leased_lock_client2
-                .observe_lock(request_timeout)
-                .await
-                .unwrap();
+            let mut observe_response = lease_client2.observe(request_timeout).await.unwrap();
 
             let receive_notifications_task = tokio::task::spawn({
                 async move {
@@ -547,7 +518,7 @@ async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests
                         panic!("Received unexpected None for notification");
                     };
 
-                    assert_eq!(notification.key, test_task2_lock_name1.clone().into_bytes());
+                    assert_eq!(notification.key, test_task2_key_name1.clone().into_bytes());
                     assert_eq!(notification.operation, state_store::Operation::Del);
                 }
             });
@@ -580,26 +551,23 @@ async fn leased_lock_second_holder_observes_until_lock_is_released_network_tests
 }
 
 #[tokio::test]
-async fn leased_lock_shutdown_state_store_while_observing_lock_network_tests() {
-    let test_id = "leased_lock_shutdown_state_store_while_observing_lock_network_tests";
+async fn lease_shutdown_state_store_while_observing_lock_network_tests() {
+    let test_id = "lease_shutdown_state_store_while_observing_lock_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
     let test_task1 = tokio::task::spawn({
         async move {
             let request_timeout = Duration::from_secs(50);
 
-            let mut observe_response = leased_lock_client1
-                .observe_lock(request_timeout)
-                .await
-                .unwrap();
+            let mut observe_response = lease_client1.observe(request_timeout).await.unwrap();
 
             let receive_notifications_task = tokio::task::spawn({
                 async move { observe_response.response.recv_notification().await }
@@ -627,29 +595,29 @@ async fn leased_lock_shutdown_state_store_while_observing_lock_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_second_holder_observes_until_lock_expires_network_tests() {
-    let test_id = "leased_lock_second_holder_observes_until_lock_expires_network_tests";
+async fn lease_second_holder_observes_until_lock_expires_network_tests() {
+    let test_id = "lease_second_holder_observes_until_lock_expires_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
+    let key_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
 
     let test_task1 = tokio::task::spawn({
         async move {
             let lock_expiry = Duration::from_secs(4);
             let request_timeout = Duration::from_secs(50);
 
-            let _ = leased_lock_client1
-                .acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client1
+                .acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
@@ -660,17 +628,14 @@ async fn leased_lock_second_holder_observes_until_lock_expires_network_tests() {
         }
     });
 
-    let test_task2_lock_name1 = lock_name1.clone();
+    let test_task2_key_name1 = key_name1.clone();
     let test_task2 = tokio::task::spawn({
         async move {
             let request_timeout = Duration::from_secs(50);
 
             sleep(Duration::from_secs(1)).await;
 
-            let mut observe_response = leased_lock_client2
-                .observe_lock(request_timeout)
-                .await
-                .unwrap();
+            let mut observe_response = lease_client2.observe(request_timeout).await.unwrap();
 
             let receive_notifications_task = tokio::task::spawn({
                 async move {
@@ -680,7 +645,7 @@ async fn leased_lock_second_holder_observes_until_lock_expires_network_tests() {
                         panic!("Received unexpected None for notification.");
                     };
 
-                    assert_eq!(notification.key, test_task2_lock_name1.clone().into_bytes());
+                    assert_eq!(notification.key, test_task2_key_name1.clone().into_bytes());
                     assert_eq!(notification.operation, state_store::Operation::Del);
                 }
             });
@@ -712,273 +677,13 @@ async fn leased_lock_second_holder_observes_until_lock_expires_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_single_holder_do_acquire_lock_and_update_value_to_set_and_delete_key_network_tests()
- {
-    let test_id = "leased_lock_single_holder_do_acquire_lock_and_update_value_to_set_and_delete_key_network_tests";
+async fn lease_attempt_to_release_twice_network_tests() {
+    let test_id = "lease_attempt_to_release_twice_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let lock_name1 = format!("{test_id}-lock");
-    let holder_name1 = format!("{test_id}1");
-    let shared_resource_key_name = format!("{test_id}-key");
-    let shared_resource_key_value = format!("{test_id}-value");
-
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
-
-    let test_task1 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(30);
-
-            assert!(
-                leased_lock_client1
-                    .acquire_lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        shared_resource_key_name.clone().into_bytes(),
-                        &|key_current_value: Option<Vec<u8>>| {
-                            assert!(key_current_value.is_none());
-                            AcquireAndUpdateKeyOption::Update(
-                                shared_resource_key_value.clone().into_bytes(),
-                                SetOptions {
-                                    set_condition: SetCondition::Unconditional,
-                                    expires: Some(Duration::from_secs(10)),
-                                },
-                            )
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                leased_lock_client1
-                    .get_lock_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert_eq!(
-                state_store_client1
-                    .get(
-                        shared_resource_key_name.clone().into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .unwrap(),
-                shared_resource_key_value.into_bytes()
-            );
-
-            assert!(
-                leased_lock_client1
-                    .acquire_lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        shared_resource_key_name.clone().into_bytes(),
-                        &|_key_current_value: Option<Vec<u8>>| {
-                            AcquireAndUpdateKeyOption::Delete
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                state_store_client1
-                    .get(shared_resource_key_name.into_bytes(), request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client1.shutdown().await.is_ok());
-
-            exit_handle1.try_exit().await.unwrap();
-        }
-    });
-
-    // if an assert fails in the test task, propagate the panic to end the test,
-    // while still running the test task and the session to completion on the happy path
-    assert!(
-        tokio::try_join!(
-            async move { test_task1.await.map_err(|e| { e.to_string() }) },
-            async move { session1.run().await.map_err(|e| { e.to_string() }) },
-        )
-        .is_ok()
-    );
-}
-
-#[tokio::test]
-async fn leased_lock_two_holders_do_acquire_lock_and_update_value_to_set_and_delete_key_network_tests()
- {
-    let test_id = "leased_lock_two_holders_do_acquire_lock_and_update_value_to_set_and_delete_key_network_tests";
-    if !setup_test(test_id) {
-        return;
-    }
-
-    let lock_name1 = format!("{test_id}-lock");
-    let holder_name1 = format!("{test_id}1");
-    let holder_name2 = format!("{test_id}2");
-    let shared_resource_key_name = format!("{test_id}-key");
-
-    let (session1, state_store_client1, leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &lock_name1.clone());
-
-    let (session2, state_store_client2, leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &lock_name1);
-
-    let task1_notify = Arc::new(Notify::new());
-    let task2_notify = task1_notify.clone();
-
-    let test_task1_holder_name1 = holder_name1.clone();
-    let test_task1_shared_resource_key_name = shared_resource_key_name.clone();
-    let test_task1 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(30);
-
-            assert!(
-                leased_lock_client1
-                    .acquire_lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        test_task1_shared_resource_key_name.clone().into_bytes(),
-                        &|key_current_value: Option<Vec<u8>>| {
-                            assert!(key_current_value.is_none());
-                            AcquireAndUpdateKeyOption::Update(
-                                test_task1_holder_name1.clone().into_bytes(),
-                                SetOptions {
-                                    set_condition: SetCondition::Unconditional,
-                                    expires: Some(Duration::from_secs(10)),
-                                },
-                            )
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                leased_lock_client1
-                    .get_lock_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert_eq!(
-                state_store_client1
-                    .get(
-                        test_task1_shared_resource_key_name.clone().into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .unwrap(),
-                test_task1_holder_name1.into_bytes()
-            );
-
-            task1_notify.notify_one();
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client1.shutdown().await.is_ok());
-
-            exit_handle1.try_exit().await.unwrap();
-        }
-    });
-
-    let test_task2_shared_resource_key_name = shared_resource_key_name.clone();
-    let test_task2 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(50);
-
-            task2_notify.notified().await;
-
-            assert!(
-                leased_lock_client2
-                    .get_lock_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert!(
-                leased_lock_client2
-                    .acquire_lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        test_task2_shared_resource_key_name.clone().into_bytes(),
-                        &|_key_current_value: Option<Vec<u8>>| AcquireAndUpdateKeyOption::Delete,
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                leased_lock_client2
-                    .get_lock_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert!(
-                state_store_client2
-                    .get(
-                        test_task2_shared_resource_key_name.into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client2.shutdown().await.is_ok());
-
-            exit_handle2.try_exit().await.unwrap();
-        }
-    });
-
-    // if an assert fails in the test task, propagate the panic to end the test,
-    // while still running the test task and the session to completion on the happy path
-    assert!(
-        tokio::try_join!(
-            async move { test_task1.await.map_err(|e| { e.to_string() }) },
-            async move { session1.run().await.map_err(|e| { e.to_string() }) },
-            async move { test_task2.await.map_err(|e| { e.to_string() }) },
-            async move { session2.run().await.map_err(|e| { e.to_string() }) }
-        )
-        .is_ok()
-    );
-}
-
-#[tokio::test]
-async fn leased_lock_attempt_to_release_lock_twice_network_tests() {
-    let test_id = "leased_lock_attempt_to_release_lock_twice_network_tests";
-    if !setup_test(test_id) {
-        return;
-    }
-
-    let (session, state_store_client, leased_lock_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&format!("{test_id}1"), &format!("{test_id}-lock"));
 
     let test_task = tokio::task::spawn({
@@ -986,15 +691,15 @@ async fn leased_lock_attempt_to_release_lock_twice_network_tests() {
             let lock_expiry = Duration::from_secs(3);
             let request_timeout = Duration::from_secs(5);
 
-            let _ = leased_lock_client
-                .try_acquire_lock(lock_expiry, request_timeout)
+            let _ = lease_client
+                .try_acquire(lock_expiry, request_timeout)
                 .await
                 .unwrap();
 
-            let release_result = leased_lock_client.release_lock(request_timeout).await;
+            let release_result = lease_client.release(request_timeout).await;
             assert!(release_result.is_ok());
 
-            let release_result2 = leased_lock_client.release_lock(request_timeout).await;
+            let release_result2 = lease_client.release(request_timeout).await;
             assert!(release_result2.is_ok());
 
             // Shutdown state store client and underlying resources
@@ -1016,23 +721,20 @@ async fn leased_lock_attempt_to_release_lock_twice_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_attempt_to_observe_lock_that_does_not_exist_network_tests() {
-    let test_id = "leased_lock_attempt_to_observe_lock_that_does_not_exist_network_tests";
+async fn lease_attempt_to_observe_that_does_not_exist_network_tests() {
+    let test_id = "lease_attempt_to_observe_that_does_not_exist_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let (session, state_store_client, leased_lock_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&format!("{test_id}1"), &format!("{test_id}-lock"));
 
     let test_task = tokio::task::spawn({
         async move {
             let request_timeout = Duration::from_secs(5);
 
-            let _observe_response = leased_lock_client
-                .observe_lock(request_timeout)
-                .await
-                .unwrap();
+            let _observe_response = lease_client.observe(request_timeout).await.unwrap();
             // Looks like this never fails. That is expected:
             // vaavva: "Since a key being deleted doesn't end your observation,
             // it makes sense that if you observe a key that doesn't exist,

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -831,8 +831,6 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
             let fencing_token2 = fencing_token2_option.unwrap();
             assert!(fencing_token1 != fencing_token2);
             assert!(fencing_token1.timestamp < fencing_token2.timestamp);
-            assert_eq!(fencing_token1.counter, fencing_token2.counter);
-            assert_eq!(fencing_token1.node_id, fencing_token2.node_id);
 
             // Verify holder.
             let get_holder_response = lease_client.get_holder(request_timeout).await.unwrap();

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -126,7 +126,7 @@ async fn lease_single_holder_acquires_a_lease_network_tests() {
                 .unwrap();
 
             // Let's verify if the fencing token was stored internally.
-            let saved_fencing_token = lease_client.get_current_lease_fencing_token();
+            let saved_fencing_token = lease_client.current_lease_fencing_token();
 
             assert!(saved_fencing_token.is_some());
             assert_eq!(fencing_token, saved_fencing_token.unwrap());
@@ -134,7 +134,7 @@ async fn lease_single_holder_acquires_a_lease_network_tests() {
             // Verify holder.
             let get_holder_response = lease_client.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
 
@@ -194,14 +194,14 @@ async fn lease_two_holders_attempt_to_acquire_with_release_network_tests() {
             assert!(release_result.is_ok());
 
             // Verify if the fencing token was cleared internally after release.
-            assert!(lease_client1.get_current_lease_fencing_token().is_none());
+            assert!(lease_client1.current_lease_fencing_token().is_none());
 
             task1_notify.notify_one(); // Let task2 acquire.
             task1_notify.notified().await; // Wait task2 acquire.
 
             let get_holder_response = lease_client1.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 test_task1_holder_name2.into_bytes()
             );
 
@@ -222,7 +222,7 @@ async fn lease_two_holders_attempt_to_acquire_with_release_network_tests() {
 
             let get_holder_response = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 test_task1_holder_name1.into_bytes()
             );
 
@@ -312,7 +312,7 @@ async fn lease_two_holders_attempt_to_acquire_first_renews_network_tests() {
 
             let get_holder_response = lease_client1.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 test_task1_holder_name2.into_bytes()
             );
 
@@ -335,7 +335,7 @@ async fn lease_two_holders_attempt_to_acquire_first_renews_network_tests() {
 
             let get_holder_response = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 test_task1_holder_name1.clone().into_bytes()
             );
 
@@ -343,7 +343,7 @@ async fn lease_two_holders_attempt_to_acquire_first_renews_network_tests() {
 
             let get_holder_response2 = lease_client2.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response2.response.unwrap(),
+                get_holder_response2.unwrap(),
                 test_task1_holder_name1.into_bytes()
             );
 
@@ -501,9 +501,7 @@ async fn lease_second_holder_observes_until_lease_is_released_network_tests() {
 
             let receive_notifications_task = tokio::task::spawn({
                 async move {
-                    let Some((notification, _)) =
-                        observe_response.response.recv_notification().await
-                    else {
+                    let Some((notification, _)) = observe_response.recv_notification().await else {
                         panic!("Received unexpected None for notification");
                     };
 
@@ -558,9 +556,8 @@ async fn lease_shutdown_state_store_while_observing_lease_network_tests() {
 
             let mut observe_response = lease_client1.observe(request_timeout).await.unwrap();
 
-            let receive_notifications_task = tokio::task::spawn({
-                async move { observe_response.response.recv_notification().await }
-            });
+            let receive_notifications_task =
+                tokio::task::spawn({ async move { observe_response.recv_notification().await } });
 
             assert!(state_store_client1.shutdown().await.is_ok());
 
@@ -628,9 +625,7 @@ async fn lease_second_holder_observes_until_lease_expires_network_tests() {
 
             let receive_notifications_task = tokio::task::spawn({
                 async move {
-                    let Some((notification, _)) =
-                        observe_response.response.recv_notification().await
-                    else {
+                    let Some((notification, _)) = observe_response.recv_notification().await else {
                         panic!("Received unexpected None for notification.");
                     };
 
@@ -689,13 +684,13 @@ async fn lease_attempt_to_release_twice_network_tests() {
             assert!(release_result.is_ok());
 
             // Verify if the fencing token was cleared internally after release.
-            assert!(lease_client.get_current_lease_fencing_token().is_none());
+            assert!(lease_client.current_lease_fencing_token().is_none());
 
             let release_result2 = lease_client.release(request_timeout).await;
             assert!(release_result2.is_ok());
 
             // Verify if the fencing token is still cleared.
-            assert!(lease_client.get_current_lease_fencing_token().is_none());
+            assert!(lease_client.current_lease_fencing_token().is_none());
 
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
@@ -781,7 +776,7 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
             sleep(Duration::from_secs(3)).await;
 
             // Expect to have a new token now (updated timestamp, but same counter and node id).
-            let fencing_token2_option = lease_client.get_current_lease_fencing_token();
+            let fencing_token2_option = lease_client.current_lease_fencing_token();
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
@@ -791,14 +786,14 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
             // Verify holder.
             let get_holder_response = lease_client.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
 
             // Wait for another renewal.
             sleep(Duration::from_secs(3)).await;
 
-            let fencing_token3_option = lease_client.get_current_lease_fencing_token();
+            let fencing_token3_option = lease_client.current_lease_fencing_token();
 
             assert!(fencing_token3_option.is_some());
             let fencing_token3 = fencing_token3_option.unwrap();
@@ -810,7 +805,7 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
             assert!(lease_client.release(request_timeout).await.is_ok());
 
             // Verify stored fencing token is cleared because of release.
-            assert!(lease_client.get_current_lease_fencing_token().is_none());
+            assert!(lease_client.current_lease_fencing_token().is_none());
 
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());
@@ -858,7 +853,7 @@ async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_test
             sleep(Duration::from_secs(3)).await;
 
             // Expect to have a new token now (updated timestamp, but same node id).
-            let fencing_token2_option = lease_client.get_current_lease_fencing_token();
+            let fencing_token2_option = lease_client.current_lease_fencing_token();
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
@@ -869,7 +864,7 @@ async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_test
             // Verify holder.
             let get_holder_response = lease_client.get_holder(request_timeout).await.unwrap();
             assert_eq!(
-                get_holder_response.response.unwrap(),
+                get_holder_response.unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
 
@@ -885,7 +880,7 @@ async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_test
             // Wait for the renewal period previously used, but expect no renewal.
             sleep(Duration::from_secs(3)).await;
 
-            let fencing_token4_option = lease_client.get_current_lease_fencing_token();
+            let fencing_token4_option = lease_client.current_lease_fencing_token();
 
             assert!(fencing_token4_option.is_some()); // On expiration, this is not updated. User app should know when renewal was used or not.
             assert_eq!(fencing_token3, fencing_token4_option.unwrap());
@@ -893,7 +888,7 @@ async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_test
             assert!(lease_client.release(request_timeout).await.is_ok());
 
             // Verify stored fencing token is cleared because of release.
-            assert!(lease_client.get_current_lease_fencing_token().is_none());
+            assert!(lease_client.current_lease_fencing_token().is_none());
 
             // Shutdown state store client and underlying resources
             assert!(state_store_client.shutdown().await.is_ok());

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -882,8 +882,8 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
 }
 
 #[tokio::test]
-async fn lease_single_holder_acquires_with_auto_renewal_and_without_network_tests() {
-    let test_id = "lease_single_holder_acquires_with_auto_renewal_and_without_network_tests";
+async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_tests() {
+    let test_id = "lease_single_holder_acquires_with_and_without_auto_renewal_network_tests";
     if !setup_test(test_id) {
         return;
     }
@@ -908,14 +908,13 @@ async fn lease_single_holder_acquires_with_auto_renewal_and_without_network_test
             // Wait for renewal at 2 seconds even if expiry time has passed.
             sleep(Duration::from_secs(3)).await;
 
-            // Expect to have a new token now (updated timestamp, but same counter and node id).
+            // Expect to have a new token now (updated timestamp, but same node id).
             let fencing_token2_option = lease_client.get_current_lease_fencing_token().await;
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
             assert!(fencing_token1 != fencing_token2);
             assert!(fencing_token1.timestamp < fencing_token2.timestamp);
-            assert_eq!(fencing_token1.counter, fencing_token2.counter);
             assert_eq!(fencing_token1.node_id, fencing_token2.node_id);
 
             // Verify holder.
@@ -932,7 +931,6 @@ async fn lease_single_holder_acquires_with_auto_renewal_and_without_network_test
 
             assert!(fencing_token2 != fencing_token3);
             assert!(fencing_token2.timestamp < fencing_token3.timestamp);
-            assert_eq!(fencing_token2.counter, fencing_token3.counter);
             assert_eq!(fencing_token2.node_id, fencing_token3.node_id);
 
             // Wait for the renewal period previously used, but expect no renewal.

--- a/rust/azure_iot_operations_services/tests/lease_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lease_client_tests.rs
@@ -112,7 +112,7 @@ async fn lease_single_holder_acquires_a_lease_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let key_name1 = format!("{test_id}-leased-key");
 
-    let (session, state_store_client, mut lease_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&holder_name1, &key_name1);
 
     let test_task = tokio::task::spawn({
@@ -167,10 +167,10 @@ async fn lease_two_holders_attempt_to_acquire_with_release_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, mut lease_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
         initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, mut lease_client2, exit_handle2) =
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
         initialize_client(&holder_name2, &key_name1);
 
     let task1_notify = Arc::new(Notify::new());
@@ -274,10 +274,10 @@ async fn lease_two_holders_attempt_to_acquire_first_renews_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, mut lease_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
         initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, mut lease_client2, exit_handle2) =
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
         initialize_client(&holder_name2, &key_name1);
 
     let task1_notify = Arc::new(Notify::new());
@@ -389,10 +389,10 @@ async fn lease_second_holder_acquires_non_released_expired_lease_network_tests()
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, mut lease_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
         initialize_client(&holder_name1, &key_name1.clone());
 
-    let (session2, state_store_client2, mut lease_client2, exit_handle2) =
+    let (session2, state_store_client2, lease_client2, exit_handle2) =
         initialize_client(&holder_name2, &key_name1);
 
     let test_task1 = tokio::task::spawn({
@@ -457,7 +457,7 @@ async fn lease_second_holder_observes_until_lease_is_released_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, mut lease_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
         initialize_client(&holder_name1, &key_name1.clone());
 
     let (session2, state_store_client2, lease_client2, exit_handle2) =
@@ -591,7 +591,7 @@ async fn lease_second_holder_observes_until_lease_expires_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, mut lease_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, exit_handle1) =
         initialize_client(&holder_name1, &key_name1.clone());
 
     let (session2, state_store_client2, lease_client2, exit_handle2) =
@@ -667,7 +667,7 @@ async fn lease_attempt_to_release_twice_network_tests() {
         return;
     }
 
-    let (session, state_store_client, mut lease_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&format!("{test_id}1"), &format!("{test_id}-leased-key"));
 
     let test_task = tokio::task::spawn({
@@ -758,7 +758,7 @@ async fn lease_single_holder_acquires_a_lease_with_auto_renewal_network_tests() 
     let holder_name1 = format!("{test_id}1");
     let key_name1 = format!("{test_id}-leased-key");
 
-    let (session, state_store_client, mut lease_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&holder_name1, &key_name1);
 
     let test_task = tokio::task::spawn({
@@ -835,7 +835,7 @@ async fn lease_single_holder_acquires_with_and_without_auto_renewal_network_test
     let holder_name1 = format!("{test_id}1");
     let key_name1 = format!("{test_id}-leased-key");
 
-    let (session, state_store_client, mut lease_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&holder_name1, &key_name1);
 
     let test_task = tokio::task::spawn({
@@ -918,7 +918,7 @@ async fn lease_acquire_with_auto_renewal_and_client_cloning_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let key_name1 = format!("{test_id}-leased-key");
 
-    let (session, state_store_client, mut lease_client, exit_handle) =
+    let (session, state_store_client, lease_client, exit_handle) =
         initialize_client(&holder_name1, &key_name1);
 
     let lease_client_clone = lease_client.clone();

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -25,6 +25,8 @@ use azure_iot_operations_services::state_store::{self};
 // Test Scenarios:
 // single holder do lock and release
 // single holder do lock and release with auto-renewal
+// two holders attempt to acquire lock simultaneously with release
+// two holders attempt to acquire lock simultaneously with expiration
 
 fn setup_test(test_name: &str) -> bool {
     let _ = Builder::new()
@@ -107,31 +109,31 @@ fn initialize_client(
 }
 
 #[tokio::test]
-async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
-    let test_id = "leased_lock_single_holder_do_lock_and_unlock_network_tests";
+async fn lock_single_holder_do_lock_and_unlock_network_tests() {
+    let test_id = "lock_single_holder_do_lock_and_unlock_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let key_name1 = format!("{test_id}-lock");
+    let lock_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
     let shared_resource_key_name = format!("{test_id}-key");
 
-    let (session1, state_store_client1, lease_client1, mut leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &key_name1.clone());
+    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({
         async move {
             let lock_expiry = Duration::from_secs(5);
             let request_timeout = Duration::from_secs(30);
 
-            let token = leased_lock_client1
+            let token = lock_client1
                 .lock(lock_expiry, request_timeout, None)
                 .await
                 .expect("Expected a fencing token");
 
             // Let's verify if the fencing token was stored internally.
-            let saved_fencing_token = leased_lock_client1.get_current_lock_fencing_token();
+            let saved_fencing_token = lock_client1.get_current_lock_fencing_token();
 
             assert!(saved_fencing_token.is_some());
             assert_eq!(token, saved_fencing_token.unwrap());
@@ -147,7 +149,7 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
                 holder_name1.into_bytes()
             );
 
-            assert!(leased_lock_client1.unlock(request_timeout).await.is_ok());
+            assert!(lock_client1.unlock(request_timeout).await.is_ok());
 
             assert!(
                 state_store_client1
@@ -159,11 +161,7 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
             );
 
             // Let's verify if the fencing token was cleared internally.
-            assert!(
-                leased_lock_client1
-                    .get_current_lock_fencing_token()
-                    .is_none()
-            );
+            assert!(lock_client1.get_current_lock_fencing_token().is_none());
 
             // Shutdown state store client and underlying resources
             assert!(state_store_client1.shutdown().await.is_ok());
@@ -184,17 +182,17 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
 }
 
 #[tokio::test]
-async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
-    let test_id = "leased_lock_single_holder_do_lock_with_auto_renewal_network_tests";
+async fn lock_single_holder_do_lock_with_auto_renewal_network_tests() {
+    let test_id = "lock_single_holder_do_lock_with_auto_renewal_network_tests";
     if !setup_test(test_id) {
         return;
     }
 
-    let key_name1 = format!("{test_id}-lock");
+    let lock_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
 
-    let (session1, state_store_client1, _lease_client1, mut leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &key_name1.clone());
+    let (session1, state_store_client1, _lease_client1, mut lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({
         async move {
@@ -202,7 +200,7 @@ async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
             let request_timeout = Duration::from_secs(10);
             let renewal_period = Duration::from_secs(2);
 
-            let fencing_token1 = leased_lock_client1
+            let fencing_token1 = lock_client1
                 .lock(lock_expiry, request_timeout, Some(renewal_period))
                 .await
                 .expect("Expected a fencing token");
@@ -211,7 +209,7 @@ async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
             sleep(Duration::from_secs(3)).await;
 
             // Expect to have a new token now (updated timestamp, but same counter and node id).
-            let fencing_token2_option = leased_lock_client1.get_current_lock_fencing_token();
+            let fencing_token2_option = lock_client1.get_current_lock_fencing_token();
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
@@ -231,6 +229,248 @@ async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
         tokio::try_join!(
             async move { test_task1.await.map_err(|e| { e.to_string() }) },
             async move { session1.run().await.map_err(|e| { e.to_string() }) },
+        )
+        .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_network_tests() {
+    let test_id =
+        "lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_network_tests";
+    if !setup_test(test_id) {
+        return;
+    }
+
+    let lock_name1 = format!("{test_id}-lock");
+    let holder_name1 = format!("{test_id}1");
+    let holder_name2 = format!("{test_id}2");
+
+    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &lock_name1.clone());
+
+    let (session2, state_store_client2, lease_client2, mut lock_client2, exit_handle2) =
+        initialize_client(&holder_name2, &lock_name1.clone());
+
+    let test_task1 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(3);
+            let request_timeout = Duration::from_secs(10);
+            let renewal_period = Duration::from_secs(2);
+
+            assert!(
+                lock_client1
+                    .lock(lock_expiry, request_timeout, Some(renewal_period))
+                    .await
+                    .is_ok()
+            );
+
+            assert_eq!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name1.as_bytes().to_vec()
+            );
+
+            // Wait for renewal at 2 seconds even if expiry time has passed.
+            sleep(Duration::from_secs(3)).await;
+
+            assert_eq!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name1.as_bytes().to_vec()
+            );
+
+            assert!(lock_client1.unlock(request_timeout).await.is_ok());
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client1.shutdown().await.is_ok());
+
+            exit_handle1.try_exit().await.unwrap();
+        }
+    });
+
+    let test_task2 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(3);
+            let request_timeout = Duration::from_secs(10);
+            let renewal_period = Duration::from_secs(2);
+
+            assert!(
+                lock_client2
+                    .lock(lock_expiry, request_timeout, Some(renewal_period))
+                    .await
+                    .is_ok()
+            );
+
+            assert_eq!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name2.as_bytes().to_vec()
+            );
+
+            // Wait for renewal at 2 seconds even if expiry time has passed.
+            sleep(Duration::from_secs(3)).await;
+
+            assert_eq!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name2.as_bytes().to_vec()
+            );
+
+            assert!(lock_client2.unlock(request_timeout).await.is_ok());
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client2.shutdown().await.is_ok());
+
+            exit_handle2.try_exit().await.unwrap();
+        }
+    });
+
+    // if an assert fails in the test task, propagate the panic to end the test,
+    // while still running the test task and the session to completion on the happy path
+    assert!(
+        tokio::try_join!(
+            async move { test_task1.await.map_err(|e| { e.to_string() }) },
+            async move { test_task2.await.map_err(|e| { e.to_string() }) },
+            async move { session1.run().await.map_err(|e| { e.to_string() }) },
+            async move { session2.run().await.map_err(|e| { e.to_string() }) },
+        )
+        .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration_network_tests() {
+    let test_id =
+        "lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration_network_tests";
+    if !setup_test(test_id) {
+        return;
+    }
+
+    let lock_name1 = format!("{test_id}-lock");
+    let holder_name1 = format!("{test_id}1");
+    let holder_name2 = format!("{test_id}2");
+
+    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &lock_name1.clone());
+
+    let (session2, state_store_client2, lease_client2, mut lock_client2, exit_handle2) =
+        initialize_client(&holder_name2, &lock_name1.clone());
+
+    let test_task1 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(3);
+            let request_timeout = Duration::from_secs(10);
+            let renewal_period = Duration::from_secs(2);
+
+            assert!(
+                lock_client1
+                    .lock(lock_expiry, request_timeout, Some(renewal_period))
+                    .await
+                    .is_ok()
+            );
+
+            assert_eq!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name1.as_bytes().to_vec()
+            );
+
+            // Wait for renewal at 2 seconds even if expiry time has passed.
+            sleep(Duration::from_secs(3)).await;
+
+            assert_eq!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name1.as_bytes().to_vec()
+            );
+
+            // Look Ma! No unlock!
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client1.shutdown().await.is_ok());
+
+            exit_handle1.try_exit().await.unwrap();
+        }
+    });
+
+    let test_task2 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(3);
+            let request_timeout = Duration::from_secs(10);
+            let renewal_period = Duration::from_secs(2);
+
+            assert!(
+                lock_client2
+                    .lock(lock_expiry, request_timeout, Some(renewal_period))
+                    .await
+                    .is_ok()
+            );
+
+            assert_eq!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name2.as_bytes().to_vec()
+            );
+
+            // Wait for renewal at 2 seconds even if expiry time has passed.
+            sleep(Duration::from_secs(3)).await;
+
+            assert_eq!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name2.as_bytes().to_vec()
+            );
+
+            // Look Ma! No unlock!
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client2.shutdown().await.is_ok());
+
+            exit_handle2.try_exit().await.unwrap();
+        }
+    });
+
+    // if an assert fails in the test task, propagate the panic to end the test,
+    // while still running the test task and the session to completion on the happy path
+    assert!(
+        tokio::try_join!(
+            async move { test_task1.await.map_err(|e| { e.to_string() }) },
+            async move { test_task2.await.map_err(|e| { e.to_string() }) },
+            async move { session1.run().await.map_err(|e| { e.to_string() }) },
+            async move { session2.run().await.map_err(|e| { e.to_string() }) },
         )
         .is_ok()
     );

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(feature = "leased_lock")]
+
+use std::assert_eq;
+use std::time::SystemTime;
+use std::{env, sync::Arc, time::Duration};
+
+use env_logger::Builder;
+
+use tokio::sync::Notify;
+
+use azure_iot_operations_mqtt::MqttConnectionSettingsBuilder;
+use azure_iot_operations_mqtt::session::{
+    Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
+};
+use azure_iot_operations_protocol::application::ApplicationContextBuilder;
+use azure_iot_operations_services::leased_lock::{
+    self, AcquireAndUpdateKeyOption, SetCondition, SetOptions,
+};
+use azure_iot_operations_services::state_store::{self};
+
+// API:
+// lock
+// unlock
+// lock_and_update_value
+// acquire_and_delete_value
+
+// Test Scenarios:
+// basic try lock
+// single holder acquires a lock
+// two holders attempt to acquire a lock simultaneously, with release
+// two holders attempt to acquire a lock, first renews lease
+// second holder acquires non-released expired lock.
+// second holder observes until lock released
+// second holder observes until lock expires
+// single holder do lock_and_update_value to set and delete a key
+// two holders do lock_and_update_value to set and delete a key
+// single holder attempts to release a lock twice
+// attempt to observe lock that does not exist
+
+fn setup_test(test_name: &str) -> bool {
+    let _ = Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .format_timestamp(None)
+        .filter_module("rumqttc", log::LevelFilter::Warn)
+        .filter_module("azure_iot_operations", log::LevelFilter::Warn)
+        .try_init();
+
+    if env::var("ENABLE_NETWORK_TESTS").is_err() {
+        log::warn!("Test {test_name} is skipped. Set ENABLE_NETWORK_TESTS to run.");
+        return false;
+    }
+
+    true
+}
+
+fn initialize_client(
+    client_id: &str,
+    key_name: &str,
+) -> (
+    Session,
+    Arc<state_store::Client<SessionManagedClient>>,
+    leased_lock::lease::Client<SessionManagedClient>,
+    leased_lock::Client<SessionManagedClient>,
+    SessionExitHandle,
+) {
+    let connection_settings = MqttConnectionSettingsBuilder::default()
+        .client_id(client_id)
+        .hostname("localhost")
+        .tcp_port(1883u16)
+        .keep_alive(Duration::from_secs(5))
+        .use_tls(false)
+        .build()
+        .unwrap();
+
+    let session_options = SessionOptionsBuilder::default()
+        .connection_settings(connection_settings)
+        .build()
+        .unwrap();
+
+    let session = Session::new(session_options).unwrap();
+    let application_context = ApplicationContextBuilder::default().build().unwrap();
+
+    let state_store_client = state_store::Client::new(
+        application_context,
+        session.create_managed_client(),
+        session.create_connection_monitor(),
+        state_store::ClientOptionsBuilder::default()
+            .build()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let state_store_client = Arc::new(state_store_client);
+
+    let exit_handle: SessionExitHandle = session.create_exit_handle();
+
+    let lease_client = leased_lock::lease::Client::new(
+        state_store_client.clone(),
+        key_name.into(),
+        client_id.into(),
+    )
+    .unwrap();
+
+    let leased_lock_client = leased_lock::Client::new(
+        state_store_client.clone(),
+        key_name.into(),
+        client_id.into(),
+    )
+    .unwrap();
+
+    (
+        session,
+        state_store_client,
+        lease_client,
+        leased_lock_client,
+        exit_handle,
+    )
+}
+
+#[tokio::test]
+async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
+    let test_id = "leased_lock_single_holder_do_lock_and_unlock_network_tests";
+    if !setup_test(test_id) {
+        return;
+    }
+
+    let key_name1 = format!("{test_id}-lock");
+    let holder_name1 = format!("{test_id}1");
+    let shared_resource_key_name = format!("{test_id}-key");
+
+    let (session1, state_store_client1, lease_client1, leased_lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
+
+    let test_task1 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(5);
+            let request_timeout = Duration::from_secs(30);
+
+            let token = leased_lock_client1
+                .lock(lock_expiry, request_timeout)
+                .await
+                .expect("Expected a fencing token");
+
+            // Arbitrarily validate that the fencing token obtained from the lock operation is not older than 2 seconds.
+            assert!(
+                token
+                    .timestamp
+                    .duration_since(SystemTime::now())
+                    .expect("{difference:?}")
+                    .as_secs()
+                    < 2
+            );
+
+            assert_eq!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                holder_name1.into_bytes()
+            );
+
+            assert!(leased_lock_client1.unlock(request_timeout).await.is_ok());
+
+            assert!(
+                state_store_client1
+                    .get(shared_resource_key_name.into_bytes(), request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client1.shutdown().await.is_ok());
+
+            exit_handle1.try_exit().await.unwrap();
+        }
+    });
+
+    // if an assert fails in the test task, propagate the panic to end the test,
+    // while still running the test task and the session to completion on the happy path
+    assert!(
+        tokio::try_join!(
+            async move { test_task1.await.map_err(|e| { e.to_string() }) },
+            async move { session1.run().await.map_err(|e| { e.to_string() }) },
+        )
+        .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn leased_lock_single_holder_do_lock_and_update_value_to_set_and_delete_key_network_tests() {
+    let test_id =
+        "leased_lock_single_holder_do_lock_and_update_value_to_set_and_delete_key_network_tests";
+    if !setup_test(test_id) {
+        return;
+    }
+
+    let key_name1 = format!("{test_id}-lock");
+    let holder_name1 = format!("{test_id}1");
+    let shared_resource_key_name = format!("{test_id}-key");
+    let shared_resource_key_value = format!("{test_id}-value");
+
+    let (session1, state_store_client1, lease_client1, leased_lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
+
+    let test_task1 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(5);
+            let request_timeout = Duration::from_secs(30);
+
+            assert!(
+                leased_lock_client1
+                    .lock_and_update_value(
+                        lock_expiry,
+                        request_timeout,
+                        shared_resource_key_name.clone().into_bytes(),
+                        &|key_current_value: Option<Vec<u8>>| {
+                            assert!(key_current_value.is_none());
+                            AcquireAndUpdateKeyOption::Update(
+                                shared_resource_key_value.clone().into_bytes(),
+                                SetOptions {
+                                    set_condition: SetCondition::Unconditional,
+                                    expires: Some(Duration::from_secs(10)),
+                                },
+                            )
+                        },
+                    )
+                    .await
+                    .unwrap()
+                    .response
+            );
+
+            assert!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            assert_eq!(
+                state_store_client1
+                    .get(
+                        shared_resource_key_name.clone().into_bytes(),
+                        request_timeout
+                    )
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                shared_resource_key_value.into_bytes()
+            );
+
+            assert!(
+                leased_lock_client1
+                    .lock_and_update_value(
+                        lock_expiry,
+                        request_timeout,
+                        shared_resource_key_name.clone().into_bytes(),
+                        &|_key_current_value: Option<Vec<u8>>| {
+                            AcquireAndUpdateKeyOption::Delete
+                        },
+                    )
+                    .await
+                    .unwrap()
+                    .response
+            );
+
+            assert!(
+                state_store_client1
+                    .get(shared_resource_key_name.into_bytes(), request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client1.shutdown().await.is_ok());
+
+            exit_handle1.try_exit().await.unwrap();
+        }
+    });
+
+    // if an assert fails in the test task, propagate the panic to end the test,
+    // while still running the test task and the session to completion on the happy path
+    assert!(
+        tokio::try_join!(
+            async move { test_task1.await.map_err(|e| { e.to_string() }) },
+            async move { session1.run().await.map_err(|e| { e.to_string() }) },
+        )
+        .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn leased_lock_two_holders_do_lock_and_update_value_to_set_and_delete_key_network_tests() {
+    let test_id =
+        "leased_lock_two_holders_do_lock_and_update_value_to_set_and_delete_key_network_tests";
+    if !setup_test(test_id) {
+        return;
+    }
+
+    let key_name1 = format!("{test_id}-lock");
+    let holder_name1 = format!("{test_id}1");
+    let holder_name2 = format!("{test_id}2");
+    let shared_resource_key_name = format!("{test_id}-key");
+
+    let (session1, state_store_client1, lease_client1, leased_lock_client1, exit_handle1) =
+        initialize_client(&holder_name1, &key_name1.clone());
+
+    let (session2, state_store_client2, lease_client2, leased_lock_client2, exit_handle2) =
+        initialize_client(&holder_name2, &key_name1);
+
+    let task1_notify = Arc::new(Notify::new());
+    let task2_notify = task1_notify.clone();
+
+    let test_task1_holder_name1 = holder_name1.clone();
+    let test_task1_shared_resource_key_name = shared_resource_key_name.clone();
+    let test_task1 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(5);
+            let request_timeout = Duration::from_secs(30);
+
+            assert!(
+                leased_lock_client1
+                    .lock_and_update_value(
+                        lock_expiry,
+                        request_timeout,
+                        test_task1_shared_resource_key_name.clone().into_bytes(),
+                        &|key_current_value: Option<Vec<u8>>| {
+                            assert!(key_current_value.is_none());
+                            AcquireAndUpdateKeyOption::Update(
+                                test_task1_holder_name1.clone().into_bytes(),
+                                SetOptions {
+                                    set_condition: SetCondition::Unconditional,
+                                    expires: Some(Duration::from_secs(10)),
+                                },
+                            )
+                        },
+                    )
+                    .await
+                    .unwrap()
+                    .response
+            );
+
+            assert!(
+                lease_client1
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            assert_eq!(
+                state_store_client1
+                    .get(
+                        test_task1_shared_resource_key_name.clone().into_bytes(),
+                        request_timeout
+                    )
+                    .await
+                    .unwrap()
+                    .response
+                    .unwrap(),
+                test_task1_holder_name1.into_bytes()
+            );
+
+            task1_notify.notify_one();
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client1.shutdown().await.is_ok());
+
+            exit_handle1.try_exit().await.unwrap();
+        }
+    });
+
+    let test_task2_shared_resource_key_name = shared_resource_key_name.clone();
+    let test_task2 = tokio::task::spawn({
+        async move {
+            let lock_expiry = Duration::from_secs(5);
+            let request_timeout = Duration::from_secs(50);
+
+            task2_notify.notified().await;
+
+            assert!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            assert!(
+                leased_lock_client2
+                    .lock_and_update_value(
+                        lock_expiry,
+                        request_timeout,
+                        test_task2_shared_resource_key_name.clone().into_bytes(),
+                        &|_key_current_value: Option<Vec<u8>>| AcquireAndUpdateKeyOption::Delete,
+                    )
+                    .await
+                    .unwrap()
+                    .response
+            );
+
+            assert!(
+                lease_client2
+                    .get_holder(request_timeout)
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            assert!(
+                state_store_client2
+                    .get(
+                        test_task2_shared_resource_key_name.into_bytes(),
+                        request_timeout
+                    )
+                    .await
+                    .unwrap()
+                    .response
+                    .is_none()
+            );
+
+            // Shutdown state store client and underlying resources
+            assert!(state_store_client2.shutdown().await.is_ok());
+
+            exit_handle2.try_exit().await.unwrap();
+        }
+    });
+
+    // if an assert fails in the test task, propagate the panic to end the test,
+    // while still running the test task and the session to completion on the happy path
+    assert!(
+        tokio::try_join!(
+            async move { test_task1.await.map_err(|e| { e.to_string() }) },
+            async move { session1.run().await.map_err(|e| { e.to_string() }) },
+            async move { test_task2.await.map_err(|e| { e.to_string() }) },
+            async move { session2.run().await.map_err(|e| { e.to_string() }) }
+        )
+        .is_ok()
+    );
+}

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -137,16 +137,6 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
                 .await
                 .expect("Expected a fencing token");
 
-            // Arbitrarily validate that the fencing token obtained from the lock operation is not older than 2 seconds.
-            assert!(
-                token
-                    .timestamp
-                    .duration_since(SystemTime::now())
-                    .expect("{difference:?}")
-                    .as_secs()
-                    < 2
-            );
-
             // Let's verify if the fencing token was stored internally.
             let saved_fencing_token = leased_lock_client1.get_current_lock_fencing_token().await;
 
@@ -494,7 +484,6 @@ async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
             assert!(fencing_token1.timestamp < fencing_token2.timestamp);
-            assert_eq!(fencing_token1.counter, fencing_token2.counter);
             assert_eq!(fencing_token1.node_id, fencing_token2.node_id);
 
             // Shutdown state store client and underlying resources

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -119,7 +119,7 @@ async fn lock_single_holder_do_lock_and_unlock_network_tests() {
     let holder_name1 = format!("{test_id}1");
     let shared_resource_key_name = format!("{test_id}-key");
 
-    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, lock_client1, exit_handle1) =
         initialize_client(&holder_name1, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({
@@ -190,7 +190,7 @@ async fn lock_single_holder_do_lock_with_auto_renewal_network_tests() {
     let lock_name1 = format!("{test_id}-lock");
     let holder_name1 = format!("{test_id}1");
 
-    let (session1, state_store_client1, _lease_client1, mut lock_client1, exit_handle1) =
+    let (session1, state_store_client1, _lease_client1, lock_client1, exit_handle1) =
         initialize_client(&holder_name1, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({
@@ -245,10 +245,10 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_ne
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, lock_client1, exit_handle1) =
         initialize_client(&holder_name1, &lock_name1.clone());
 
-    let (session2, state_store_client2, lease_client2, mut lock_client2, exit_handle2) =
+    let (session2, state_store_client2, lease_client2, lock_client2, exit_handle2) =
         initialize_client(&holder_name2, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({
@@ -362,10 +362,10 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration
     let holder_name1 = format!("{test_id}1");
     let holder_name2 = format!("{test_id}2");
 
-    let (session1, state_store_client1, lease_client1, mut lock_client1, exit_handle1) =
+    let (session1, state_store_client1, lease_client1, lock_client1, exit_handle1) =
         initialize_client(&holder_name1, &lock_name1.clone());
 
-    let (session2, state_store_client2, lease_client2, mut lock_client2, exit_handle2) =
+    let (session2, state_store_client2, lease_client2, lock_client2, exit_handle2) =
         initialize_client(&holder_name2, &lock_name1.clone());
 
     let test_task1 = tokio::task::spawn({

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -133,7 +133,7 @@ async fn lock_single_holder_do_lock_and_unlock_network_tests() {
                 .expect("Expected a fencing token");
 
             // Let's verify if the fencing token was stored internally.
-            let saved_fencing_token = lock_client1.get_current_lock_fencing_token();
+            let saved_fencing_token = lock_client1.current_lock_fencing_token();
 
             assert!(saved_fencing_token.is_some());
             assert_eq!(token, saved_fencing_token.unwrap());
@@ -144,7 +144,6 @@ async fn lock_single_holder_do_lock_and_unlock_network_tests() {
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name1.into_bytes()
             );
@@ -161,7 +160,7 @@ async fn lock_single_holder_do_lock_and_unlock_network_tests() {
             );
 
             // Let's verify if the fencing token was cleared internally.
-            assert!(lock_client1.get_current_lock_fencing_token().is_none());
+            assert!(lock_client1.current_lock_fencing_token().is_none());
 
             // Shutdown state store client and underlying resources
             assert!(state_store_client1.shutdown().await.is_ok());
@@ -209,7 +208,7 @@ async fn lock_single_holder_do_lock_with_auto_renewal_network_tests() {
             sleep(Duration::from_secs(3)).await;
 
             // Expect to have a new token now (updated timestamp, but same counter and node id).
-            let fencing_token2_option = lock_client1.get_current_lock_fencing_token();
+            let fencing_token2_option = lock_client1.current_lock_fencing_token();
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();
@@ -270,7 +269,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_ne
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
@@ -283,7 +281,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_ne
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
@@ -315,7 +312,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_ne
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name2.as_bytes().to_vec()
             );
@@ -328,7 +324,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_release_ne
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name2.as_bytes().to_vec()
             );
@@ -391,7 +386,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
@@ -404,7 +398,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name1.as_bytes().to_vec()
             );
@@ -436,7 +429,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name2.as_bytes().to_vec()
             );
@@ -449,7 +441,6 @@ async fn lock_two_holders_attempt_to_acquire_lock_simultaneously_with_expiration
                     .get_holder(request_timeout)
                     .await
                     .unwrap()
-                    .response
                     .unwrap(),
                 holder_name2.as_bytes().to_vec()
             );

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -8,28 +8,22 @@ use std::{env, sync::Arc, time::Duration};
 
 use env_logger::Builder;
 
-use tokio::{sync::Notify, time::sleep};
+use tokio::time::sleep;
 
 use azure_iot_operations_mqtt::MqttConnectionSettingsBuilder;
 use azure_iot_operations_mqtt::session::{
     Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
 };
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
-use azure_iot_operations_services::leased_lock::{
-    self, AcquireAndUpdateKeyOption, SetCondition, SetOptions,
-};
+use azure_iot_operations_services::leased_lock::{lease, lock};
 use azure_iot_operations_services::state_store::{self};
 
 // API:
 // lock
 // unlock
-// lock_and_update_value
-// acquire_and_delete_value
 
 // Test Scenarios:
 // single holder do lock and release
-// single holder do lock_and_update_value to set and delete a key
-// two holders do lock_and_update_value to set and delete a key
 // single holder do lock and release with auto-renewal
 
 fn setup_test(test_name: &str) -> bool {
@@ -54,8 +48,8 @@ fn initialize_client(
 ) -> (
     Session,
     Arc<state_store::Client<SessionManagedClient>>,
-    leased_lock::lease::Client<SessionManagedClient>,
-    leased_lock::Client<SessionManagedClient>,
+    lease::Client<SessionManagedClient>,
+    lock::Client<SessionManagedClient>,
     SessionExitHandle,
 ) {
     let connection_settings = MqttConnectionSettingsBuilder::default()
@@ -89,14 +83,14 @@ fn initialize_client(
 
     let exit_handle: SessionExitHandle = session.create_exit_handle();
 
-    let lease_client = leased_lock::lease::Client::new(
+    let lease_client = lease::Client::new(
         state_store_client.clone(),
         key_name.into(),
         client_id.into(),
     )
     .unwrap();
 
-    let leased_lock_client = leased_lock::Client::new(
+    let leased_lock_client = lock::Client::new(
         state_store_client.clone(),
         key_name.into(),
         client_id.into(),
@@ -137,7 +131,7 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
                 .expect("Expected a fencing token");
 
             // Let's verify if the fencing token was stored internally.
-            let saved_fencing_token = leased_lock_client1.get_current_lock_fencing_token().await;
+            let saved_fencing_token = leased_lock_client1.get_current_lock_fencing_token();
 
             assert!(saved_fencing_token.is_some());
             assert_eq!(token, saved_fencing_token.unwrap());
@@ -168,7 +162,6 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
             assert!(
                 leased_lock_client1
                     .get_current_lock_fencing_token()
-                    .await
                     .is_none()
             );
 
@@ -185,266 +178,6 @@ async fn leased_lock_single_holder_do_lock_and_unlock_network_tests() {
         tokio::try_join!(
             async move { test_task1.await.map_err(|e| { e.to_string() }) },
             async move { session1.run().await.map_err(|e| { e.to_string() }) },
-        )
-        .is_ok()
-    );
-}
-
-#[tokio::test]
-async fn leased_lock_single_holder_do_lock_and_update_value_to_set_and_delete_key_network_tests() {
-    let test_id =
-        "leased_lock_single_holder_do_lock_and_update_value_to_set_and_delete_key_network_tests";
-    if !setup_test(test_id) {
-        return;
-    }
-
-    let key_name1 = format!("{test_id}-lock");
-    let holder_name1 = format!("{test_id}1");
-    let shared_resource_key_name = format!("{test_id}-key");
-    let shared_resource_key_value = format!("{test_id}-value");
-
-    let (session1, state_store_client1, lease_client1, mut leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &key_name1.clone());
-
-    let test_task1 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(30);
-
-            assert!(
-                leased_lock_client1
-                    .lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        shared_resource_key_name.clone().into_bytes(),
-                        &|key_current_value: Option<Vec<u8>>| {
-                            assert!(key_current_value.is_none());
-                            AcquireAndUpdateKeyOption::Update(
-                                shared_resource_key_value.clone().into_bytes(),
-                                SetOptions {
-                                    set_condition: SetCondition::Unconditional,
-                                    expires: Some(Duration::from_secs(10)),
-                                },
-                            )
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                lease_client1
-                    .get_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert_eq!(
-                state_store_client1
-                    .get(
-                        shared_resource_key_name.clone().into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .unwrap(),
-                shared_resource_key_value.into_bytes()
-            );
-
-            assert!(
-                leased_lock_client1
-                    .lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        shared_resource_key_name.clone().into_bytes(),
-                        &|_key_current_value: Option<Vec<u8>>| {
-                            AcquireAndUpdateKeyOption::Delete
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                state_store_client1
-                    .get(shared_resource_key_name.into_bytes(), request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client1.shutdown().await.is_ok());
-
-            exit_handle1.try_exit().await.unwrap();
-        }
-    });
-
-    // if an assert fails in the test task, propagate the panic to end the test,
-    // while still running the test task and the session to completion on the happy path
-    assert!(
-        tokio::try_join!(
-            async move { test_task1.await.map_err(|e| { e.to_string() }) },
-            async move { session1.run().await.map_err(|e| { e.to_string() }) },
-        )
-        .is_ok()
-    );
-}
-
-#[tokio::test]
-async fn leased_lock_two_holders_do_lock_and_update_value_to_set_and_delete_key_network_tests() {
-    let test_id =
-        "leased_lock_two_holders_do_lock_and_update_value_to_set_and_delete_key_network_tests";
-    if !setup_test(test_id) {
-        return;
-    }
-
-    let key_name1 = format!("{test_id}-lock");
-    let holder_name1 = format!("{test_id}1");
-    let holder_name2 = format!("{test_id}2");
-    let shared_resource_key_name = format!("{test_id}-key");
-
-    let (session1, state_store_client1, lease_client1, mut leased_lock_client1, exit_handle1) =
-        initialize_client(&holder_name1, &key_name1.clone());
-
-    let (session2, state_store_client2, lease_client2, mut leased_lock_client2, exit_handle2) =
-        initialize_client(&holder_name2, &key_name1);
-
-    let task1_notify = Arc::new(Notify::new());
-    let task2_notify = task1_notify.clone();
-
-    let test_task1_holder_name1 = holder_name1.clone();
-    let test_task1_shared_resource_key_name = shared_resource_key_name.clone();
-    let test_task1 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(30);
-
-            assert!(
-                leased_lock_client1
-                    .lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        test_task1_shared_resource_key_name.clone().into_bytes(),
-                        &|key_current_value: Option<Vec<u8>>| {
-                            assert!(key_current_value.is_none());
-                            AcquireAndUpdateKeyOption::Update(
-                                test_task1_holder_name1.clone().into_bytes(),
-                                SetOptions {
-                                    set_condition: SetCondition::Unconditional,
-                                    expires: Some(Duration::from_secs(10)),
-                                },
-                            )
-                        },
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                lease_client1
-                    .get_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert_eq!(
-                state_store_client1
-                    .get(
-                        test_task1_shared_resource_key_name.clone().into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .unwrap(),
-                test_task1_holder_name1.into_bytes()
-            );
-
-            task1_notify.notify_one();
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client1.shutdown().await.is_ok());
-
-            exit_handle1.try_exit().await.unwrap();
-        }
-    });
-
-    let test_task2_shared_resource_key_name = shared_resource_key_name.clone();
-    let test_task2 = tokio::task::spawn({
-        async move {
-            let lock_expiry = Duration::from_secs(5);
-            let request_timeout = Duration::from_secs(50);
-
-            task2_notify.notified().await;
-
-            assert!(
-                lease_client2
-                    .get_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert!(
-                leased_lock_client2
-                    .lock_and_update_value(
-                        lock_expiry,
-                        request_timeout,
-                        test_task2_shared_resource_key_name.clone().into_bytes(),
-                        &|_key_current_value: Option<Vec<u8>>| AcquireAndUpdateKeyOption::Delete,
-                    )
-                    .await
-                    .unwrap()
-                    .response
-            );
-
-            assert!(
-                lease_client2
-                    .get_holder(request_timeout)
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            assert!(
-                state_store_client2
-                    .get(
-                        test_task2_shared_resource_key_name.into_bytes(),
-                        request_timeout
-                    )
-                    .await
-                    .unwrap()
-                    .response
-                    .is_none()
-            );
-
-            // Shutdown state store client and underlying resources
-            assert!(state_store_client2.shutdown().await.is_ok());
-
-            exit_handle2.try_exit().await.unwrap();
-        }
-    });
-
-    // if an assert fails in the test task, propagate the panic to end the test,
-    // while still running the test task and the session to completion on the happy path
-    assert!(
-        tokio::try_join!(
-            async move { test_task1.await.map_err(|e| { e.to_string() }) },
-            async move { session1.run().await.map_err(|e| { e.to_string() }) },
-            async move { test_task2.await.map_err(|e| { e.to_string() }) },
-            async move { session2.run().await.map_err(|e| { e.to_string() }) }
         )
         .is_ok()
     );
@@ -478,7 +211,7 @@ async fn leased_lock_single_holder_do_lock_with_auto_renewal_network_tests() {
             sleep(Duration::from_secs(3)).await;
 
             // Expect to have a new token now (updated timestamp, but same counter and node id).
-            let fencing_token2_option = leased_lock_client1.get_current_lock_fencing_token().await;
+            let fencing_token2_option = leased_lock_client1.get_current_lock_fencing_token();
 
             assert!(fencing_token2_option.is_some());
             let fencing_token2 = fencing_token2_option.unwrap();

--- a/rust/azure_iot_operations_services/tests/lock_client_tests.rs
+++ b/rust/azure_iot_operations_services/tests/lock_client_tests.rs
@@ -4,7 +4,6 @@
 #![cfg(feature = "leased_lock")]
 
 use std::assert_eq;
-use std::time::SystemTime;
 use std::{env, sync::Arc, time::Duration};
 
 use env_logger::Builder;


### PR DESCRIPTION
According to ADR 20 this leased lock client should be split into two layers, lease and lock clients. The lease client will have the bulk of logic for acquiring, renewing and releasing a key. The lock layer will present the expected semantics for locking operations.
Additionally auto-renewal of leases was not yet implemented in the leased lock client. included in this PR is the logic to perform the auto-renewal of leases/locks. 