### PR TITLE
Fix AVRO codegen when type is repeated

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Array/code/ArrayAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Array/code/ArrayAvroSchema.cs
@@ -1,18 +1,23 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class ArrayAvroSchema : ITemplateTransform
     {
+        private readonly CodeName schema;
         private readonly DTSchemaInfo elementSchema;
         private readonly int indent;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
-        public ArrayAvroSchema(DTSchemaInfo elementSchema, int indent, CodeName? sharedPrefix)
+        public ArrayAvroSchema(CodeName schema, DTSchemaInfo elementSchema, int indent, CodeName? sharedPrefix, HashSet<Dtmi> definedIds)
         {
+            this.schema = schema;
             this.elementSchema = elementSchema;
             this.indent = indent;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = definedIds;
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Array/t4/ArrayAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Array/t4/ArrayAvroSchema.tt
@@ -1,8 +1,11 @@
 <#@ template language="C#" linePragmas="false" #>
 <#@ import namespace="DTDLParser.Models" #>
+{
 <# this.PushIndent(new string(' ', this.indent)); #>
-"type": "array",
-"items": {
-<#=AvroSchemaSupport.GetTypeAndAddenda(this.elementSchema, 2, this.sharedPrefix, nullable: false, nestNamedType: false)#>
-},
-"default": []<# this.PopIndent(); #>
+<# if (this.schema != null) { #>
+  "name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
+<# } #>
+  "type": "array",
+  "items": <#=AvroSchemaSupport.GetTypeAndAddenda(this.elementSchema, 2, this.sharedPrefix, nullable: false, this.definedIds)#>,
+  "default": []
+}<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Command/code/CommandAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Command/code/CommandAvroSchema.cs
@@ -1,5 +1,6 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class CommandAvroSchema : ITemplateTransform
@@ -13,6 +14,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly DTSchemaInfo paramSchema;
         private readonly CodeName? sharedPrefix;
         private readonly bool isNullable;
+        private readonly HashSet<Dtmi> definedIds;
 
         public CommandAvroSchema(string projectName, CodeName genNamespace, ITypeName schema, string commandName, string subType, string paramName, DTSchemaInfo paramSchema, CodeName? sharedPrefix, bool isNullable)
         {
@@ -25,6 +27,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.paramSchema = paramSchema;
             this.sharedPrefix = sharedPrefix;
             this.isNullable = isNullable;
+            this.definedIds = new HashSet<Dtmi>();
         }
 
         public string FileName { get => $"{this.schema.GetFileName(TargetLanguage.Independent)}.avsc"; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Command/t4/CommandAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Command/t4/CommandAvroSchema.tt
@@ -6,7 +6,7 @@
   "fields": [
     {
       "name": "<#=this.paramName#>",
-<#=AvroSchemaSupport.GetTypeAndAddenda(this.paramSchema, indent: 6, this.sharedPrefix, this.isNullable, nestNamedType: true)#>
+      "type": <#=AvroSchemaSupport.GetTypeAndAddenda(this.paramSchema, indent: 6, this.sharedPrefix, this.isNullable, this.definedIds)#>
     }
   ]
 }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Enum/t4/EnumAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Enum/t4/EnumAvroSchema.tt
@@ -1,11 +1,13 @@
 <#@ template language="C#" linePragmas="false" #>
 <#@ import namespace="DTDLParser.Models" #>
+{
 <# this.PushIndent(new string(' ', this.indent)); #>
 <# if (this.schema != null) { #>
-"name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
+  "name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
 <# if (this.sharedNamespace != null) { #>
-"namespace": "<#=this.sharedNamespace.AsGiven#>",
+  "namespace": "<#=this.sharedNamespace.AsGiven#>",
 <# } #>
 <# } #>
-"type": "enum",
-"symbols": [ <#= string.Join(", ", this.names.Select(n => $"\"{n}\"")) #> ]<# this.PopIndent(); #>
+  "type": "enum",
+  "symbols": [ <#= string.Join(", ", this.names.Select(n => $"\"{n}\"")) #> ]
+}<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Map/code/MapAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Map/code/MapAvroSchema.cs
@@ -1,18 +1,23 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class MapAvroSchema : ITemplateTransform
     {
+        private readonly CodeName schema;
         private readonly DTSchemaInfo valueSchema;
         private readonly int indent;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
-        public MapAvroSchema(DTSchemaInfo valueSchema, int indent, CodeName? sharedPrefix)
+        public MapAvroSchema(CodeName schema, DTSchemaInfo valueSchema, int indent, CodeName? sharedPrefix, HashSet<Dtmi> definedIds)
         {
+            this.schema = schema;
             this.valueSchema = valueSchema;
             this.indent = indent;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = definedIds;
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Map/t4/MapAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Map/t4/MapAvroSchema.tt
@@ -1,8 +1,11 @@
 <#@ template language="C#" linePragmas="false" #>
 <#@ import namespace="DTDLParser.Models" #>
+{
 <# this.PushIndent(new string(' ', this.indent)); #>
-"type": "map",
-"values": {
-<#=AvroSchemaSupport.GetTypeAndAddenda(this.valueSchema, 2, this.sharedPrefix, nullable: false, nestNamedType: false)#>
-},
-"default": {}<# this.PopIndent(); #>
+<# if (this.schema != null) { #>
+  "name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
+<# } #>
+  "type": "map",
+  "values": <#=AvroSchemaSupport.GetTypeAndAddenda(this.valueSchema, 2, this.sharedPrefix, nullable: false, this.definedIds)#>,
+  "default": {}
+}<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Nullable/code/NullableAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Nullable/code/NullableAvroSchema.cs
@@ -1,5 +1,6 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class NullableAvroSchema : ITemplateTransform
@@ -7,12 +8,14 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly DTSchemaInfo schema;
         private readonly int indent;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
-        public NullableAvroSchema(DTSchemaInfo schema, int indent, CodeName? sharedPrefix)
+        public NullableAvroSchema(DTSchemaInfo schema, int indent, CodeName? sharedPrefix, HashSet<Dtmi> definedIds)
         {
             this.schema = schema;
             this.indent = indent;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = definedIds;
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Nullable/t4/NullableAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Nullable/t4/NullableAvroSchema.tt
@@ -1,9 +1,7 @@
 <#@ template language="C#" linePragmas="false" #>
 <#@ import namespace="DTDLParser.Models" #>
+[
 <# this.PushIndent(new string(' ', this.indent)); #>
-"type": [
   "null",
-  {
-<#=AvroSchemaSupport.GetTypeAndAddenda(this.schema, 4, this.sharedPrefix, nullable: false, nestNamedType: false)#>
-  }
+  <#=AvroSchemaSupport.GetTypeAndAddenda(this.schema, 2, this.sharedPrefix, nullable: false, this.definedIds)#>
 ]<# this.PopIndent(); #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/code/ObjectAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/code/ObjectAvroSchema.cs
@@ -1,6 +1,7 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
     using System.Collections.Generic;
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class ObjectAvroSchema : ITemplateTransform
@@ -10,14 +11,16 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly List<(string, DTSchemaInfo, bool)> nameSchemaRequireds;
         private readonly int indent;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
-        public ObjectAvroSchema(CodeName schema, CodeName? sharedNamespace, List<(string, DTSchemaInfo, bool)> nameSchemaRequireds, int indent, CodeName? sharedPrefix)
+        public ObjectAvroSchema(CodeName schema, CodeName? sharedNamespace, List<(string, DTSchemaInfo, bool)> nameSchemaRequireds, int indent, CodeName? sharedPrefix, HashSet<Dtmi> definedIds)
         {
             this.schema = schema;
             this.sharedNamespace = sharedNamespace;
             this.nameSchemaRequireds = nameSchemaRequireds;
             this.indent = indent;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = definedIds;
         }
 
         public string FileName { get => string.Empty; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/code/ResultAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/code/ResultAvroSchema.cs
@@ -1,5 +1,6 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class ResultAvroSchema : ITemplateTransform
@@ -9,6 +10,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly ITypeName schema;
         private readonly List<(string, string, DTSchemaInfo, bool, int)> nameDescSchemaRequiredIndices;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
         public ResultAvroSchema(string projectName, CodeName genNamespace, ITypeName schema, List<(string, string, DTSchemaInfo, bool, int)> nameDescSchemaRequiredIndices, CodeName? sharedPrefix)
         {
@@ -17,6 +19,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.schema = schema;
             this.nameDescSchemaRequiredIndices = nameDescSchemaRequiredIndices;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = new HashSet<Dtmi>();
         }
 
         public string FileName { get => $"{this.schema.GetFileName(TargetLanguage.Independent)}.avsc"; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/t4/ObjectAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/t4/ObjectAvroSchema.tt
@@ -1,21 +1,23 @@
 <#@ template language="C#" linePragmas="false" #>
 <#@ import namespace="DTDLParser.Models" #>
+{
 <# this.PushIndent(new string(' ', this.indent)); #>
 <# if (this.schema != null) { #>
-"name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
+  "name": "<#=this.schema.GetTypeName(TargetLanguage.Independent)#>",
 <# if (this.sharedNamespace != null) { #>
-"namespace": "<#=this.sharedNamespace.AsGiven#>",
+  "namespace": "<#=this.sharedNamespace.AsGiven#>",
 <# } #>
 <# } #>
-"type": "record",
-"fields": [
+  "type": "record",
+  "fields": [
 <# foreach (var nameSchemaRequired in this.nameSchemaRequireds) { #>
-  {
-    "name": "<#=nameSchemaRequired.Item1#>",
-<#=AvroSchemaSupport.GetTypeAndAddenda(nameSchemaRequired.Item2, 4, this.sharedPrefix, nullable: !nameSchemaRequired.Item3, nestNamedType: true)#>
-  }<#=this.IsLast(nameSchemaRequired) ? "" : ","#>
+    {
+      "name": "<#=nameSchemaRequired.Item1#>",
+      "type": <#=AvroSchemaSupport.GetTypeAndAddenda(nameSchemaRequired.Item2, 6, this.sharedPrefix, nullable: !nameSchemaRequired.Item3, this.definedIds)#>
+    }<#=this.IsLast(nameSchemaRequired) ? "" : ","#>
 <# } #>
-]<# this.PopIndent(); #>
+  ]
+}<# this.PopIndent(); #>
 <#+
     private bool IsLast((string, DTSchemaInfo, bool) nameSchemaRequired) => nameSchemaRequired.Item1 == this.nameSchemaRequireds.Last().Item1;
 #>

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/t4/ResultAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Object/t4/ResultAvroSchema.tt
@@ -8,7 +8,7 @@
 <# foreach (var nameDescSchemaRequiredIndex in this.nameDescSchemaRequiredIndices) { #>
     {
       "name": "<#=nameDescSchemaRequiredIndex.Item1#>",
-<#=AvroSchemaSupport.GetTypeAndAddenda(nameDescSchemaRequiredIndex.Item3, 4, this.sharedPrefix, nullable: !nameDescSchemaRequiredIndex.Item4, nestNamedType: true)#>
+<#=AvroSchemaSupport.GetTypeAndAddenda(nameDescSchemaRequiredIndex.Item3, 4, this.sharedPrefix, nullable: !nameDescSchemaRequiredIndex.Item4, this.definedIds)#>
     }<#=this.IsLast(nameDescSchemaRequiredIndex) ? "" : ","#>
 <# } #>
   ]

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Telemetry/code/TelemetryAvroSchema.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Telemetry/code/TelemetryAvroSchema.cs
@@ -1,6 +1,7 @@
 namespace Azure.Iot.Operations.ProtocolCompiler
 {
     using System.Collections.Generic;
+    using DTDLParser;
     using DTDLParser.Models;
 
     public partial class TelemetryAvroSchema : ITemplateTransform
@@ -10,6 +11,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private readonly ITypeName schema;
         private readonly List<(string, string, DTSchemaInfo, bool, int)> nameDescSchemaRequiredIndices;
         private readonly CodeName? sharedPrefix;
+        private readonly HashSet<Dtmi> definedIds;
 
         public TelemetryAvroSchema(string projectName, CodeName genNamespace, ITypeName schema, List<(string, string, DTSchemaInfo, bool, int)> nameDescSchemaRequiredIndices, CodeName? sharedPrefix)
         {
@@ -18,6 +20,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             this.schema = schema;
             this.nameDescSchemaRequiredIndices = nameDescSchemaRequiredIndices;
             this.sharedPrefix = sharedPrefix;
+            this.definedIds = new HashSet<Dtmi>();
         }
 
         public string FileName { get => $"{this.schema.GetFileName(TargetLanguage.Independent)}.avsc"; }

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Telemetry/t4/TelemetryAvroSchema.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/serialization/Telemetry/t4/TelemetryAvroSchema.tt
@@ -8,7 +8,7 @@
 <# foreach (var nameDescSchemaRequiredIndex in this.nameDescSchemaRequiredIndices) { #>
     {
       "name": "<#=nameDescSchemaRequiredIndex.Item1#>",
-<#=AvroSchemaSupport.GetTypeAndAddenda(nameDescSchemaRequiredIndex.Item3, indent: 6, this.sharedPrefix, nullable: !nameDescSchemaRequiredIndex.Item4, nestNamedType: true)#>
+      "type": <#=AvroSchemaSupport.GetTypeAndAddenda(nameDescSchemaRequiredIndex.Item3, indent: 6, this.sharedPrefix, nullable: !nameDescSchemaRequiredIndex.Item4, this.definedIds)#>
     }<#=this.IsLast(nameDescSchemaRequiredIndex) ? "" : ","#>
 <# } #>
   ]

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/TypeGenerator/AvroSchemaStandardizer.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/TypeGenerator/AvroSchemaStandardizer.cs
@@ -79,7 +79,7 @@
                 case "array":
                     return new ArrayType(GetSchemaType(schemaElt.GetProperty("items"), schemaTypes, genNamespace));
                 default:
-                    throw new Exception("unrecognized schema");
+                    throw new Exception($"Unrecognized schema type: {typeElt.GetString()}");
             }
         }
 

--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/TypeGenerator/AvroSchemaStandardizer.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/TypeGenerator/AvroSchemaStandardizer.cs
@@ -25,6 +25,11 @@
 
         private SchemaType GetSchemaType(JsonElement schemaElt, List<SchemaType> schemaTypes, CodeName parentNamespace)
         {
+            if (schemaElt.ValueKind == JsonValueKind.String)
+            {
+                return this.TryGetPrimitiveType(schemaElt.GetString(), out SchemaType schemaType) ? schemaType : new ReferenceType(new CodeName(schemaElt.GetString()!), parentNamespace);
+            }
+
             JsonElement typeElt = schemaElt.GetProperty("type");
 
             if (typeElt.ValueKind == JsonValueKind.Object)
@@ -48,6 +53,11 @@
             CodeName? schemaName = schemaElt.TryGetProperty("name", out JsonElement nameElt) ? new CodeName(nameElt.GetString()!) : null;
             CodeName genNamespace = schemaElt.TryGetProperty("namespace", out JsonElement namespaceElt) && !namespaceElt.GetString()!.Contains('.') ? new CodeName(namespaceElt.GetString()!) : parentNamespace;
 
+            if (this.TryGetPrimitiveType(typeElt.GetString(), out SchemaType primitiveType))
+            {
+                return primitiveType;
+            }
+
             switch (typeElt.GetString())
             {
                 case "record":
@@ -68,22 +78,39 @@
                     return new MapType(GetSchemaType(schemaElt.GetProperty("values"), schemaTypes, genNamespace));
                 case "array":
                     return new ArrayType(GetSchemaType(schemaElt.GetProperty("items"), schemaTypes, genNamespace));
-                case "boolean":
-                    return new BooleanType();
-                case "double":
-                    return new DoubleType();
-                case "float":
-                    return new FloatType();
-                case "int":
-                    return new IntegerType();
-                case "long":
-                    return new LongType();
-                case "string":
-                    return new StringType();
-                case "bytes":
-                    return new BytesType();
                 default:
                     throw new Exception("unrecognized schema");
+            }
+        }
+
+        private bool TryGetPrimitiveType(string? typeName, out SchemaType schemaType)
+        {
+            switch (typeName)
+            {
+                case "boolean":
+                    schemaType = new BooleanType();
+                    return true;
+                case "double":
+                    schemaType = new DoubleType();
+                    return true;
+                case "float":
+                    schemaType = new FloatType();
+                    return true;
+                case "int":
+                    schemaType = new IntegerType();
+                    return true;
+                case "long":
+                    schemaType = new LongType();
+                    return true;
+                case "string":
+                    schemaType = new StringType();
+                    return true;
+                case "bytes":
+                    schemaType = new BytesType();
+                    return true;
+                default:
+                    schemaType = null!;
+                    return false;
             }
         }
 


### PR DESCRIPTION
The ProtocolCompiler failed to deduplicate embedded type definitions when generating AVSC files, which could result in invalid schema definitions.  This change fixes the problem by ensuring that each definition is included in the AVSC file only once.