### PR TITLE
[Rust][Connector] Changing from ; delineation to newline

### DIFF
--- a/rust/azure_iot_operations_connector/examples/filemount_azure_device_registry_observation.rs
+++ b/rust/azure_iot_operations_connector/examples/filemount_azure_device_registry_observation.rs
@@ -203,7 +203,7 @@ impl FileMountManager {
     fn add_device_endpoint(&self, device_endpoint: &DeviceEndpointRef, asset_names: &[AssetRef]) {
         let file_path = self.dir.as_path().join(device_endpoint.to_string());
         let content: Vec<_> = asset_names.iter().map(|asset| asset.name.clone()).collect();
-        let content = content.join(";");
+        let content = content.join("\n");
         fs::write(file_path, content).unwrap();
     }
 
@@ -222,7 +222,7 @@ impl FileMountManager {
         }
         // Append the asset name to the file
         if !content.is_empty() {
-            content.push(';');
+            content.push('\n');
         }
         content.push_str(asset.name.as_str());
         fs::write(file_path, content).unwrap();
@@ -234,10 +234,10 @@ impl FileMountManager {
 
         // Remove the asset name from the file
         content = content
-            .split(';')
+            .lines()
             .filter(|&name| name != asset.name.as_str())
             .collect::<Vec<_>>()
-            .join(";");
+            .join("\n");
 
         fs::write(file_path, content).unwrap();
     }

--- a/rust/azure_iot_operations_connector/examples/filemount_azure_device_registry_observation.rs
+++ b/rust/azure_iot_operations_connector/examples/filemount_azure_device_registry_observation.rs
@@ -11,7 +11,7 @@
 //!
 //! NOTE: Make sure that the environment variable folder exists and is empty before running the example.
 
-use std::{fs, path::PathBuf, time::Duration};
+use std::{fs, io::Write, path::PathBuf, time::Duration};
 
 use azure_iot_operations_connector::filemount::azure_device_registry::{
     AssetRef, DeviceEndpointCreateObservation, DeviceEndpointRef, get_mount_path,
@@ -202,9 +202,15 @@ impl FileMountManager {
 
     fn add_device_endpoint(&self, device_endpoint: &DeviceEndpointRef, asset_names: &[AssetRef]) {
         let file_path = self.dir.as_path().join(device_endpoint.to_string());
-        let content: Vec<_> = asset_names.iter().map(|asset| asset.name.clone()).collect();
-        let content = content.join("\n");
-        fs::write(file_path, content).unwrap();
+        let mut file = fs::File::options()
+            .append(true)
+            .create(true)
+            .open(file_path)
+            .unwrap();
+        for asset in asset_names {
+            // Write the asset name to the file
+            writeln!(&mut file, "{}", asset.name).unwrap();
+        }
     }
 
     fn remove_device_endpoint(&self, device_endpoint: &DeviceEndpointRef) {
@@ -214,31 +220,36 @@ impl FileMountManager {
 
     fn add_asset(&self, device_endpoint: &DeviceEndpointRef, asset: &AssetRef) {
         let file_path = self.dir.as_path().join(device_endpoint.to_string());
-        let mut content = fs::read_to_string(&file_path).unwrap();
 
         // Make sure the asset name is not already present
-        if content.contains(asset.name.as_str()) {
+        if fs::read_to_string(&file_path)
+            .unwrap()
+            .contains(asset.name.as_str())
+        {
             return;
         }
+
+        let mut file = fs::File::options().append(true).open(file_path).unwrap();
         // Append the asset name to the file
-        if !content.is_empty() {
-            content.push('\n');
-        }
-        content.push_str(asset.name.as_str());
-        fs::write(file_path, content).unwrap();
+        writeln!(&mut file, "{}", asset.name).unwrap();
     }
 
     fn remove_asset(&self, device_endpoint: &DeviceEndpointRef, asset: &AssetRef) {
         let file_path = self.dir.as_path().join(device_endpoint.to_string());
-        let mut content = fs::read_to_string(&file_path).unwrap();
+        let content = fs::read_to_string(&file_path).unwrap();
 
-        // Remove the asset name from the file
-        content = content
-            .lines()
-            .filter(|&name| name != asset.name.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
+        // Write the assets back to the file
+        let mut file = fs::File::options()
+            .write(true)
+            .truncate(true)
+            .open(file_path)
+            .unwrap();
 
-        fs::write(file_path, content).unwrap();
+        for line in content.lines() {
+            // If the line is not the asset name, write it back to the file
+            if line != asset.name.as_str() {
+                writeln!(&mut file, "{line}").unwrap();
+            }
+        }
     }
 }

--- a/rust/azure_iot_operations_connector/src/filemount/azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/filemount/azure_device_registry.rs
@@ -280,9 +280,9 @@ fn get_asset_names(
         return Ok(HashSet::new());
     }
 
-    // Split the file content by ';' and create a HashSet of AssetRef
+    // Split the file content by '\n' and create a HashSet of AssetRef
     Ok(file_content
-        .split(';')
+        .lines()
         .map(|asset_name| AssetRef {
             name: asset_name.to_string(),
             device_name: device_endpoint.device_name.clone(),
@@ -555,7 +555,7 @@ mod tests {
         ) {
             let file_path = self.dir.path().join(device_endpoint.to_string());
             let content: Vec<_> = asset_names.iter().map(|asset| asset.name.clone()).collect();
-            let content = content.join(";");
+            let content = content.join("\n");
             fs::write(file_path, content).unwrap();
         }
 
@@ -574,7 +574,7 @@ mod tests {
             }
             // Append the asset name to the file
             if !content.is_empty() {
-                content.push(';');
+                content.push('\n');
             }
             content.push_str(asset.name.as_str());
             fs::write(file_path, content).unwrap();
@@ -586,10 +586,10 @@ mod tests {
 
             // Remove the asset name from the file
             content = content
-                .split(';')
+                .lines()
                 .filter(|&name| name != asset.name.as_str())
                 .collect::<Vec<_>>()
-                .join(";");
+                .join("\n");
 
             fs::write(file_path, content).unwrap();
         }

--- a/rust/azure_iot_operations_connector/src/filemount/azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/filemount/azure_device_registry.rs
@@ -280,7 +280,7 @@ fn get_asset_names(
         return Ok(HashSet::new());
     }
 
-    // Split the file content by '\n' and create a HashSet of AssetRef
+    // Split the file content by newline and create a HashSet of AssetRef
     Ok(file_content
         .lines()
         .map(|asset_name| AssetRef {
@@ -512,6 +512,7 @@ mod tests {
 
     use std::collections::HashSet;
     use std::fs;
+    use std::io::Write;
 
     const DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
 
@@ -554,9 +555,15 @@ mod tests {
             asset_names: &[AssetRef],
         ) {
             let file_path = self.dir.path().join(device_endpoint.to_string());
-            let content: Vec<_> = asset_names.iter().map(|asset| asset.name.clone()).collect();
-            let content = content.join("\n");
-            fs::write(file_path, content).unwrap();
+            let mut file = fs::File::options()
+                .append(true)
+                .create(true)
+                .open(file_path)
+                .unwrap();
+            for asset in asset_names {
+                // Write the asset name to the file
+                writeln!(&mut file, "{}", asset.name).unwrap();
+            }
         }
 
         fn remove_device_endpoint(&self, device_endpoint: &DeviceEndpointRef) {
@@ -566,32 +573,37 @@ mod tests {
 
         fn add_asset(&self, device_endpoint: &DeviceEndpointRef, asset: &AssetRef) {
             let file_path = self.dir.path().join(device_endpoint.to_string());
-            let mut content = fs::read_to_string(&file_path).unwrap();
 
             // Make sure the asset name is not already present
-            if content.contains(asset.name.as_str()) {
+            if fs::read_to_string(&file_path)
+                .unwrap()
+                .contains(asset.name.as_str())
+            {
                 return;
             }
+
+            let mut file = fs::File::options().append(true).open(file_path).unwrap();
             // Append the asset name to the file
-            if !content.is_empty() {
-                content.push('\n');
-            }
-            content.push_str(asset.name.as_str());
-            fs::write(file_path, content).unwrap();
+            writeln!(&mut file, "{}", asset.name).unwrap();
         }
 
         fn remove_asset(&self, device_endpoint: &DeviceEndpointRef, asset: &AssetRef) {
             let file_path = self.dir.path().join(device_endpoint.to_string());
-            let mut content = fs::read_to_string(&file_path).unwrap();
+            let content = fs::read_to_string(&file_path).unwrap();
 
-            // Remove the asset name from the file
-            content = content
-                .lines()
-                .filter(|&name| name != asset.name.as_str())
-                .collect::<Vec<_>>()
-                .join("\n");
+            // Write the assets back to the file
+            let mut file = fs::File::options()
+                .write(true)
+                .truncate(true)
+                .open(file_path)
+                .unwrap();
 
-            fs::write(file_path, content).unwrap();
+            for line in content.lines() {
+                // If the line is not the asset name, write it back to the file
+                if line != asset.name.as_str() {
+                    writeln!(&mut file, "{line}").unwrap();
+                }
+            }
         }
 
         fn path(&self) -> &Path {


### PR DESCRIPTION
## Context

Assets in files mounted by ADR are no longer delimited by `;` and are instead separated by newline.

## Changes

- file mount client now uses `\n` as a delimiter for asset names in files