### PR TITLE
[ADR] Missing dataSetConfiguration dtdl

### DIFF
--- a/eng/dtdl/device-name-based-operations.json
+++ b/eng/dtdl/device-name-based-operations.json
@@ -599,6 +599,11 @@
                       },
                       {
                         "@type": "Field",
+                        "name": "datasetConfiguration",
+                        "schema": "string"
+                      },
+                      {
+                        "@type": "Field",
                         "@id": "dtmi:com:microsoft:akri:AssetDatasetDestination;1",
                         "name": "destinations",
                         "schema": {


### PR DESCRIPTION
There was a missing datasetConfiguration field in the ADR dtdl. for a dataset object Added relevant folks working on ADR. 

This would affect: #761 and #778 I believe