### PR TITLE
[Rust] Update feature/akri to use latest adr client

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -12,27 +12,18 @@ readme = "README.md"
 publish = true
 
 [dependencies]
-# azure_iot_operations_protocol = { version = "0.9", path = "../azure_iot_operations_protocol", registry = "aio-sdks"  }
-# temporary so that the adr client uses the same version of the protocol crate as the connector does
-azure_iot_operations_protocol = { git = "https://github.com/Azure/iot-operations-sdks", branch = "feature/rust-akri" }
-# azure_iot_operations_services = { version = "0.8", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
-# temporary import from branch while ADR client gets code reviewed
-azure_iot_operations_services = { git = "https://github.com/Azure/iot-operations-sdks", branch = "feature/rust-akri", features = ["state_store", "schema_registry", "azure_device_registry"]  }
-# azure_iot_operations_mqtt = { version = "0.9", path = "../azure_iot_operations_mqtt", registry = "aio-sdks"  }
-# temporary so that the adr client uses the same version of the mqtt crate as the connector does
-azure_iot_operations_mqtt = { git = "https://github.com/Azure/iot-operations-sdks", branch = "feature/rust-akri" }
-# derive_builder.workspace = true
+azure_iot_operations_protocol = { version = "0.9", path = "../azure_iot_operations_protocol", registry = "aio-sdks"  }
+azure_iot_operations_services = { version = "0.8", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_mqtt = { version = "0.9", path = "../azure_iot_operations_mqtt", registry = "aio-sdks"  }
+log.workspace = true
+notify.workspace = true
+notify-debouncer-full.workspace = true
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror.workspace = true
 # tokio.workspace = true
 tokio = { version = "1.41", features = ["full"] } # TODO: If I use the workspace version of tokio I run into errors with tokio in the tests, will investigate later
 tokio-util.workspace = true
-notify.workspace = true
-notify-debouncer-full.workspace = true
-# futures = "0.3"
-# tokio-stream = "0.1"
-thiserror.workspace = true
-log.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions.rs
+++ b/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions.rs
@@ -244,7 +244,7 @@ async fn run_program(
                                                 // now we should update the status of the asset
                                                 let mut dataset_statuses = Vec::new();
                                                 for dataset in asset.specification.datasets {
-                                                    dataset_statuses.push(azure_device_registry::AssetDatasetEventStreamStatus {
+                                                    dataset_statuses.push(azure_device_registry::DatasetEventStreamStatus {
                                                     error: None,
                                                     message_schema_reference: None,
                                                     name: dataset.name,
@@ -255,7 +255,7 @@ async fn run_program(
                                                     version: asset.specification.version,
                                                     ..azure_device_registry::StatusConfig::default()
                                                 }),
-                                                datasets_schema: Some(dataset_statuses),
+                                                datasets: Some(dataset_statuses),
                                                 ..azure_device_registry::AssetStatus::default()
                                             };
                                                 match azure_device_registry_client_clone

--- a/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/connector_template.yaml
+++ b/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/connector_template.yaml
@@ -17,13 +17,14 @@ spec:
   runtimeConfiguration:
     runtimeConfigurationType: managedConfiguration
     managedConfigurationSettings:
-      allocation:
-        policy: "Bucketized"
-        bucketSize: 1
       managedConfigurationType: imageConfiguration
       imageConfigurationSettings:
-        image: "connectorgetadrdefinitions:latest"
-        imagePullPolicy: Never
+        imageName: "connectorgetadrdefinitions"
+        imagePullPolicy: Never # This sample image is built locally, so no need to pull
+        replicas: 1
+        tagDigestSettings:
+          tagDigestType: tag
+          tag: "latest"
   mqttConnectionConfiguration:
     host: "aio-broker:1883"
     tls:

--- a/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/rest-thermostat-asset-definition.yaml
+++ b/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/rest-thermostat-asset-definition.yaml
@@ -4,9 +4,9 @@ metadata:
   name: my-rest-thermostat-asset
   namespace: azure-iot-operations
 spec:
-  attributes:
-    assetId: my-rest-thermostat-asset
-    assetType: thermostat
+  # attributes: # This part of the spec is currently broken in the operator. Re-enable later
+  #   assetId: my-rest-thermostat-asset
+  #   assetType: thermostat
   datasets:
     - name: thermostat_status
       dataPoints:

--- a/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/thermostat-device-definition.yaml
+++ b/rust/azure_iot_operations_connector/examples/connector_get_adr_definitions_resources/thermostat-device-definition.yaml
@@ -14,18 +14,12 @@ spec:
         additionalConfiguration: '{"key1": "value1", "nested": {"key2": 2}}'
         address: http://rest-server-service.azure-iot-operations.svc.cluster.local:80
         authentication:
-          method: UsernamePassword
-          usernamePasswordCredentials:
-            usernameSecretName: rest-server-auth-creds/username
-            passwordSecretName: rest-server-auth-creds/password
+          method: Anonymous
         endpointType: rest-thermostat
       my-coap-endpoint:
         address: coap://thermostat.local/temp
         authentication:
-          method: UsernamePassword
-          usernamePasswordCredentials:
-            usernameSecretName: coap-auth-creds/username
-            passwordSecretName: coap-auth-creds/password
+          method: Anonymous
         endpointType: coap-thermostat
   uuid: 1234-5678-9012-3456
   version: 2

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use azure_iot_operations_mqtt::interface::AckToken;
 use azure_iot_operations_services::azure_device_registry::{
-    Asset, AssetDataset, AssetUpdateObservation, ConfigError, Device, DeviceUpdateObservation,
+    Asset, Dataset, AssetUpdateObservation, ConfigError, Device, DeviceUpdateObservation,
     MessageSchemaReference,
 };
 
@@ -186,7 +186,7 @@ where
 /// to report status, translate data, and send data to the destination
 pub struct DatasetClient<T: DataTransformer> {
     /// Dataset Definition
-    pub dataset_definition: AssetDataset,
+    pub dataset_definition: Dataset,
     dataset_data_transformer: T::MyDatasetDataTransformer,
     reporter: Arc<Reporter>,
 }
@@ -195,7 +195,7 @@ impl<T> DatasetClient<T>
 where
     T: DataTransformer,
 {
-    pub(crate) fn new(dataset_definition: AssetDataset, data_transformer: &T) -> Self {
+    pub(crate) fn new(dataset_definition: Dataset, data_transformer: &T) -> Self {
         // Create a new dataset
         let forwarder = Forwarder::new(dataset_definition.clone());
         let reporter = Arc::new(Reporter::new(dataset_definition.clone()));
@@ -238,7 +238,7 @@ pub struct Reporter {
 }
 #[allow(dead_code)]
 impl Reporter {
-    pub(crate) fn new(_dataset_definition: AssetDataset) -> Self {
+    pub(crate) fn new(_dataset_definition: Dataset) -> Self {
         // Create a new forwarder
         Self {
             message_schema_uri: None,

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use azure_iot_operations_mqtt::interface::AckToken;
 use azure_iot_operations_services::azure_device_registry::{
-    Asset, Dataset, AssetUpdateObservation, ConfigError, Device, DeviceUpdateObservation,
+    Asset, AssetUpdateObservation, ConfigError, Dataset, Device, DeviceUpdateObservation,
     MessageSchemaReference,
 };
 

--- a/rust/azure_iot_operations_connector/src/data_transformer.rs
+++ b/rust/azure_iot_operations_connector/src/data_transformer.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use azure_iot_operations_services::azure_device_registry::AssetDataset;
+use azure_iot_operations_services::azure_device_registry::Dataset;
 
 use crate::destination_endpoint::Forwarder;
 use crate::{Data, base_connector::managed_azure_device_registry::Reporter};
@@ -17,7 +17,7 @@ pub trait DataTransformer {
     type MyDatasetDataTransformer: DatasetDataTransformer;
     fn new_dataset_data_transformer(
         &self,
-        dataset_definition: AssetDataset,
+        dataset_definition: Dataset,
         forwarder: Forwarder,
         reporter: Arc<Reporter>,
     ) -> Self::MyDatasetDataTransformer;
@@ -37,7 +37,7 @@ impl DataTransformer for PassthroughDataTransformer {
     #[must_use]
     fn new_dataset_data_transformer(
         &self,
-        _dataset_definition: AssetDataset,
+        _dataset_definition: Dataset,
         forwarder: Forwarder,
         _reporter: Arc<Reporter>,
     ) -> Self::MyDatasetDataTransformer {

--- a/rust/azure_iot_operations_connector/src/destination_endpoint.rs
+++ b/rust/azure_iot_operations_connector/src/destination_endpoint.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs)]
 
-use azure_iot_operations_services::azure_device_registry::{AssetDataset, MessageSchemaReference};
+use azure_iot_operations_services::azure_device_registry::{Dataset, MessageSchemaReference};
 
 use crate::Data;
 
@@ -14,7 +14,7 @@ pub struct Forwarder {
 }
 impl Forwarder {
     #[must_use]
-    pub fn new(_dataset_definition: AssetDataset) -> Self {
+    pub fn new(_dataset_definition: Dataset) -> Self {
         // Create a new forwarder
         Self {
             message_schema_uri: None,


### PR DESCRIPTION
This PR:
- updates the azure_iot_operations_connector crate to point to the adr client in feature/akri instead of pointing to feature/rust-akri now that changes have been merged to feature/akri
- updates connector crate and sample to align with slight adr client API changes
- updates connector resources to work with the latest operator/adr service