### PR TITLE
Make cross language pipeline timeout more generous

### DIFF
--- a/.github/workflows/e2e-cross-language.yml
+++ b/.github/workflows/e2e-cross-language.yml
@@ -26,7 +26,7 @@ jobs:
   cross-language:
     name: CI-cross-language
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
I'm seeing this pipeline timeout more often now that the AIO installation step itself can take ~10 minutes