### PR TITLE
[.NET][Akri] Remove placeholder client ids

### DIFF
--- a/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/Program.cs
+++ b/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/Program.cs
@@ -6,7 +6,7 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using EventDrivenTcpThermostatConnector;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? "todo";
+string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/Program.cs
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/Program.cs
@@ -6,7 +6,7 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using RestThermostatConnector;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? "todo";
+string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/dotnet/samples/Connectors/SqlConnector/Program.cs
+++ b/dotnet/samples/Connectors/SqlConnector/Program.cs
@@ -6,7 +6,7 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using SqlQualityAnalyzerConnectorApp;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? "todo";
+string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
 
 IHost host = Host.CreateDefaultBuilder(args)
 

--- a/dotnet/src/Azure.Iot.Operations.Connector/Configurations/ConnectorFileMountSettings.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Configurations/ConnectorFileMountSettings.cs
@@ -26,7 +26,7 @@ namespace Azure.Iot.Operations.Connector.ConnectorConfigurations
         /// <returns>The instance of <see cref="MqttConnectionSettings"/> that allows the connector to connect to the MQTT broker.</returns>
         public static MqttConnectionSettings FromFileMount()
         {
-            string clientId = Environment.GetEnvironmentVariable(ConnectorClientIdEnvVar) ?? "todo";
+            string clientId = Environment.GetEnvironmentVariable(ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
             string? brokerTrustBundleMountPath = Environment.GetEnvironmentVariable(BrokerTrustBundleMountPathEnvVar);
             string? brokerSatMountPath = Environment.GetEnvironmentVariable(BrokerSatMountPathEnvVar);
 


### PR DESCRIPTION
These hardcoded client ids were just used while we waited on the Akri operator to deploy connectors with their actual client Ids.