### PR TITLE
Fix interaction between NormalResult and shared namespace

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/EnvoyGenerator/EnvoyTransformFactory.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/EnvoyGenerator/EnvoyTransformFactory.cs
@@ -320,7 +320,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
 
                     if (normalResultSchema != null)
                     {
-                        yield return new RustSerialization(respSchemaNamespace ?? genNamespace, genFormat, normalResultSchema, workingPath);
+                        yield return new RustSerialization(normalResultNamespace ?? genNamespace, genFormat, normalResultSchema, workingPath);
                     }
 
                     break;


### PR DESCRIPTION
One-line fix to Rust code generation when using both CLI --shared option and Result co-type