### PR TITLE
[.NET][Akri] Fix log statement

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
@@ -94,7 +94,7 @@ namespace Azure.Iot.Operations.Connector
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError("Failed to read the file mount for MQTT connection settings. Will try again: {}", ex.Message);
+                    _logger.LogWarning("Failed to read the file mount for MQTT connection settings. Will try again: {}", ex.Message);
                     await Task.Delay(TimeSpan.FromMilliseconds(100));
 
                     if (++currentRetryCount >= maxRetryCount)


### PR DESCRIPTION
Don't use Trace inside a sample, use the provided logger instead.

This call to Trace also threw because it expected a different argument format, but now the log statement executes without throwing