### PR TITLE
[.NET] Re-add static constructor for ExtendedResponse

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Protocol/RPC/ExtendedResponse.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/RPC/ExtendedResponse.cs
@@ -18,6 +18,17 @@ namespace Azure.Iot.Operations.Protocol.RPC
 
         public CommandResponseMetadata? ResponseMetadata { get; set; }
 
+#pragma warning disable CA1000 // Do not declare static members on generic types
+        public static ExtendedResponse<TResp> CreateFromResponse(TResp response)
+        {
+            return new()
+            {
+                Response = response,
+                ResponseMetadata = null,
+            };
+        }
+#pragma warning restore CA1000 // Do not declare static members on generic types
+
         public ExtendedResponse<TResp> WithApplicationError(string errorCode)
         {
             ResponseMetadata ??= new();


### PR DESCRIPTION
#676 deleted this static constructor, but apparently code gen still needs it