### PR TITLE
[.Net] Integration tests

### DIFF
--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
@@ -47,6 +47,24 @@ public class AdrServiceClientIntegrationTests
     }
 
     [Fact]
+    public async Task GetDeviceThrowsAkriServiceErrorExceptionWhenDeviceNotFoundAsync()
+    {
+        // Arrange
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        ApplicationContext applicationContext = new();
+        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<AkriServiceErrorException>(
+            () => client.GetDeviceAsync("non-existent-device", "my-rest-endpoint"));
+
+        _output.WriteLine($"Expected exception: {exception.Message}");
+        Assert.NotNull(exception.AkriServiceError);
+        Assert.Equal("KubeError", exception.AkriServiceError.Code);
+        Assert.StartsWith("Error fetching device non-existent-device.my-rest-endpoint", exception.AkriServiceError.Message);
+    }
+
+    [Fact]
     public async Task CanUpdateDeviceStatusAsync()
     {
         // Arrange
@@ -323,7 +341,7 @@ public class AdrServiceClientIntegrationTests
     }
 
     [Fact]
-    public async Task CanCreateDetectedAssetAsync()
+    public async Task CanCreateOrUpdateDiscoveredAssetAsync()
     {
         // Arrange
         await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
@@ -339,6 +357,27 @@ public class AdrServiceClientIntegrationTests
         Assert.NotNull(result);
         Assert.NotEmpty(result.DiscoveryId);
         _output.WriteLine($"Detected asset created with DiscoveryId: {result.DiscoveryId}");
+    }
+
+    [Fact]
+    public async Task CanCreateOrUpdateDiscoveredDeviceAsync()
+    {
+        // Arrange
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        ApplicationContext applicationContext = new();
+        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+
+        var request = CreateCreateDiscoveredDeviceRequest();
+
+        // Act
+        var response = await client.CreateOrUpdateDiscoveredDeviceAsync(request, "my-rest-endpoint");
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.DiscoveryId);
+        Assert.NotEmpty(response.DiscoveryId);
+        Assert.Equal("test-discovered-device", response.DiscoveryId);
+        _output.WriteLine($"Discovered device created with name: {response.DiscoveryId}");
     }
 
     [Fact]
@@ -728,4 +767,44 @@ public class AdrServiceClientIntegrationTests
         };
     }
 
+        private CreateDiscoveredAssetEndpointProfileRequest CreateCreateDiscoveredDeviceRequest()
+    {
+        return new CreateDiscoveredAssetEndpointProfileRequest
+        {
+            Name = "test-discovered-device",
+            Manufacturer = "Test Manufacturer",
+            Model = "Test Model",
+            OperatingSystem = "Linux",
+            OperatingSystemVersion = "1.0",
+            ExternalDeviceId = "external-device-id-123",
+            Endpoints = new DiscoveredDeviceEndpoint
+            {
+                Inbound = new Dictionary<string, DiscoveredDeviceInboundEndpoint>
+                {
+                    {
+                        TestEndpointName,
+                        new DiscoveredDeviceInboundEndpoint
+                        {
+                            Address = "http://example.com",
+                            EndpointType = "rest",
+                            Version = "1.0",
+                            SupportedAuthenticationMethods = new List<string> { "Basic", "OAuth2" }
+                        }
+                    }
+                },
+                Outbound = new DiscoveredDeviceOutboundEndpoints
+                {
+                    Assigned = new Dictionary<string, DeviceOutboundEndpoint>
+                    {
+                        { "outbound-endpoint-1", new DeviceOutboundEndpoint { Address = "http://outbound.example.com", EndpointType = "rest" } }
+                    }
+                }
+            },
+            Attributes = new Dictionary<string, string>
+            {
+                { "attribute1", "value1" },
+                { "attribute2", "value2" }
+            }
+        };
+    }
 }

--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
@@ -61,7 +61,6 @@ public class AdrServiceClientIntegrationTests
         _output.WriteLine($"Expected exception: {exception.Message}");
         Assert.NotNull(exception.AkriServiceError);
         Assert.Equal("KubeError", exception.AkriServiceError.Code);
-        Assert.StartsWith("Error fetching device non-existent-device.my-rest-endpoint", exception.AkriServiceError.Message);
     }
 
     [Fact]
@@ -767,7 +766,7 @@ public class AdrServiceClientIntegrationTests
         };
     }
 
-        private CreateDiscoveredAssetEndpointProfileRequest CreateCreateDiscoveredDeviceRequest()
+    private CreateDiscoveredAssetEndpointProfileRequest CreateCreateDiscoveredDeviceRequest()
     {
         return new CreateDiscoveredAssetEndpointProfileRequest
         {


### PR DESCRIPTION
This pull request enhances the integration tests in `AdrServiceClientIntegrationTests.cs` by adding new test cases and helper methods to improve coverage and functionality for device-related operations. The most important changes include adding tests for error handling and discovered device creation, as well as introducing a helper method to create requests for discovered devices.

### Added test cases for device operations:

* **Error handling**: Added a test case `GetDeviceThrowsAkriServiceErrorExceptionWhenDeviceNotFoundAsync` to verify that an appropriate exception is thrown when attempting to fetch a non-existent device.
* **Discovered device creation**: Added a test case `CanCreateOrUpdateDiscoveredDeviceAsync` to validate the creation or update of discovered devices, ensuring the response contains a valid `DiscoveryId`.

### Helper method for discovered device requests:

* **Request creation**: Introduced the `CreateCreateDiscoveredDeviceRequest` method to simplify the creation of requests for discovered devices, including attributes, endpoints, and other metadata.

### Minor adjustment to existing test:

* **Renamed test**: Updated the name of an existing test from `CanCreateDetectedAssetAsync` to `CanCreateOrUpdateDiscoveredAssetAsync` to better reflect its functionality.