### PR TITLE
Add user-defined props AppErrorCode and AppErrorPayload to RPC

### DIFF
--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -37,6 +37,12 @@ pub enum UserProperty {
     /// This property is only used when a command executor rejects a command invocation because the
     /// requested protocol version either wasn't supported or was malformed.
     RequestProtocolVersion,
+    /// Custom user-defined application error code.
+    /// This property is defined by the application and is opaque to the RPC protocol.
+    ApplicationErrorCode,
+    /// Custom user-defined application error message.
+    /// This property is defined by the application and is opaque to the RPC protocol.
+    ApplicationErrorPayload,
 }
 
 impl Display for UserProperty {
@@ -53,6 +59,8 @@ impl Display for UserProperty {
             UserProperty::ProtocolVersion => write!(f, "__protVer"),
             UserProperty::SupportedMajorVersions => write!(f, "__supProtMajVer"),
             UserProperty::RequestProtocolVersion => write!(f, "__requestProtVer"),
+            UserProperty::ApplicationErrorCode => write!(f, "AppErrCode"),
+            UserProperty::ApplicationErrorPayload => write!(f, "AppErrPayload"),
         }
     }
 }
@@ -72,6 +80,8 @@ impl FromStr for UserProperty {
             "__protVer" => Ok(UserProperty::ProtocolVersion),
             "__supProtMajVer" => Ok(UserProperty::SupportedMajorVersions),
             "__requestProtVer" => Ok(UserProperty::RequestProtocolVersion),
+            "AppErrCode" => Ok(UserProperty::ApplicationErrorCode),
+            "AppErrPayload" => Ok(UserProperty::ApplicationErrorPayload),
             _ => Err(()),
         }
     }

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -54,6 +54,8 @@ struct ResponseArguments {
     request_protocol_version: Option<String>,
     cached_key: Option<CacheKey>,
     cached_entry_status: CacheEntryStatus,
+    application_error_code: Option<String>,
+    application_error_payload: Option<String>,
 }
 
 /// Command Executor Request struct.
@@ -670,6 +672,8 @@ where
                         request_protocol_version: None,
                         cached_key: None,
                         cached_entry_status: CacheEntryStatus::NotFound,
+                        application_error_code: None,
+                        application_error_payload: None,
                     };
 
                     // Get message expiry interval
@@ -1172,6 +1176,20 @@ where
                 user_properties.push((
                     UserProperty::RequestProtocolVersion.to_string(),
                     request_protocol_version,
+                ));
+            }
+
+            if let Some(application_error_code) = response_arguments.application_error_code {
+                user_properties.push((
+                    UserProperty::ApplicationErrorCode.to_string(),
+                    application_error_code,
+                ));
+            }
+
+            if let Some(application_error_payload) = response_arguments.application_error_payload {
+                user_properties.push((
+                    UserProperty::ApplicationErrorPayload.to_string(),
+                    application_error_payload,
                 ));
             }
 

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -323,6 +323,8 @@ where
             UserProperty::ProtocolVersion,
             UserProperty::SupportedMajorVersions,
             UserProperty::RequestProtocolVersion,
+            UserProperty::ApplicationErrorCode,
+            UserProperty::ApplicationErrorPayload,
         ];
         let mut response_custom_user_data = vec![];
         let mut response_aio_data = HashMap::new();


### PR DESCRIPTION
Implementation of https://github.com/Azure/iot-operations-sdks/blob/main/doc/dev/adr/0021-error-modeling-headers.md in the AIO Rust RPC client.

Still pending for PR completion:
- Tests