### PR TITLE
[Rust][Protocol] Add user-defined props AppErrorCode and AppErrorPayload to RPC

### DIFF
--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -11,6 +11,12 @@ use std::{
 /// Users cannot set this property on the invoker. For more details, see: [shared_subscriptions.md](https://github.com/Azure/iot-operations-sdks/blob/main/doc/reference/shared-subscriptions.md).
 pub(crate) const PARTITION_KEY: &str = "$partition";
 
+/// Name of the user-defined Application Error Code header.
+pub(crate) const APPLICATION_ERROR_CODE_HEADER: &str = "AppErrCode";
+
+/// Name of the user-defined Application Error Payload header.
+pub(crate) const APPLICATION_ERROR_PAYLOAD_HEADER: &str = "AppErrPayload";
+
 /// Enum representing the system properties.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum UserProperty {

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -11,12 +11,6 @@ use std::{
 /// Users cannot set this property on the invoker. For more details, see: [shared_subscriptions.md](https://github.com/Azure/iot-operations-sdks/blob/main/doc/reference/shared-subscriptions.md).
 pub(crate) const PARTITION_KEY: &str = "$partition";
 
-/// Name of the user-defined Application Error Code header.
-pub(crate) const APPLICATION_ERROR_CODE_HEADER: &str = "AppErrCode";
-
-/// Name of the user-defined Application Error Payload header.
-pub(crate) const APPLICATION_ERROR_PAYLOAD_HEADER: &str = "AppErrPayload";
-
 /// Enum representing the system properties.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum UserProperty {

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -212,6 +212,42 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
         }
         Ok(())
     }
+
+    /// Helper function to add user-defined application error headers to `response`.
+    ///
+    /// `application_error_code` required to be a non-empty `String`.
+    /// `application_error_payload` is optional and can be an empty `String`, in which case it is ignored and not added to `response`.
+    ///
+    /// Returns `Ok()` if `application_error_code` is not an empty `String`.
+    ///
+    /// # Errors
+    /// Returns an Error with the `String` "`application_error_code` cannot be empty" if `application_error_code` is an empty string.
+    pub fn add_application_error_headers(
+        mut response: Response<TResp>,
+        application_error_code: String,
+        application_error_payload: String,
+    ) -> Result<(), String> {
+        if application_error_code.is_empty() {
+            return Err("application_error_code cannot be empty".into());
+        }
+
+        let app_error_code_property = "AppErrCode";
+
+        response
+            .custom_user_data
+            .push((app_error_code_property.to_string(), application_error_code));
+
+        if !application_error_payload.is_empty() {
+            let app_error_payload_property = "AppErrPayload";
+
+            response.custom_user_data.push((
+                app_error_payload_property.to_string(),
+                application_error_payload,
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 /// Command Executor Cache Key struct.

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -219,7 +219,7 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
 /// `custom_user_data` can be an empty Vec or an existing Vec of custom user data. This function will add the application error headers to this Vec.
 /// `application_error_code` required to be a non-empty `String`.
 /// `application_error_payload` is optional and can be an empty `String`, in which case it is ignored and not added to `custom_user_data`. It is conventionally, but not necessarily, a stringified JSON object/value/array.
-/// 
+///
 /// Returns `Ok(())` if the properties are added to `custom_user_data`. If an error is returned, `custom_user_data`` won't get modified.
 ///
 /// # Errors

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -218,9 +218,9 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
 ///
 /// `custom_user_data` can be an empty Vec or an existing Vec of custom user data. This function will add the application error headers to this Vec.
 /// `application_error_code` required to be a non-empty `String`.
-/// `application_error_payload` is optional and can be an empty `String`, in which case it is ignored and not added to `response`. It is conventionally, but not necessarily, a stringified JSON object/value/array.
-///
-/// Returns `Ok(())` if the properties are added to `custom_user_data`.
+/// `application_error_payload` is optional and can be an empty `String`, in which case it is ignored and not added to `custom_user_data`. It is conventionally, but not necessarily, a stringified JSON object/value/array.
+/// 
+/// Returns `Ok(())` if the properties are added to `custom_user_data`. If an error is returned, `custom_user_data`` won't get modified.
 ///
 /// # Errors
 /// Returns an Error with the `String` "`application_error_code` cannot be empty" if `application_error_code` is an empty string.

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1819,7 +1819,9 @@ mod tests {
             .times(1);
 
         let mut custom_user_data = Vec::new();
-        assert!(application_error_headers(&mut custom_user_data, "500".into(), "  ".into()).is_ok());
+        assert!(
+            application_error_headers(&mut custom_user_data, "500".into(), "  ".into()).is_ok()
+        );
 
         let response = ResponseBuilder::default()
             .custom_user_data(custom_user_data)

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -220,7 +220,7 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
 /// `application_error_code` required to be a non-empty `String`.
 /// `application_error_payload` is optional and can be an empty `String`, in which case it is ignored and not added to `custom_user_data`. It is conventionally, but not necessarily, a stringified JSON object/value/array.
 ///
-/// Returns `Ok(())` if the properties are added to `custom_user_data`. If an error is returned, `custom_user_data`` won't get modified.
+/// Returns `Ok(())` if the properties are added to `custom_user_data`. If an error is returned, `custom_user_data` won't get modified.
 ///
 /// # Errors
 /// Returns an Error with the `String` "`application_error_code` cannot be empty" if `application_error_code` is an empty string.

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1821,9 +1821,16 @@ mod tests {
             .times(1);
 
         let mut binding = ResponseBuilder::default();
-        let mut response = binding.payload(mock_response_payload).unwrap().build().unwrap();
+        let mut response = binding
+            .payload(mock_response_payload)
+            .unwrap()
+            .build()
+            .unwrap();
 
-        assert!(ResponseBuilder::add_application_error_headers(&mut response, "500".into(), "".into()).is_ok());
+        assert!(
+            ResponseBuilder::add_application_error_headers(&mut response, "500".into(), "".into())
+                .is_ok()
+        );
         assert_eq!(response.custom_user_data.len(), 1);
     }
 
@@ -1842,9 +1849,20 @@ mod tests {
             .times(1);
 
         let mut binding = ResponseBuilder::default();
-        let mut response = binding.payload(mock_response_payload).unwrap().build().unwrap();
+        let mut response = binding
+            .payload(mock_response_payload)
+            .unwrap()
+            .build()
+            .unwrap();
 
-        assert!(ResponseBuilder::add_application_error_headers(&mut response, "".into(), "Some error".into()).is_err());
+        assert!(
+            ResponseBuilder::add_application_error_headers(
+                &mut response,
+                "".into(),
+                "Some error".into()
+            )
+            .is_err()
+        );
     }
 }
 

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -167,7 +167,7 @@ where
 /// - the second element is the application error payload (or [`None`] if not present).
 #[must_use]
 pub fn application_error_headers(
-    custom_user_data: Vec<(String, String)>,
+    custom_user_data: &Vec<(String, String)>,
 ) -> (Option<String>, Option<String>) {
     const APPLICATION_ERROR_CODE_HEADER: &str = "AppErrCode";
     const APPLICATION_ERROR_PAYLOAD_HEADER: &str = "AppErrPayload";
@@ -2025,7 +2025,7 @@ mod tests {
         let user_data: Vec<(String, String)> = Vec::new();
 
         let (application_error_code, application_error_payload) =
-            application_error_headers(user_data);
+            application_error_headers(&user_data);
         assert!(application_error_code.is_none());
         assert!(application_error_payload.is_none());
     }
@@ -2044,7 +2044,7 @@ mod tests {
         assert_eq!(custom_user_data.len(), 2);
 
         let (application_error_code, application_error_payload) =
-            application_error_headers(custom_user_data);
+            application_error_headers(&custom_user_data);
         assert_eq!(application_error_code, Some(error_code_content.into()));
         assert_eq!(
             application_error_payload,
@@ -2052,7 +2052,7 @@ mod tests {
         );
     }
 
-    /// Tests success: custom_user_data contains both Application Error Code and Payload.
+    /// Tests success: custom_user_data contains Application Error Code, but no Payload.
     #[tokio::test]
     async fn test_response_with_app_error_code_but_no_payload() {
         let error_code_content = "5888";
@@ -2062,7 +2062,7 @@ mod tests {
         assert_eq!(custom_user_data.len(), 1);
 
         let (application_error_code, application_error_payload) =
-            application_error_headers(custom_user_data);
+            application_error_headers(&custom_user_data);
         assert_eq!(application_error_code, Some(error_code_content.into()));
         assert!(application_error_payload.is_none());
     }

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -160,28 +160,32 @@ where
     pub timestamp: Option<HybridLogicalClock>,
 }
 
-impl<TResp: PayloadSerialize> Response<TResp> {
-    /// Helper function to return the application error code and payload, if present in the response [`Response::custom_user_data`].
-    ///
-    /// Returns a [`(Option<String>, Option<String>)`] tuple where:
-    /// - the first element is the application error code (or [`None`] if not present), and
-    /// - the second element is the application error payload (or [`None`] if not present).
-    pub fn application_error_headers(self) -> (Option<String>, Option<String>) {
-        let mut app_error_code: Option<String> = None;
-        let mut app_error_payload: Option<String> = None;
+/// Helper function to return the application error code and payload, if present in `custom_user_data`.
+///
+/// Returns a [`(Option<String>, Option<String>)`] tuple where:
+/// - the first element is the application error code (or [`None`] if not present), and
+/// - the second element is the application error payload (or [`None`] if not present).
+#[must_use]
+pub fn application_error_headers(
+    custom_user_data: Vec<(String, String)>,
+) -> (Option<String>, Option<String>) {
+    const APPLICATION_ERROR_CODE_HEADER: &str = "AppErrCode";
+    const APPLICATION_ERROR_PAYLOAD_HEADER: &str = "AppErrPayload";
 
-        for (key, value) in self.custom_user_data {
-            if key == crate::common::user_properties::APPLICATION_ERROR_CODE_HEADER {
-                app_error_code = Some(value.clone());
-            }
+    let mut app_error_code: Option<String> = None;
+    let mut app_error_payload: Option<String> = None;
 
-            if key == crate::common::user_properties::APPLICATION_ERROR_PAYLOAD_HEADER {
-                app_error_payload = Some(value.clone());
-            }
+    for (key, value) in custom_user_data {
+        if key == APPLICATION_ERROR_CODE_HEADER {
+            app_error_code = Some(value.clone());
         }
 
-        (app_error_code, app_error_payload)
+        if key == APPLICATION_ERROR_PAYLOAD_HEADER {
+            app_error_payload = Some(value.clone());
+        }
     }
+
+    (app_error_code, app_error_payload)
 }
 
 /// Represents an error reported by a remote executor
@@ -2015,48 +2019,32 @@ mod tests {
         assert!(request_builder_result.is_err());
     }
 
-    /// Tests success: Response::application_error_headers() returns no Application Error Code and Payload since it has none.
+    /// Tests success: application_error_headers() returns no Application Error Code and Payload since custom_user_data has none.
     #[tokio::test]
     async fn test_no_app_error_code_and_payload() {
         let user_data: Vec<(String, String)> = Vec::new();
 
-        let response = Response {
-            payload: MockPayload::default(),
-            content_type: None,
-            format_indicator: FormatIndicator::UnspecifiedBytes,
-            custom_user_data: user_data,
-            timestamp: None,
-        };
-
         let (application_error_code, application_error_payload) =
-            response.application_error_headers();
+            application_error_headers(user_data);
         assert!(application_error_code.is_none());
         assert!(application_error_payload.is_none());
     }
 
-    /// Tests success: Response contains both Application Error Code and Payload.
+    /// Tests success: custom_user_data contains both Application Error Code and Payload.
     #[tokio::test]
     async fn test_response_with_app_error_code_and_payload() {
         let error_code_content = "5888";
         let error_payload_content = "5888 is a fictitious error code";
 
-        let user_data = vec![
+        let custom_user_data = vec![
             ("AppErrCode".into(), error_code_content.into()),
             ("AppErrPayload".into(), error_payload_content.into()),
         ];
 
-        let response = Response {
-            payload: MockPayload::default(),
-            content_type: None,
-            format_indicator: FormatIndicator::UnspecifiedBytes,
-            custom_user_data: user_data,
-            timestamp: None,
-        };
-
-        assert_eq!(response.custom_user_data.len(), 2);
+        assert_eq!(custom_user_data.len(), 2);
 
         let (application_error_code, application_error_payload) =
-            response.application_error_headers();
+            application_error_headers(custom_user_data);
         assert_eq!(application_error_code, Some(error_code_content.into()));
         assert_eq!(
             application_error_payload,
@@ -2064,25 +2052,17 @@ mod tests {
         );
     }
 
-    /// Tests success: Response contains both Application Error Code and Payload.
+    /// Tests success: custom_user_data contains both Application Error Code and Payload.
     #[tokio::test]
     async fn test_response_with_app_error_code_but_no_payload() {
         let error_code_content = "5888";
 
-        let user_data = vec![("AppErrCode".into(), error_code_content.into())];
+        let custom_user_data = vec![("AppErrCode".into(), error_code_content.into())];
 
-        let response = Response {
-            payload: MockPayload::default(),
-            content_type: None,
-            format_indicator: FormatIndicator::UnspecifiedBytes,
-            custom_user_data: user_data,
-            timestamp: None,
-        };
-
-        assert_eq!(response.custom_user_data.len(), 1);
+        assert_eq!(custom_user_data.len(), 1);
 
         let (application_error_code, application_error_payload) =
-            response.application_error_headers();
+            application_error_headers(custom_user_data);
         assert_eq!(application_error_code, Some(error_code_content.into()));
         assert!(application_error_payload.is_none());
     }

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -274,20 +274,21 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
             let response = result.unwrap();
             assert_eq!(response.custom_user_data.len(), 2);
 
-            let mut user_error_headers_checksum = 0;
+            let mut app_err_code_header_count = 0;
+            let mut app_err_payload_header_count = 0;
             for (key, value) in response.custom_user_data {
                 if key == "AppErrCode" {
                     assert_eq!(value, "345");
-                    user_error_headers_checksum += 1;
+                    app_err_code_header_count += 1;
                 }
 
                 if key == "AppErrPayload" {
                     assert_eq!(value, "Failed543");
-                    user_error_headers_checksum += 1000;
+                    app_err_payload_header_count += 1;
                 }
             }
-
-            assert_eq!(user_error_headers_checksum, 1001);
+            assert_eq!(app_err_code_header_count, 1);
+            assert_eq!(app_err_payload_header_count, 1);
 
             // wait for the receive_requests_task to finish to ensure any failed asserts are captured.
             assert!(receive_requests_task.await.is_ok());
@@ -377,20 +378,21 @@ async fn command_response_apperrorcode_no_apperrorpayload_network_tests() {
 
             assert_eq!(response.custom_user_data.len(), 1);
 
-            let mut user_error_headers_checksum = 0;
+            let mut app_err_code_header_count = 0;
+            let mut app_err_payload_header_count = 0;
             for (key, value) in response.custom_user_data {
                 if key == "AppErrCode" {
                     assert_eq!(value, "345");
-                    user_error_headers_checksum += 1;
+                    app_err_code_header_count += 1;
                 }
 
                 if key == "AppErrPayload" {
-                    assert_eq!(value, "");
-                    user_error_headers_checksum += 1000;
+                    app_err_payload_header_count += 1;
                 }
             }
 
-            assert_eq!(user_error_headers_checksum, 1);
+            assert_eq!(app_err_code_header_count, 1);
+            assert_eq!(app_err_payload_header_count, 0);
 
             // wait for the receive_requests_task to finish to ensure any failed asserts are captured.
             assert!(receive_requests_task.await.is_ok());

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -233,9 +233,12 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
                         // Validate contents of the request match expected based on what was sent
                         assert_eq!(request.invoker_id, Some(String::from(invoker_id)));
 
+                        let mut custom_user_data = Vec::new();
+                        assert!(rpc_command::executor::application_error_headers(&mut custom_user_data, "345".into(), "Failed543".into()).is_ok());
+
                         // send response
                         let response = rpc_command::executor::ResponseBuilder::default()
-                            .custom_user_data(azure_iot_operations_protocol::rpc_command::executor::application_error_headers(Vec::new(), "345".into(), "Failed543".into()).unwrap())
+                            .custom_user_data(custom_user_data)
                             .payload(EmptyPayload::default())
                             .unwrap()
                             .build()
@@ -285,8 +288,8 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
             assert_eq!(app_err_payload_header_count, 1);
 
             let (app_error_code, app_error_payload) =
-                azure_iot_operations_protocol::rpc_command::invoker::application_error_headers(
-                    response.custom_user_data,
+                rpc_command::invoker::application_error_headers(
+                    &response.custom_user_data,
                 );
             assert_eq!(app_error_code, Some("345".into()));
             assert_eq!(app_error_payload, Some("Failed543".into()));

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -234,7 +234,14 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
                         assert_eq!(request.invoker_id, Some(String::from(invoker_id)));
 
                         let mut custom_user_data = Vec::new();
-                        assert!(rpc_command::executor::application_error_headers(&mut custom_user_data, "345".into(), "Failed543".into()).is_ok());
+                        assert!(
+                            rpc_command::executor::application_error_headers(
+                                &mut custom_user_data,
+                                "345".into(),
+                                "Failed543".into()
+                            )
+                            .is_ok()
+                        );
 
                         // send response
                         let response = rpc_command::executor::ResponseBuilder::default()
@@ -288,9 +295,7 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
             assert_eq!(app_err_payload_header_count, 1);
 
             let (app_error_code, app_error_payload) =
-                rpc_command::invoker::application_error_headers(
-                    &response.custom_user_data,
-                );
+                rpc_command::invoker::application_error_headers(&response.custom_user_data);
             assert_eq!(app_error_code, Some("345".into()));
             assert_eq!(app_error_payload, Some("Failed543".into()));
 

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -209,7 +209,6 @@ async fn command_basic_invoke_response_network_tests() {
     );
 }
 
-
 /// Tests application error code and payload headers
 #[tokio::test]
 async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
@@ -240,7 +239,14 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
                             .unwrap()
                             .build()
                             .unwrap();
-                        assert!(rpc_command::executor::ResponseBuilder::add_application_error_headers(&mut response, "345".into(), "Failed543".into()).is_ok());
+                        assert!(
+                            rpc_command::executor::ResponseBuilder::add_application_error_headers(
+                                &mut response,
+                                "345".into(),
+                                "Failed543".into()
+                            )
+                            .is_ok()
+                        );
                         assert!(request.complete(response).await.is_ok());
                     }
 
@@ -261,13 +267,13 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
                 .timeout(Duration::from_secs(2))
                 .build()
                 .unwrap();
-            
+
             let result = invoker.invoke(request).await;
             // Validate contents of the response match expected based on what was sent
             assert!(result.is_ok(), "result: {result:?}");
             let response = result.unwrap();
             assert_eq!(response.custom_user_data.len(), 2);
-            
+
             let mut user_error_headers_checksum = 0;
             for (key, value) in response.custom_user_data {
                 if key == "AppErrCode" {
@@ -308,9 +314,10 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
 #[tokio::test]
 async fn command_response_apperrorcode_no_apperrorpayload_network_tests() {
     let invoker_id = "command_response_apperrorcode_no_apperrorpayload_network_tests-rust";
-    let Ok((session, invoker, mut executor, exit_handle)) =
-        setup_test::<EmptyPayload, EmptyPayload>(invoker_id, "protocol/tests/apperrorcodeonly/command")
-    else {
+    let Ok((session, invoker, mut executor, exit_handle)) = setup_test::<EmptyPayload, EmptyPayload>(
+        invoker_id,
+        "protocol/tests/apperrorcodeonly/command",
+    ) else {
         // Network tests disabled, skipping tests
         return;
     };
@@ -334,7 +341,14 @@ async fn command_response_apperrorcode_no_apperrorpayload_network_tests() {
                             .unwrap()
                             .build()
                             .unwrap();
-                        assert!(rpc_command::executor::ResponseBuilder::add_application_error_headers(&mut response, "345".into(), "".into()).is_ok());
+                        assert!(
+                            rpc_command::executor::ResponseBuilder::add_application_error_headers(
+                                &mut response,
+                                "345".into(),
+                                "".into()
+                            )
+                            .is_ok()
+                        );
                         assert!(request.complete(response).await.is_ok());
                     }
 
@@ -355,14 +369,14 @@ async fn command_response_apperrorcode_no_apperrorpayload_network_tests() {
                 .timeout(Duration::from_secs(2))
                 .build()
                 .unwrap();
-            
+
             let result = invoker.invoke(request).await;
             // Validate contents of the response match expected based on what was sent
             assert!(result.is_ok(), "result: {result:?}");
             let response = result.unwrap();
 
             assert_eq!(response.custom_user_data.len(), 1);
-            
+
             let mut user_error_headers_checksum = 0;
             for (key, value) in response.custom_user_data {
                 if key == "AppErrCode" {

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -235,9 +235,8 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
 
                         // send response
                         let response = rpc_command::executor::ResponseBuilder::default()
+                            .custom_user_data(azure_iot_operations_protocol::rpc_command::executor::application_error_headers(Vec::new(), "345".into(), "Failed543".into()).unwrap())
                             .payload(EmptyPayload::default())
-                            .unwrap()
-                            .application_error_headers("345".into(), "Failed543".into())
                             .unwrap()
                             .build()
                             .unwrap();
@@ -285,7 +284,10 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
             assert_eq!(app_err_code_header_count, 1);
             assert_eq!(app_err_payload_header_count, 1);
 
-            let (app_error_code, app_error_payload) = response.application_error_headers();
+            let (app_error_code, app_error_payload) =
+                azure_iot_operations_protocol::rpc_command::invoker::application_error_headers(
+                    response.custom_user_data,
+                );
             assert_eq!(app_error_code, Some("345".into()));
             assert_eq!(app_error_payload, Some("Failed543".into()));
 

--- a/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
+++ b/rust/azure_iot_operations_protocol/tests/command_network_tests.rs
@@ -60,7 +60,7 @@ fn setup_test<
 
     let connection_settings = MqttConnectionSettingsBuilder::default()
         .client_id(client_id)
-        .hostname("172.22.0.3")
+        .hostname("localhost")
         .tcp_port(1883u16)
         .keep_alive(Duration::from_secs(5))
         .clean_start(true)
@@ -234,19 +234,14 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
                         assert_eq!(request.invoker_id, Some(String::from(invoker_id)));
 
                         // send response
-                        let mut response = rpc_command::executor::ResponseBuilder::default()
+                        let response = rpc_command::executor::ResponseBuilder::default()
                             .payload(EmptyPayload::default())
+                            .unwrap()
+                            .application_error_headers("345".into(), "Failed543".into())
                             .unwrap()
                             .build()
                             .unwrap();
-                        assert!(
-                            rpc_command::executor::ResponseBuilder::add_application_error_headers(
-                                &mut response,
-                                "345".into(),
-                                "Failed543".into()
-                            )
-                            .is_ok()
-                        );
+
                         assert!(request.complete(response).await.is_ok());
                     }
 
@@ -276,7 +271,7 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
 
             let mut app_err_code_header_count = 0;
             let mut app_err_payload_header_count = 0;
-            for (key, value) in response.custom_user_data {
+            for (key, value) in &response.custom_user_data {
                 if key == "AppErrCode" {
                     assert_eq!(value, "345");
                     app_err_code_header_count += 1;
@@ -290,109 +285,9 @@ async fn command_response_apperrorcode_and_apperrorpayload_network_tests() {
             assert_eq!(app_err_code_header_count, 1);
             assert_eq!(app_err_payload_header_count, 1);
 
-            // wait for the receive_requests_task to finish to ensure any failed asserts are captured.
-            assert!(receive_requests_task.await.is_ok());
-
-            // cleanup should be successful
-            assert!(invoker.shutdown().await.is_ok());
-
-            exit_handle.try_exit().await.unwrap();
-        }
-    });
-
-    // if an assert fails in the test task, propagate the panic to end the test,
-    // while still running the test task and the session to completion on the happy path
-    assert!(
-        tokio::try_join!(
-            async move { test_task.await.map_err(|e| { e.to_string() }) },
-            async move { session.run().await.map_err(|e| { e.to_string() }) }
-        )
-        .is_ok()
-    );
-}
-
-/// Tests application error code header only, without payload
-#[tokio::test]
-async fn command_response_apperrorcode_no_apperrorpayload_network_tests() {
-    let invoker_id = "command_response_apperrorcode_no_apperrorpayload_network_tests-rust";
-    let Ok((session, invoker, mut executor, exit_handle)) = setup_test::<EmptyPayload, EmptyPayload>(
-        invoker_id,
-        "protocol/tests/apperrorcodeonly/command",
-    ) else {
-        // Network tests disabled, skipping tests
-        return;
-    };
-    let monitor = session.create_connection_monitor();
-
-    let test_task = tokio::task::spawn({
-        async move {
-            // async task to receive command requests on executor
-            let receive_requests_task = tokio::task::spawn({
-                async move {
-                    let mut count = 0;
-                    if let Some(Ok(request)) = executor.recv().await {
-                        count += 1;
-
-                        // Validate contents of the request match expected based on what was sent
-                        assert_eq!(request.invoker_id, Some(String::from(invoker_id)));
-
-                        // send response
-                        let mut response = rpc_command::executor::ResponseBuilder::default()
-                            .payload(EmptyPayload::default())
-                            .unwrap()
-                            .build()
-                            .unwrap();
-                        assert!(
-                            rpc_command::executor::ResponseBuilder::add_application_error_headers(
-                                &mut response,
-                                "345".into(),
-                                "".into()
-                            )
-                            .is_ok()
-                        );
-                        assert!(request.complete(response).await.is_ok());
-                    }
-
-                    // only the 1 expected request should occur (checks that recv() didn't return None when it shouldn't have)
-                    assert_eq!(count, 1);
-                    // cleanup should be successful
-                    assert!(executor.shutdown().await.is_ok());
-                }
-            });
-            // briefly wait after connection to let executor subscribe before sending requests
-            monitor.connected().await;
-            tokio::time::sleep(Duration::from_secs(1)).await;
-
-            // Send request with empty payload
-            let request = rpc_command::invoker::RequestBuilder::default()
-                .payload(EmptyPayload::default())
-                .unwrap()
-                .timeout(Duration::from_secs(2))
-                .build()
-                .unwrap();
-
-            let result = invoker.invoke(request).await;
-            // Validate contents of the response match expected based on what was sent
-            assert!(result.is_ok(), "result: {result:?}");
-            let response = result.unwrap();
-
-            assert_eq!(response.custom_user_data.len(), 1);
-
-            let mut app_err_code_header_count = 0;
-            let mut app_err_payload_header_count = 0;
-            for (key, value) in response.custom_user_data {
-                if key == "AppErrCode" {
-                    assert_eq!(value, "345");
-                    app_err_code_header_count += 1;
-                }
-
-                if key == "AppErrPayload" {
-                    app_err_payload_header_count += 1;
-                }
-            }
-
-            assert_eq!(app_err_code_header_count, 1);
-            assert_eq!(app_err_payload_header_count, 0);
+            let (app_error_code, app_error_payload) = response.application_error_headers();
+            assert_eq!(app_error_code, Some("345".into()));
+            assert_eq!(app_error_payload, Some("Failed543".into()));
 
             // wait for the receive_requests_task to finish to ensure any failed asserts are captured.
             assert!(receive_requests_task.await.is_ok());


### PR DESCRIPTION
Implementation of https://github.com/Azure/iot-operations-sdks/blob/main/doc/dev/adr/0021-error-modeling-headers.md in the AIO Rust RPC client.