### PR TITLE
[.NET] Add client-side validation of state store expiry time

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/LeaderElectionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/LeaderElectionClient.cs
@@ -149,6 +149,11 @@ namespace Azure.Iot.Operations.Services.LeaderElection
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
 
+            if (electionTerm.TotalMilliseconds < 1)
+            {
+                throw new ArgumentException("Election term must be at least 1 millisecond.", nameof(electionTerm));
+            }
+
             options ??= new CampaignRequestOptions();
 
             var acquireLockOptions = new AcquireLockRequestOptions()
@@ -172,6 +177,12 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (electionTerm.TotalMilliseconds < 1)
+            {
+                throw new ArgumentException("Election term must be at least 1 millisecond.", nameof(electionTerm));
+            }
+
 
             options ??= new CampaignRequestOptions();
 

--- a/dotnet/src/Azure.Iot.Operations.Services/LeasedLock/LeasedLockClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/LeasedLock/LeasedLockClient.cs
@@ -207,6 +207,11 @@ namespace Azure.Iot.Operations.Services.LeasedLock
 
             options ??= new AcquireLockRequestOptions();
 
+            if (leaseDuration.TotalMilliseconds < 1)
+            {
+                throw new ArgumentException("Lease duration must be at least 1 millisecond.", nameof(leaseDuration));
+            }
+
             StateStoreValue value = string.IsNullOrEmpty(options.SessionId)
                 ? new StateStoreValue(LockHolderName)
                 : new StateStoreValue(string.Format(ValueFormat, LockHolderName, options.SessionId));

--- a/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStorePayloadParser.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/StateStore/StateStorePayloadParser.cs
@@ -190,8 +190,15 @@ namespace Azure.Iot.Operations.Services.StateStore
 
                 if (options.ExpiryTime != null)
                 {
+                    var expiryTimeMilliseconds = options.ExpiryTime.Value.TotalMilliseconds;
+
+                    if (expiryTimeMilliseconds < 1)
+                    {
+                        throw new ArgumentException("Expiry time must be at least 1 millisecond.");
+                    }
+
                     builder.Add(Resp3Protocol.BuildBlobString(Encoding.ASCII.GetBytes("PX")));
-                    builder.Add(Resp3Protocol.BuildBlobString(Encoding.ASCII.GetBytes("" + options.ExpiryTime.Value.TotalMilliseconds)));
+                    builder.Add(Resp3Protocol.BuildBlobString(Encoding.ASCII.GetBytes("" + expiryTimeMilliseconds)));
                 }
             }
 

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeaderElection/LeaderElectionClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeaderElection/LeaderElectionClientTests.cs
@@ -412,6 +412,20 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             await leaderElectionClient.DisposeAsync();
         }
 
+        [Fact]
+        public async Task CampaignWithTooShortTermLengthThrows()
+        {
+            // arrange
+            TimeSpan expectedDuration = TimeSpan.FromMicroseconds(1);
+            Mock<LeasedLockClient> mockedLeasedLockClient = GetMockLeasedLockClient();
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            var leaderElectionClient = new LeaderElectionClient(mockedLeasedLockClient.Object);
+
+            // act/assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await leaderElectionClient.TryCampaignAsync(expectedDuration, cancellationToken: tokenSource.Token));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await leaderElectionClient.CampaignAsync(expectedDuration, cancellationToken: tokenSource.Token));
+        }
+
         private static Mock<LeasedLockClient> GetMockLeasedLockClient()
         {
             return new Mock<LeasedLockClient>();

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/LeasedLockClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/LeasedLockClientTests.cs
@@ -526,6 +526,25 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
             await leasedLockClient.DisposeAsync();
         }
 
+        [Fact]
+        public async Task AcquireLockWithTooShortLeaseDurationThrows()
+        {
+            // arrange
+            TimeSpan leaseDuration = TimeSpan.FromMicroseconds(1);
+            Mock<StateStoreClient> mockStateStoreClient = GetMockStateStoreClient();
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
+            var leasedLockClient = new LeasedLockClient(mockStateStoreClient.Object, "someLockName", "someValue");
+
+            // act/assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await leasedLockClient.TryAcquireLockAsync(
+                leaseDuration,
+                cancellationToken: tokenSource.Token));
+
+            await Assert.ThrowsAsync<ArgumentException>(async () => await leasedLockClient.AcquireLockAsync(
+                leaseDuration,
+                cancellationToken: tokenSource.Token));
+        }
+
         private static Mock<StateStoreClient> GetMockStateStoreClient()
         {
             return new Mock<StateStoreClient>();

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/StateStore/StateStoreClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/StateStore/StateStoreClientTests.cs
@@ -954,6 +954,29 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore
                     Times.Once());
         }
 
+        [Fact]
+        public async Task SetAsyncWithTooShortExpiryTimeThrows()
+        {
+            // arrange
+            ApplicationContext applicationContext = new ApplicationContext();
+            StateStoreKey key = new StateStoreKey("someKey");
+            StateStoreValue value = new StateStoreValue("someValue");
+            string clientId = "someClientId";
+
+            var mockStateStoreGeneratedClient = new Mock<IStateStoreClientStub>();
+            var mockMqttClient = GetMockMqttClient(clientId);
+
+            await using StateStoreClient stateStoreClient = new StateStoreClient(mockMqttClient.Object, mockStateStoreGeneratedClient.Object);
+
+            StateStoreSetRequestOptions setOptions = new()
+            {
+                ExpiryTime = TimeSpan.FromMicroseconds(1),
+            };
+
+            // act/assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await stateStoreClient.SetAsync(key, value, setOptions));
+        }
+
         private static Mock<IMqttPubSubClient> GetMockMqttClient(string clientId)
         {
             var mockMqttClient = new Mock<IMqttPubSubClient>();


### PR DESCRIPTION
If a user provides a sub-millisecond leader election term limit, they get a cryptic error message from the state store. This change makes it more obvious to users that they are using too short of an election term length/lease duration/state store key expiry time.

Our documentation already points out that these TimeSpan arguments only have millisecond precision.