### PR TITLE
[Rust][Services][Connector] Version Bump for 05-10-25 alpha release

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"
@@ -13,7 +13,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "0.10.0-alpha.1", path = "../azure_iot_operations_protocol", registry = "aio-sdks"  }
-azure_iot_operations_services = { version = "0.9.0-alpha.2", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "0.9.0-alpha.3", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "0.10.0-alpha.1", path = "../azure_iot_operations_mqtt", registry = "aio-sdks"  }
 chrono.workspace = true
 derive-getters.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Services"


### PR DESCRIPTION
`services`: `0.9.0-alpha.2` -> `0.9.0-alpha.3`
`connector`: `0.1.0-alpha.2`  -> `0.9.0-alpha.3`