### PR TITLE
[Rust][Services][Connector] Version Bump for 06-11-25 alpha release

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"


### PR DESCRIPTION
connector: 0.1.0-alpha.3 -> 0.1.0-alpha.4