### PR TITLE
[Rust] [Connector] Connector pass-through support for ADR discovery APIs

### DIFF
--- a/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
+++ b/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
@@ -10,12 +10,12 @@
 //!
 //! To deploy and test this example, see instructions in `rust/azure_iot_operations_connector/README.md`
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use azure_iot_operations_connector::{
     AdrConfigError, Data,
     base_connector::{
-        BaseConnector,
+        self, BaseConnector,
         managed_azure_device_registry::{
             AssetClient, AssetClientCreationObservation, DatasetClient,
             DatasetClientCreationObservation, DeviceEndpointClient,
@@ -25,6 +25,7 @@ use azure_iot_operations_connector::{
     data_processor::derived_json,
 };
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
+use azure_iot_operations_services::azure_device_registry;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,12 +49,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device_creation_observation =
         base_connector.create_device_endpoint_client_create_observation();
 
+    let adr_discovery_client = base_connector.discovery_client();
+
     // Run the Session and the Azure Device Registry operations concurrently
     let r = tokio::join!(
         run_program(device_creation_observation),
+        run_discovery(adr_discovery_client),
         base_connector.run(),
     );
     r.1?;
+    r.2?;
     Ok(())
 }
 
@@ -296,6 +301,53 @@ fn generate_asset_status(asset_client: &AssetClient) -> Result<(), AdrConfigErro
                 message: Some("asset manufacturer type is not supported".to_string()),
                 ..Default::default()
             })
+        }
+    }
+}
+
+/// NOTE: This is just showing that running discovery concurrently works. In a real world solution,
+/// this should be run in a loop and create the discovered devices through an actual disovery process
+/// instead of being hard-coded
+async fn run_discovery(
+    discovery_client: base_connector::adr_discovery::Client,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let device_name = "my-thermostat".to_string();
+
+    let discovered_inbound_endpoints = HashMap::from([(
+        "inbound_endpoint1".to_string(),
+        azure_device_registry::models::DiscoveredInboundEndpoint {
+            address: "tcp://inbound/endpoint1".to_string(),
+            endpoint_type: "rest-thermostat".to_string(),
+            supported_authentication_methods: vec![],
+            version: Some("1.0.0".to_string()),
+            last_updated_on: Some(chrono::Utc::now()),
+            additional_configuration: None,
+        },
+    )]);
+    let device = azure_device_registry::models::DiscoveredDevice {
+        attributes: HashMap::default(),
+        endpoints: Some(azure_device_registry::models::DiscoveredDeviceEndpoints {
+            inbound: discovered_inbound_endpoints,
+            outbound: None,
+        }),
+        external_device_id: None,
+        manufacturer: Some("Contoso".to_string()),
+        model: Some("Device Model".to_string()),
+        operating_system: Some("MyOS".to_string()),
+        operating_system_version: Some("1.0.0".to_string()),
+    };
+
+    match discovery_client
+        .create_or_update_discovered_device(device_name, device, "rest-thermostat".to_string())
+        .await
+    {
+        Ok(response) => {
+            log::info!("Discovered device created or updated successfully: {response:?}");
+            Ok(())
+        }
+        Err(e) => {
+            log::error!("Error creating or updating discovered device: {e}");
+            Err(Box::new(e))
         }
     }
 }

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -14,6 +14,7 @@ use managed_azure_device_registry::DeviceEndpointClientCreationObservation;
 
 use crate::filemount::connector_artifacts::ConnectorArtifacts;
 
+pub mod adr_discovery;
 pub mod managed_azure_device_registry;
 
 /// Context required to run the base connector operations
@@ -149,6 +150,16 @@ impl BaseConnector {
         &self,
     ) -> DeviceEndpointClientCreationObservation {
         DeviceEndpointClientCreationObservation::new(self.connector_context.clone())
+    }
+
+    /// Creates a handle to use the [`BaseConnector`]'s Azure Device Registry client for discovery operations.
+    pub fn discovery_client(&self) -> adr_discovery::Client {
+        adr_discovery::Client::new(self.connector_context.clone())
+    }
+
+    /// Returns a copy of the connector artifacts
+    pub fn connector_artifacts(&self) -> ConnectorArtifacts {
+        self.connector_context.connector_config.clone()
     }
 }
 

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -154,7 +154,7 @@ impl BaseConnector {
 
     /// Creates a handle to use the [`BaseConnector`]'s Azure Device Registry client for discovery operations.
     pub fn discovery_client(&self) -> adr_discovery::Client {
-        adr_discovery::Client::new(self.connector_context.clone())
+        adr_discovery::Client(self.connector_context.clone())
     }
 
     /// Returns a copy of the connector artifacts

--- a/rust/azure_iot_operations_connector/src/base_connector/adr_discovery.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/adr_discovery.rs
@@ -13,16 +13,9 @@ use azure_iot_operations_services::azure_device_registry::{
 use super::ConnectorContext;
 
 /// Client exposing Azure Device Registry Discovery operations
-pub struct Client {
-    connector_context: Arc<ConnectorContext>,
-}
+pub struct Client(pub(crate) Arc<ConnectorContext>);
 
 impl Client {
-    /// Creates a new Azure Device Registry Discovery [`Client`].
-    pub(crate) fn new(connector_context: Arc<ConnectorContext>) -> Self {
-        Client { connector_context }
-    }
-
     /// Creates or updates a discovered device in the Azure Device Registry service.
     ///
     /// If the specified discovered device does not yet exist, it will be created.
@@ -37,17 +30,17 @@ impl Client {
     /// Returns tuple containing the discovery ID and version of the discovered device.
     ///
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
+    /// [`azure_device_registry::Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
     /// if timeout is 0 or > `u32::max`.
     ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
+    /// [`azure_device_registry::Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
     /// - inbound endpoint type is invalid for the topic.
     /// - there are any underlying errors from the AIO RPC protocol.
     ///
-    /// [`struct@Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
+    /// [`azure_device_registry::Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
     /// if the device name is empty.
     ///
-    /// [`struct@Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
+    /// [`azure_device_registry::Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
     /// by the Azure Device Registry service.
     pub async fn create_or_update_discovered_device(
         &self,
@@ -55,13 +48,13 @@ impl Client {
         device: adr_models::DiscoveredDevice,
         inbound_endpoint_type: String,
     ) -> Result<(String, u64), azure_device_registry::Error> {
-        self.connector_context
+        self.0
             .azure_device_registry_client
             .create_or_update_discovered_device(
                 device_name,
                 device,
                 inbound_endpoint_type,
-                self.connector_context.default_timeout,
+                self.0.default_timeout,
             )
             .await
     }
@@ -81,17 +74,17 @@ impl Client {
     /// Returns a tuple containing the discovery ID and version of the discovered asset.
     ///
     /// # Errors
-    /// [`struct@Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
+    /// [`azure_device_registry::Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
     /// if timeout is 0 or > `u32::max`.
     ///
-    /// [`struct@Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
+    /// [`azure_device_registry::Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
     /// - device or inbound endpoint names are invalid.
     /// - there are any underlying errors from the AIO RPC protocol.
     ///
-    /// [`struct@Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
+    /// [`azure_device_registry::Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
     /// if the asset name is empty.
     ///
-    /// [`struct@Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
+    /// [`azure_device_registry::Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
     /// by the Azure Device Registry service.
     pub async fn create_or_update_discovered_asset(
         &self,
@@ -100,14 +93,14 @@ impl Client {
         asset_name: String,
         asset: adr_models::DiscoveredAsset,
     ) -> Result<(String, u64), azure_device_registry::Error> {
-        self.connector_context
+        self.0
             .azure_device_registry_client
             .create_or_update_discovered_asset(
                 device_name,
                 inbound_endpoint_name,
                 asset_name,
                 asset,
-                self.connector_context.default_timeout,
+                self.0.default_timeout,
             )
             .await
     }

--- a/rust/azure_iot_operations_connector/src/base_connector/adr_discovery.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/adr_discovery.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Client to do Azure Device Registry Discovery operations with a base connector.
+
+use std::sync::Arc;
+
+use azure_iot_operations_services::azure_device_registry::{
+    self,
+    models::{self as adr_models},
+};
+
+use super::ConnectorContext;
+
+/// Client exposing Azure Device Registry Discovery operations
+pub struct Client {
+    connector_context: Arc<ConnectorContext>,
+}
+
+impl Client {
+    /// Creates a new Azure Device Registry Discovery [`Client`].
+    pub(crate) fn new(connector_context: Arc<ConnectorContext>) -> Self {
+        Client { connector_context }
+    }
+
+    /// Creates or updates a discovered device in the Azure Device Registry service.
+    ///
+    /// If the specified discovered device does not yet exist, it will be created.
+    /// If it already exists, it will be replaced.
+    ///
+    /// # Arguments
+    /// * `device_name` - The name of the discovered device.
+    /// * `device` - The specification of the discovered device.
+    /// * `inbound_endpoint_type` - The type of the inbound endpoint.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns tuple containing the discovery ID and version of the discovered device.
+    ///
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
+    /// if timeout is 0 or > `u32::max`.
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
+    /// - inbound endpoint type is invalid for the topic.
+    /// - there are any underlying errors from the AIO RPC protocol.
+    ///
+    /// [`struct@Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
+    /// if the device name is empty.
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
+    /// by the Azure Device Registry service.
+    pub async fn create_or_update_discovered_device(
+        &self,
+        device_name: String,
+        device: adr_models::DiscoveredDevice,
+        inbound_endpoint_type: String,
+    ) -> Result<(String, u64), azure_device_registry::Error> {
+        self.connector_context
+            .azure_device_registry_client
+            .create_or_update_discovered_device(
+                device_name,
+                device,
+                inbound_endpoint_type,
+                self.connector_context.default_timeout,
+            )
+            .await
+    }
+
+    /// Creates or updates a discovered asset in the Azure Device Registry service.
+    ///
+    /// If the specified discovered asset does not yet exist, it will be created.
+    /// If it already exists, it will be replaced.
+    ///
+    /// # Arguments
+    /// * `device_name` - The name of the device.
+    /// * `inbound_endpoint_name` - The name of the inbound endpoint.
+    /// * `asset_name` - The name of the discovered asset.
+    /// * `asset` - The specification of the discovered asset.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns a tuple containing the discovery ID and version of the discovered asset.
+    ///
+    /// # Errors
+    /// [`struct@Error`] of kind [`InvalidRequestArgument`](azure_device_registry::ErrorKind::InvalidRequestArgument)
+    /// if timeout is 0 or > `u32::max`.
+    ///
+    /// [`struct@Error`] of kind [`AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if:
+    /// - device or inbound endpoint names are invalid.
+    /// - there are any underlying errors from the AIO RPC protocol.
+    ///
+    /// [`struct@Error`] of kind [`ValidationError`](azure_device_registry::ErrorKind::ValidationError)
+    /// if the asset name is empty.
+    ///
+    /// [`struct@Error`] of kind [`ServiceError`](azure_device_registry::ErrorKind::ServiceError) if an error is returned
+    /// by the Azure Device Registry service.
+    pub async fn create_or_update_discovered_asset(
+        &self,
+        device_name: String,
+        inbound_endpoint_name: String,
+        asset_name: String,
+        asset: adr_models::DiscoveredAsset,
+    ) -> Result<(String, u64), azure_device_registry::Error> {
+        self.connector_context
+            .azure_device_registry_client
+            .create_or_update_discovered_asset(
+                device_name,
+                inbound_endpoint_name,
+                asset_name,
+                asset,
+                self.connector_context.default_timeout,
+            )
+            .await
+    }
+}


### PR DESCRIPTION
This PR:
- allows connectors using the base connector to use the ADR discovery APIs in a portable manner
- adds using this to the sample for sanity testing and to show how it is portable
- adds exposure for connector artifacts as well so that connector applications don't need to create their own instance to read these fields