### PR TITLE
[.NET][Akri] Address feedback

### DIFF
--- a/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/Program.cs
+++ b/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/Program.cs
@@ -6,8 +6,6 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using EventDrivenTcpThermostatConnector;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
-
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
@@ -15,7 +13,7 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton(MqttSessionClientFactoryProvider.MqttSessionClientFactory);
         services.AddSingleton(NoMessageSchemaProvider.NoMessageSchemaProviderFactory);
         services.AddSingleton(LeaderElectionConfigurationProvider.ConnectorLeaderElectionConfigurationProviderFactory);
-        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!, connectorClientId));
+        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!));
         services.AddHostedService<EventDrivenTcpThermostatConnectorWorker>();
     })
     .Build();

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/Program.cs
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/Program.cs
@@ -6,8 +6,6 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using RestThermostatConnector;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
-
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
@@ -16,7 +14,7 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton(RestThermostatDatasetSamplerFactory.RestDatasetSourceFactoryProvider);
         services.AddSingleton(NoMessageSchemaProvider.NoMessageSchemaProviderFactory);
         services.AddSingleton(LeaderElectionConfigurationProvider.ConnectorLeaderElectionConfigurationProviderFactory);
-        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!, connectorClientId));
+        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!));
         services.AddHostedService<PollingTelemetryConnectorWorker>();
     })
     .Build();

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/RestThermostatDatasetSamplerFactory.cs
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/RestThermostatDatasetSamplerFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Connector;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace RestThermostatConnector

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/ThermostatStatusDatasetSampler.cs
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/ThermostatStatusDatasetSampler.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Connector;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using System.Net.Http.Headers;
 using System.Text;

--- a/dotnet/samples/Connectors/SqlConnector/Program.cs
+++ b/dotnet/samples/Connectors/SqlConnector/Program.cs
@@ -6,8 +6,6 @@ using Azure.Iot.Operations.Connector.ConnectorConfigurations;
 using Azure.Iot.Operations.Protocol;
 using SqlQualityAnalyzerConnectorApp;
 
-string connectorClientId = Environment.GetEnvironmentVariable(ConnectorFileMountSettings.ConnectorClientIdEnvVar) ?? throw new InvalidOperationException("No MQTT client Id configured by Akri operator");
-
 IHost host = Host.CreateDefaultBuilder(args)
 
     .ConfigureServices(services =>
@@ -17,7 +15,7 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton(SqlQualityAnalyzerDatasetSamplerFactory.DatasetSamplerFactoryProvider);
         services.AddSingleton(NoMessageSchemaProvider.NoMessageSchemaProviderFactory);
         services.AddSingleton(LeaderElectionConfigurationProvider.ConnectorLeaderElectionConfigurationProviderFactory);
-        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!, connectorClientId));
+        services.AddSingleton<IAdrClientWrapper>((services) => new AdrClientWrapper(services.GetService<ApplicationContext>()!, services.GetService<IMqttClient>()!));
         services.AddHostedService<PollingTelemetryConnectorWorker>();
     })
     .Build();

--- a/dotnet/samples/Connectors/SqlConnector/QualityAnalyzerDatasetSampler.cs
+++ b/dotnet/samples/Connectors/SqlConnector/QualityAnalyzerDatasetSampler.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 using System.Text;
 using System.Data.SqlClient;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 
 namespace SqlQualityAnalyzerConnectorApp
 {

--- a/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerDatasetSamplerFactory.cs
+++ b/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerDatasetSamplerFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Connector;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace SqlQualityAnalyzerConnectorApp

--- a/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Protocol;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
@@ -166,7 +166,7 @@ namespace Azure.Iot.Operations.Connector
             return Task.CompletedTask;
         }
 
-        private async void AssetFileChanged(object? sender, Assets.AssetChangedEventArgs e)
+        private async void AssetFileChanged(object? sender, AssetFileChangedEventArgs e)
         {
             if (e.ChangeType == AssetFileMonitorChangeType.Deleted)
             {
@@ -197,7 +197,7 @@ namespace Azure.Iot.Operations.Connector
             }
         }
 
-        private async void DeviceFileChanged(object? sender, Assets.DeviceChangedEventArgs e)
+        private async void DeviceFileChanged(object? sender, DeviceFileChangedEventArgs e)
         {
             if (e.ChangeType == AssetFileMonitorChangeType.Deleted)
             {

--- a/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
@@ -72,7 +72,6 @@ namespace Azure.Iot.Operations.Connector
             _monitor.ObserveAssets(deviceName, inboundEndpointName);
         }
 
-        //TODO "setnotificationpreference"
         /// </inheritdoc>
         public async Task UnobserveAssetsAsync(string deviceName, string inboundEndpointName, CancellationToken cancellationToken = default)
         {

--- a/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
@@ -33,12 +33,12 @@ namespace Azure.Iot.Operations.Connector
             _monitor.AssetFileChanged += AssetFileChanged;
         }
 
-        public AdrClientWrapper(IAdrServiceClient adrServiceClient)
+        public AdrClientWrapper(IAdrServiceClient adrServiceClient, IAssetFileMonitor? assetFileMonitor = null)
         {
             _client = adrServiceClient;
             _client.OnReceiveAssetUpdateEventTelemetry += AssetUpdateReceived;
             _client.OnReceiveDeviceUpdateEventTelemetry += DeviceUpdateReceived;
-            _monitor = new AssetFileMonitor();
+            _monitor = assetFileMonitor ?? new AssetFileMonitor();
             _monitor.DeviceFileChanged += DeviceFileChanged;
             _monitor.AssetFileChanged += AssetFileChanged;
         }

--- a/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
@@ -23,9 +23,9 @@ namespace Azure.Iot.Operations.Connector
 
         public event EventHandler<DeviceChangedEventArgs>? DeviceChanged;
 
-        public AdrClientWrapper(ApplicationContext applicationContext, IMqttPubSubClient mqttPubSubClient, string connectorClientId)
+        public AdrClientWrapper(ApplicationContext applicationContext, IMqttPubSubClient mqttPubSubClient)
         {
-            _client = new AdrServiceClient(applicationContext, mqttPubSubClient, connectorClientId);
+            _client = new AdrServiceClient(applicationContext, mqttPubSubClient);
             _client.OnReceiveAssetUpdateEventTelemetry += AssetUpdateReceived;
             _client.OnReceiveDeviceUpdateEventTelemetry += DeviceUpdateReceived;
             _monitor = new AssetFileMonitor();

--- a/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AdrClientWrapper.cs
@@ -33,6 +33,16 @@ namespace Azure.Iot.Operations.Connector
             _monitor.AssetFileChanged += AssetFileChanged;
         }
 
+        public AdrClientWrapper(IAdrServiceClient adrServiceClient)
+        {
+            _client = adrServiceClient;
+            _client.OnReceiveAssetUpdateEventTelemetry += AssetUpdateReceived;
+            _client.OnReceiveDeviceUpdateEventTelemetry += DeviceUpdateReceived;
+            _monitor = new AssetFileMonitor();
+            _monitor.DeviceFileChanged += DeviceFileChanged;
+            _monitor.AssetFileChanged += AssetFileChanged;
+        }
+
         /// </inheritdoc>
         public void ObserveDevices()
         {
@@ -62,6 +72,7 @@ namespace Azure.Iot.Operations.Connector
             _monitor.ObserveAssets(deviceName, inboundEndpointName);
         }
 
+        //TODO "setnotificationpreference"
         /// </inheritdoc>
         public async Task UnobserveAssetsAsync(string deviceName, string inboundEndpointName, CancellationToken cancellationToken = default)
         {
@@ -150,6 +161,24 @@ namespace Azure.Iot.Operations.Connector
         public IEnumerable<string> GetDeviceNames()
         {
             return _monitor.GetDeviceNames();
+        }
+
+        /// </inheritdoc>
+        public Task<CreateOrUpdateDiscoveredAssetResponsePayload> CreateOrUpdateDiscoveredAssetAsync(string deviceName, string inboundEndpointName, CreateOrUpdateDiscoveredAssetRequest request, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        {
+            return _client.CreateOrUpdateDiscoveredAssetAsync(deviceName, inboundEndpointName, request, commandTimeout, cancellationToken);
+        }
+
+        /// </inheritdoc>
+        public Task<CreateOrUpdateDiscoveredDeviceResponsePayload> CreateOrUpdateDiscoveredDeviceAsync(CreateOrUpdateDiscoveredDeviceRequestSchema request, string inboundEndpointType, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        {
+            return _client.CreateOrUpdateDiscoveredDeviceAsync(request, inboundEndpointType, commandTimeout, cancellationToken);
+        }
+
+        /// </inheritdoc>
+        public ValueTask DisposeAsync()
+        {
+            return _client.DisposeAsync();
         }
 
         private Task DeviceUpdateReceived(string compositeDeviceName, Device device)

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileChangedEventArgs.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileChangedEventArgs.cs
@@ -4,9 +4,9 @@
 
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
-    public class AssetChangedEventArgs : EventArgs
+    public class AssetFileChangedEventArgs : EventArgs
     {
         public string DeviceName { get; set; }
 
@@ -16,7 +16,7 @@ namespace Azure.Iot.Operations.Connector.Assets
 
         public AssetFileMonitorChangeType ChangeType { get; set; }
 
-        internal AssetChangedEventArgs(string deviceName, string inboundEndpointName, string assetName, AssetFileMonitorChangeType changeType)
+        internal AssetFileChangedEventArgs(string deviceName, string inboundEndpointName, string assetName, AssetFileMonitorChangeType changeType)
         {
             DeviceName = deviceName;
             AssetName = assetName;

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
@@ -4,7 +4,6 @@
 using Azure.Iot.Operations.Connector.Files.FileMonitor;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Text;
 
 namespace Azure.Iot.Operations.Connector.Files

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets.FileMonitor;
+using Azure.Iot.Operations.Connector.Files.FileMonitor;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
     /// <summary>
     /// This class allows for getting and monitor changes to assets and devices.
@@ -35,10 +35,10 @@ namespace Azure.Iot.Operations.Connector.Assets
         private FilesMonitor? _deviceDirectoryMonitor;
 
         /// </inheritdoc>
-        public event EventHandler<AssetChangedEventArgs>? AssetFileChanged;
+        public event EventHandler<AssetFileChangedEventArgs>? AssetFileChanged;
 
         /// </inheritdoc>
-        public event EventHandler<DeviceChangedEventArgs>? DeviceFileChanged;
+        public event EventHandler<DeviceFileChangedEventArgs>? DeviceFileChanged;
 
         public AssetFileMonitor()
         {

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitorChangeType.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitorChangeType.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
     public enum AssetFileMonitorChangeType
     {

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/DeviceFileChangedEventArgs.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/DeviceFileChangedEventArgs.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
-    public class DeviceChangedEventArgs : EventArgs
+    public class DeviceFileChangedEventArgs : EventArgs
     {
         public string DeviceName { get; set; }
 
@@ -11,7 +11,7 @@ namespace Azure.Iot.Operations.Connector.Assets
 
         public AssetFileMonitorChangeType ChangeType { get; set; }
 
-        internal DeviceChangedEventArgs(string deviceName, string inboundEndpointName, AssetFileMonitorChangeType changeType)
+        internal DeviceFileChangedEventArgs(string deviceName, string inboundEndpointName, AssetFileMonitorChangeType changeType)
         {
             DeviceName = deviceName;
             InboundEndpointName = inboundEndpointName;

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/EndpointCredentials.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/EndpointCredentials.cs
@@ -3,7 +3,7 @@
 
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
     public class EndpointCredentials
     {

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/FileUtilities.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/FileUtilities.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
     internal class FileUtilities
     {

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/FilesMonitor/FileChangedEventArgs.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/FilesMonitor/FileChangedEventArgs.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.Operations.Connector.Assets.FileMonitor
+namespace Azure.Iot.Operations.Connector.Files.FileMonitor
 {
     /// <summary>
     /// EventArgs that contains context on what change happened to which file

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/FilesMonitor/FilesMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/FilesMonitor/FilesMonitor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Iot.Operations.Connector.Assets.FileMonitor
+namespace Azure.Iot.Operations.Connector.Files.FileMonitor
 {
     internal class FilesMonitor
     {

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/IAssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/IAssetFileMonitor.cs
@@ -5,7 +5,7 @@ using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector.Files
 {
-    internal interface IAssetFileMonitor
+    public interface IAssetFileMonitor
     {
         /// <summary>
         /// Executes whenever an asset is added to or removed from an existing device after observing asset changes with <see cref="ObserveAssets(string, string)"/>.

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/IAssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/IAssetFileMonitor.cs
@@ -3,19 +3,19 @@
 
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
-namespace Azure.Iot.Operations.Connector.Assets
+namespace Azure.Iot.Operations.Connector.Files
 {
     internal interface IAssetFileMonitor
     {
         /// <summary>
         /// Executes whenever an asset is added to or removed from an existing device after observing asset changes with <see cref="ObserveAssets(string, string)"/>.
         /// </summary>
-        event EventHandler<AssetChangedEventArgs>? AssetFileChanged;
+        event EventHandler<AssetFileChangedEventArgs>? AssetFileChanged;
 
         /// <summary>
         /// Executes whenever a device file is created or deleted after observing device changes with <see cref="ObserveDevices"/>.
         /// </summary>
-        event EventHandler<DeviceChangedEventArgs>? DeviceFileChanged;
+        event EventHandler<DeviceFileChangedEventArgs>? DeviceFileChanged;
 
         /// <summary>
         /// Start observing changes to assets for the given endpoint within the given device.

--- a/dotnet/src/Azure.Iot.Operations.Connector/IAdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/IAdrClientWrapper.cs
@@ -6,7 +6,7 @@ using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector
 {
-    public interface IAdrClientWrapper
+    public interface IAdrClientWrapper : IAsyncDisposable
     {
         /// <summary>
         /// Executes whenever a asset is created, updated, or deleted.
@@ -121,6 +121,35 @@ namespace Azure.Iot.Operations.Connector
             string deviceName,
             string inboundEndpointName,
             DeviceStatus status,
+            TimeSpan? commandTimeout = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates or updates a discovered asset.
+        /// </summary>
+        /// <param name="deviceName">The name of the device.</param>
+        /// <param name="inboundEndpointName">The name of the inbound endpoint.</param>
+        /// <param name="request">The request containing discovered asset creation parameters.</param>
+        /// <param name="commandTimeout">Optional timeout for the command.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation, containing the response for the created discovered asset.</returns>
+        Task<CreateOrUpdateDiscoveredAssetResponsePayload> CreateOrUpdateDiscoveredAssetAsync(string deviceName,
+            string inboundEndpointName,
+            CreateOrUpdateDiscoveredAssetRequest request,
+            TimeSpan? commandTimeout = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates or updates a discovered device.
+        /// </summary>
+        /// <param name="request">The request containing discovered device endpoint profile creation parameters.</param>
+        /// <param name="inboundEndpointType"></param>
+        /// <param name="commandTimeout">Optional timeout for the command.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation, containing the response for the created discovered device endpoint profile.</returns>
+        Task<CreateOrUpdateDiscoveredDeviceResponsePayload> CreateOrUpdateDiscoveredDeviceAsync(
+            CreateOrUpdateDiscoveredDeviceRequestSchema request,
+            string inboundEndpointType,
             TimeSpan? commandTimeout = null,
             CancellationToken cancellationToken = default);
     }

--- a/dotnet/src/Azure.Iot.Operations.Connector/IAdrClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/IAdrClientWrapper.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector

--- a/dotnet/src/Azure.Iot.Operations.Connector/IDatasetSamplerFactory.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/IDatasetSamplerFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector

--- a/dotnet/src/Azure.Iot.Operations.Connector/PollingTelemetryConnectorWorker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/PollingTelemetryConnectorWorker.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright(c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Protocol;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using Microsoft.Extensions.Logging;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AdrServiceClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AdrServiceClient.cs
@@ -16,7 +16,7 @@ using NotificationResponse = Azure.Iot.Operations.Services.AssetAndDeviceRegistr
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry;
 
-public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, string clientId) : IAdrServiceClient
+public class AdrServiceClient : IAdrServiceClient
 {
     private const string _connectorClientIdTokenKey = "connectorClientId";
     private const string _discoveryClientIdTokenKey = "discoveryClientId";
@@ -25,11 +25,24 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
     private const string _inboundEpTypeTokenKey = "inboundEndpointType";
     private const byte _dummyByte = 1;
     private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
-    private readonly AdrBaseServiceClientStub _adrBaseServiceClient = new(applicationContext, mqttClient);
-    private readonly DeviceDiscoveryServiceClientStub _deviceDiscoveryServiceClient = new(applicationContext, mqttClient);
+    private readonly string _connectorClientId;
+    private readonly IMqttPubSubClient _mqttClient;
+    private readonly ApplicationContext _applicationContext;
+    private readonly AdrBaseServiceClientStub _adrBaseServiceClient;
+    private readonly DeviceDiscoveryServiceClientStub _deviceDiscoveryServiceClient;
     private readonly ConcurrentDictionary<string, byte> _observedAssets = new();
     private readonly ConcurrentDictionary<string, byte> _observedEndpoints = new();
     private bool _disposed;
+
+    public AdrServiceClient(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
+    {
+        _applicationContext = applicationContext;
+        _mqttClient = mqttClient;
+        _connectorClientId = mqttClient.ClientId ?? throw new ArgumentException("Must provide an MQTT client Id in the IMqttPubSubClient");
+
+        _adrBaseServiceClient = new(_applicationContext, _mqttClient);
+        _deviceDiscoveryServiceClient = new(_applicationContext, _mqttClient);
+    }
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
@@ -56,7 +69,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -92,7 +105,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -131,7 +144,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -158,7 +171,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -192,7 +205,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -222,7 +235,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -254,7 +267,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -283,7 +296,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -319,7 +332,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _connectorClientIdTokenKey, clientId },
+            { _connectorClientIdTokenKey, _connectorClientId },
             { _deviceNameTokenKey, deviceName },
             { _endpointNameTokenKey, inboundEndpointName }
         };
@@ -350,7 +363,7 @@ public class AdrServiceClient(ApplicationContext applicationContext, IMqttPubSub
 
         Dictionary<string, string> additionalTopicTokenMap = new()
         {
-            { _discoveryClientIdTokenKey, clientId },
+            { _discoveryClientIdTokenKey, _connectorClientId },
             { _inboundEpTypeTokenKey, inboundEndpointType },
         };
 

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AdrServiceClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AdrServiceClient.cs
@@ -3,16 +3,13 @@
 
 using System.Collections.Concurrent;
 using Azure.Iot.Operations.Protocol;
-using Azure.Iot.Operations.Protocol.RPC;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.AdrBaseService;
-using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.DeviceDiscoveryService;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using AkriServiceErrorException = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.AdrBaseService.AkriServiceErrorException;
 using Asset = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models.Asset;
 using AssetStatus = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models.AssetStatus;
 using Device = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models.Device;
 using DeviceStatus = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models.DeviceStatus;
-using NotificationResponse = Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models.NotificationResponse;
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry;
 

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrServiceClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrServiceClient.cs
@@ -18,7 +18,7 @@ public interface IAdrServiceClient : IAsyncDisposable
     Task<SetNotificationPreferenceForDeviceUpdatesResponsePayload> SetNotificationPreferenceForDeviceUpdatesAsync(
         string deviceName,
         string inboundEndpointName,
-        Models.NotificationPreference notificationPreference,
+        NotificationPreference notificationPreference,
         TimeSpan? commandTimeout = null,
         CancellationToken cancellationToken = default);
 
@@ -35,7 +35,7 @@ public interface IAdrServiceClient : IAsyncDisposable
         string deviceName,
         string inboundEndpointName,
         string assetName,
-        Models.NotificationPreference notificationPreference,
+        NotificationPreference notificationPreference,
         TimeSpan? commandTimeout = null,
         CancellationToken cancellationToken = default);
 
@@ -146,7 +146,7 @@ public interface IAdrServiceClient : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates or updates a discovered device endpoint profile.
+    /// Creates or updates a discovered device.
     /// </summary>
     /// <param name="request">The request containing discovered device endpoint profile creation parameters.</param>
     /// <param name="inboundEndpointType"></param>
@@ -161,13 +161,13 @@ public interface IAdrServiceClient : IAsyncDisposable
 
     /// <summary>
     /// Event triggered when a device update telemetry event is received.
-    /// NOTE: This event starts triggering after the call to ObserveDeviceEndpointUpdatesAsync.
+    /// NOTE: This event starts triggering after the call to <see cref="SetNotificationPreferenceForDeviceUpdatesAsync(string, string, NotificationPreference, TimeSpan?, CancellationToken)"/>.
     /// </summary>
     event Func<string, Device, Task>? OnReceiveDeviceUpdateEventTelemetry;
 
     /// <summary>
     /// Event triggered when an asset update telemetry event is received.
-    /// NOTE: This event starts triggering after the call to ObserveAssetUpdatesAsync.
+    /// NOTE: This event starts triggering after the call to <see cref="SetNotificationPreferenceForAssetUpdatesAsync(string, string, string, NotificationPreference, TimeSpan?, CancellationToken)"/>.
     /// </summary>
     event Func<string, Asset, Task>? OnReceiveAssetUpdateEventTelemetry;
 }

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/AssetFileMonitorTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/AssetFileMonitorTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Xunit;
 
 namespace Azure.Iot.Operations.Connector.UnitTests
@@ -58,7 +58,7 @@ namespace Azure.Iot.Operations.Connector.UnitTests
 
             try
             {
-                TaskCompletionSource<Assets.DeviceChangedEventArgs> deviceChangedEventArgsTcs = new();
+                TaskCompletionSource<DeviceFileChangedEventArgs> deviceChangedEventArgsTcs = new();
                 assetFileMonitor.DeviceFileChanged += (sender, args) =>
                 {
                     deviceChangedEventArgsTcs.TrySetResult(args);
@@ -72,9 +72,9 @@ namespace Azure.Iot.Operations.Connector.UnitTests
                 Assert.Equal("SomeInboundEndpointName", deviceChangeArgs.InboundEndpointName);
                 Assert.Equal(AssetFileMonitorChangeType.Created, deviceChangeArgs.ChangeType);
 
-                TaskCompletionSource<Assets.AssetChangedEventArgs> asset1ChangedEventArgsTcs = new();
-                TaskCompletionSource<Assets.AssetChangedEventArgs> asset2ChangedEventArgsTcs = new();
-                TaskCompletionSource<Assets.AssetChangedEventArgs> assetChangedEventArgsTcs = new();
+                TaskCompletionSource<AssetFileChangedEventArgs> asset1ChangedEventArgsTcs = new();
+                TaskCompletionSource<AssetFileChangedEventArgs> asset2ChangedEventArgsTcs = new();
+                TaskCompletionSource<AssetFileChangedEventArgs> assetChangedEventArgsTcs = new();
                 assetFileMonitor.AssetFileChanged += (sender, args) =>
                 {
                     if (args.AssetName.Equals("SomeAssetName1"))

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAdrClientWrapper.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAdrClientWrapper.cs
@@ -78,5 +78,20 @@ namespace Azure.Iot.Operations.Connector.UnitTests
         {
             return mockClientWrapper.Object.UpdateDeviceStatusAsync(deviceName, inboundEndpointName, status, commandTimeout, cancellationToken);
         }
+
+        public Task<CreateOrUpdateDiscoveredAssetResponsePayload> CreateOrUpdateDiscoveredAssetAsync(string deviceName, string inboundEndpointName, CreateOrUpdateDiscoveredAssetRequest request, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        {
+            return mockClientWrapper.Object.CreateOrUpdateDiscoveredAssetAsync(deviceName, inboundEndpointName, request, commandTimeout, cancellationToken);
+        }
+
+        public Task<CreateOrUpdateDiscoveredDeviceResponsePayload> CreateOrUpdateDiscoveredDeviceAsync(CreateOrUpdateDiscoveredDeviceRequestSchema request, string inboundEndpointType, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        {
+            return mockClientWrapper.Object.CreateOrUpdateDiscoveredDeviceAsync(request, inboundEndpointType, commandTimeout, cancellationToken);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAdrClientWrapper.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAdrClientWrapper.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 using Moq;
 

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAssetFileMonitor.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockAssetFileMonitor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector.UnitTests
@@ -13,8 +13,8 @@ namespace Azure.Iot.Operations.Connector.UnitTests
 
         private bool _isObservingDevices = false;
 
-        public event EventHandler<Assets.AssetChangedEventArgs>? AssetFileChanged;
-        public event EventHandler<Assets.DeviceChangedEventArgs>? DeviceFileChanged;
+        public event EventHandler<AssetFileChangedEventArgs>? AssetFileChanged;
+        public event EventHandler<DeviceFileChangedEventArgs>? DeviceFileChanged;
 
         public void SimulateNewDeviceCreated(string deviceName, string inboundEndpointName)
         {

--- a/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockDatasetSamplerFactory.cs
+++ b/dotnet/test/Azure.Iot.Operations.Connector.UnitTests/MockDatasetSamplerFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Iot.Operations.Connector.Assets;
+using Azure.Iot.Operations.Connector.Files;
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
 
 namespace Azure.Iot.Operations.Connector.UnitTests

--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/AdrServiceClientIntegrationTests.cs
@@ -33,9 +33,9 @@ public class AdrServiceClientIntegrationTests
     public async Task CanGetDeviceAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         // Act
         var device = await client.GetDeviceAsync(TestDevice_1_Name, "my-rest-endpoint");
@@ -52,9 +52,9 @@ public class AdrServiceClientIntegrationTests
     public async Task GetDeviceThrowsAkriServiceErrorExceptionWhenDeviceNotFoundAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<AkriServiceErrorException>(
@@ -70,9 +70,9 @@ public class AdrServiceClientIntegrationTests
     {
         // Arrange
         var expectedTime = DateTime.Parse("2023-10-01T00:00:00Z");
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var status = new DeviceStatus
         {
@@ -104,9 +104,9 @@ public class AdrServiceClientIntegrationTests
     public async Task TriggerDeviceTelemetryEventWhenObservedAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var eventReceived = new TaskCompletionSource<bool>();
         client.OnReceiveDeviceUpdateEventTelemetry += (source, _) =>
@@ -138,9 +138,9 @@ public class AdrServiceClientIntegrationTests
     public async Task DoNotTriggerTelemetryEventAfterUnobserveDeviceAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var firstEventReceived = new TaskCompletionSource<bool>();
         var secondEventReceived = new TaskCompletionSource<bool>();
@@ -205,9 +205,9 @@ public class AdrServiceClientIntegrationTests
     public async Task CanGetAssetAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         // Act
         var asset = await client.GetAssetAsync(TestDevice_1_Name, TestEndpointName, TestAssetName);
@@ -223,9 +223,9 @@ public class AdrServiceClientIntegrationTests
     public async Task CanUpdateAssetStatusAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var expectedTime = DateTime.UtcNow;
 
@@ -244,9 +244,9 @@ public class AdrServiceClientIntegrationTests
     public async Task TriggerAssetTelemetryEventWhenObservedAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var eventReceived = new TaskCompletionSource<bool>();
         client.OnReceiveAssetUpdateEventTelemetry += (source, _) =>
@@ -278,9 +278,9 @@ public class AdrServiceClientIntegrationTests
     public async Task DoNotTriggerTelemetryEventAfterUnobserveAssetAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var firstEventReceived = new TaskCompletionSource<bool>();
         var secondEventReceived = new TaskCompletionSource<bool>();
@@ -346,9 +346,9 @@ public class AdrServiceClientIntegrationTests
     public async Task CanCreateOrUpdateDiscoveredAssetAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var request = CreateCreateDetectedAssetRequest();
 
@@ -365,9 +365,9 @@ public class AdrServiceClientIntegrationTests
     public async Task CanCreateOrUpdateDiscoveredDeviceAsync()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var request = CreateCreateDiscoveredDeviceRequest();
 
@@ -386,9 +386,9 @@ public class AdrServiceClientIntegrationTests
     public async Task ReceiveTelemetryForProperDeviceUpdateWhenMultipleDevicesUpdated()
     {
         // Arrange
-        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync(ConnectorClientId);
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient, ConnectorClientId);
+        await using AdrServiceClient client = new(applicationContext, mqttClient);
 
         var receivedEvents = new Dictionary<string, Device>();
         var eventReceived = new TaskCompletionSource<bool>();

--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/ClientFactory.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/ClientFactory.cs
@@ -5,7 +5,6 @@ using Azure.Iot.Operations.Protocol.Connection;
 using Azure.Iot.Operations.Mqtt.Session;
 using Azure.Iot.Operations.Protocol.Retry;
 using System.Diagnostics;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Azure.Iot.Operations.Services.IntegrationTest;
 
@@ -14,7 +13,7 @@ public class ClientFactory
     public static async Task<MqttSessionClient> CreateAndConnectClientAsyncFromEnvAsync(string clientId = "")
     {
         var mcs = CreateMqttConnectionSettings();
-        if (clientId.IsNullOrEmpty())
+        if (string.IsNullOrEmpty(clientId))
         {
             mcs.ClientId += Guid.NewGuid().ToString();
         }

--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/ClientFactory.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/ClientFactory.cs
@@ -5,15 +5,24 @@ using Azure.Iot.Operations.Protocol.Connection;
 using Azure.Iot.Operations.Mqtt.Session;
 using Azure.Iot.Operations.Protocol.Retry;
 using System.Diagnostics;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Azure.Iot.Operations.Services.IntegrationTest;
 
 public class ClientFactory
 {
-    public static async Task<MqttSessionClient> CreateAndConnectClientAsyncFromEnvAsync()
+    public static async Task<MqttSessionClient> CreateAndConnectClientAsyncFromEnvAsync(string clientId = "")
     {
         var mcs = CreateMqttConnectionSettings();
-        mcs.ClientId += Guid.NewGuid();
+        if (clientId.IsNullOrEmpty())
+        {
+            mcs.ClientId += Guid.NewGuid().ToString();
+        }
+        else
+        {
+            mcs.ClientId = clientId;
+        }
+
         MqttSessionClientOptions sessionClientOptions = new MqttSessionClientOptions()
         {
             // This retry policy prevents the client from retrying forever

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/AssetAndDeviceRegistry/AdrClientServiceTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/AssetAndDeviceRegistry/AdrClientServiceTests.cs
@@ -16,8 +16,9 @@ public class AdrClientServiceTests
     {
         // Arrange
         Mock<IMqttPubSubClient> mqttClient = new();
+        mqttClient.Setup(mock => mock.ClientId).Returns("ConnectorClientId");
         ApplicationContext applicationContext = new();
-        AdrServiceClient client = new(applicationContext, mqttClient.Object, "ConnectorClientId");
+        AdrServiceClient client = new(applicationContext, mqttClient.Object);
 
         // Act - Dispose
         await client.DisposeAsync();
@@ -34,8 +35,9 @@ public class AdrClientServiceTests
     {
         // Arrange
         Mock<IMqttPubSubClient> mqttClient = new();
+        mqttClient.Setup(mock => mock.ClientId).Returns("ConnectorClientId");
         ApplicationContext applicationContext = new();
-        await using AdrServiceClient client = new(applicationContext, mqttClient.Object, "ConnectorClientId");
+        await using AdrServiceClient client = new(applicationContext, mqttClient.Object);
 
         CancellationTokenSource cts = new CancellationTokenSource();
         cts.Cancel();


### PR DESCRIPTION
@marcschier provided some feedback offline:

- Fix AdrClientWrapper not exposing the CreateOrUpdateDevice/Asset APIs that are present in ADR service client
- Allow user to instantiate AdrClientWrapper with user-provided IAdrServiceClient instance (rather than creating one for them from MQTT client)
  - Also allow user to pass in an AssetFileMonitor instance as well since they are hitting some issues with our default implementation
- Differentiate/rename Device/Asset change event arg classes: 1 set for "File changed" and 1 set for "Asset/Device changed"
  - Rename "Azure.Iot.Operations.Connector.Assets" namespace to "Azure.Iot.Operations.Connector.Files" to accentuate this as well
- Make AdrServiceClient take connector client Id from MQTT client rather than asking for it as a param at ctor time 
- Make AdrClientWrapper IAsyncDisposable since the IAdrServiceClient it holds is IAsyncDisposable