### PR TITLE
[Rust][Services] Hashable key in Dispatcher

### DIFF
--- a/rust/azure_iot_operations_services/src/common.rs
+++ b/rust/azure_iot_operations_services/src/common.rs
@@ -78,10 +78,7 @@ pub mod dispatcher {
         pub fn register_receiver(&self, receiver_id: H) -> Result<Receiver<T>, RegisterError> {
             let mut tx_map = self.tx_map.lock().unwrap();
             if tx_map.get(&receiver_id).is_some() {
-                return Err(RegisterError::AlreadyRegistered(format!(
-                    "{:?}",
-                    receiver_id
-                )));
+                return Err(RegisterError::AlreadyRegistered(format!("{receiver_id:?}")));
             }
             let (tx, rx) = unbounded_channel();
             tx_map.insert(receiver_id, tx);
@@ -110,7 +107,7 @@ pub mod dispatcher {
             } else {
                 Err(DispatchError {
                     data: message,
-                    kind: DispatchErrorKind::NotFound(format!("{:?}", receiver_id)),
+                    kind: DispatchErrorKind::NotFound(format!("{receiver_id:?}")),
                 })
             }
         }

--- a/rust/azure_iot_operations_services/src/common.rs
+++ b/rust/azure_iot_operations_services/src/common.rs
@@ -10,7 +10,7 @@
 pub mod dispatcher {
     //! Provides a convenience for dispatching to a receiver based on an ID.
 
-    use std::{collections::HashMap, sync::Mutex};
+    use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Mutex};
 
     use thiserror::Error;
     use tokio::sync::mpsc::{
@@ -54,11 +54,17 @@ pub mod dispatcher {
     }
     /// Dispatches messages to receivers based on ID
     #[derive(Default)]
-    pub struct Dispatcher<T> {
-        tx_map: Mutex<HashMap<String, UnboundedSender<T>>>,
+    pub struct Dispatcher<T, H>
+    where
+        H: Eq + Hash + Debug,
+    {
+        tx_map: Mutex<HashMap<H, UnboundedSender<T>>>,
     }
 
-    impl<T> Dispatcher<T> {
+    impl<T, H> Dispatcher<T, H>
+    where
+        H: Eq + Hash + Debug,
+    {
         /// Returns a new instance of Dispatcher
         pub fn new() -> Self {
             Self {
@@ -69,10 +75,13 @@ pub mod dispatcher {
         /// Registers a new receiver with the given ID, returning the new receiver.
         ///
         /// Returns an error if a receiver with the same ID is already registered
-        pub fn register_receiver(&self, receiver_id: String) -> Result<Receiver<T>, RegisterError> {
+        pub fn register_receiver(&self, receiver_id: H) -> Result<Receiver<T>, RegisterError> {
             let mut tx_map = self.tx_map.lock().unwrap();
             if tx_map.get(&receiver_id).is_some() {
-                return Err(RegisterError::AlreadyRegistered(receiver_id));
+                return Err(RegisterError::AlreadyRegistered(format!(
+                    "{:?}",
+                    receiver_id
+                )));
             }
             let (tx, rx) = unbounded_channel();
             tx_map.insert(receiver_id, tx);
@@ -84,7 +93,7 @@ pub mod dispatcher {
         ///
         /// Returns true if a receiver was unregistered, returns false if the provided ID
         /// was not associated with a registered receiver.
-        pub fn unregister_receiver(&self, receiver_id: &str) -> bool {
+        pub fn unregister_receiver(&self, receiver_id: &H) -> bool {
             self.tx_map.lock().unwrap().remove(receiver_id).is_some()
         }
 
@@ -95,13 +104,13 @@ pub mod dispatcher {
         }
 
         /// Dispatches a message to the receiver associated with the provided ID.
-        pub fn dispatch(&self, receiver_id: &str, message: T) -> Result<(), DispatchError<T>> {
+        pub fn dispatch(&self, receiver_id: &H, message: T) -> Result<(), DispatchError<T>> {
             if let Some(tx) = self.tx_map.lock().unwrap().get(receiver_id) {
                 Ok(tx.send(message)?)
             } else {
                 Err(DispatchError {
                     data: message,
-                    kind: DispatchErrorKind::NotFound(receiver_id.to_string()),
+                    kind: DispatchErrorKind::NotFound(format!("{:?}", receiver_id)),
                 })
             }
         }

--- a/rust/azure_iot_operations_services/src/state_store/client.rs
+++ b/rust/azure_iot_operations_services/src/state_store/client.rs
@@ -72,7 +72,8 @@ where
     C::PubReceiver: Send + Sync,
 {
     invoker: rpc_command::Invoker<state_store::resp3::Request, state_store::resp3::Response, C>,
-    notification_dispatcher: Arc<Dispatcher<(state_store::KeyNotification, Option<AckToken>)>>,
+    notification_dispatcher:
+        Arc<Dispatcher<(state_store::KeyNotification, Option<AckToken>), String>>,
     shutdown_notifier: Arc<Notify>,
 }
 
@@ -574,7 +575,9 @@ where
     async fn receive_key_notification_loop(
         shutdown_notifier: Arc<Notify>,
         mut receiver: telemetry::Receiver<state_store::resp3::Operation, C>,
-        notification_dispatcher: Arc<Dispatcher<(state_store::KeyNotification, Option<AckToken>)>>,
+        notification_dispatcher: Arc<
+            Dispatcher<(state_store::KeyNotification, Option<AckToken>), String>,
+        >,
         connection_monitor: SessionConnectionMonitor,
     ) {
         let mut shutdown_attempt_count = 0;


### PR DESCRIPTION
Currently this PR only serves the main branch where only the state store client is present. 

More changes will be present on ADR client. There is a specific case where we need clone on the H (key) as well.
The resolution I got there is to do.  
```rust
       /// Returns all currently tracked receiver ids
        /// Note: This method requires Clone for H since it needs to return owned values
        pub fn get_all_receiver_ids(&self) -> Vec<H> 
        where
            H: Clone,
        {
            let tx_map = self.tx_map.lock().unwrap();
            tx_map.keys().cloned().collect()
        }
```