### PR TITLE
[Rust] [Connector] Update log level to be parsed as a string

### DIFF
--- a/rust/azure_iot_operations_connector/src/filemount/connector_artifacts.rs
+++ b/rust/azure_iot_operations_connector/src/filemount/connector_artifacts.rs
@@ -426,24 +426,8 @@ pub struct Diagnostics {
 /// Logging information
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Logs {
-    /// Level to log at
-    pub level: LogLevel,
-}
-
-/// Represents the logging level
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    /// Info logging
-    Info,
-    /// Debug logging
-    Debug,
-    /// Warn logging
-    Warn,
-    /// Error logging
-    Error,
-    /// Trace logging
-    Trace,
+    /// The log level. Examples - 'debug', 'info', 'warn', 'error', 'trace'.
+    pub level: String,
 }
 
 /// Helper function to get an environment variable as a string.

--- a/rust/azure_iot_operations_connector/tests/artifact_tests.rs
+++ b/rust/azure_iot_operations_connector/tests/artifact_tests.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use azure_iot_operations_connector::filemount::connector_artifacts::{
-    ConnectorArtifacts, LogLevel, Protocol, TlsMode,
+    ConnectorArtifacts, Protocol, TlsMode,
 };
 use azure_iot_operations_mqtt::session::{Session, SessionOptionsBuilder};
 use std::path::PathBuf;
@@ -69,7 +69,7 @@ fn local_connector_artifacts_tls() {
             // NOTE: These values come from the DIAGNOSTICS file
             assert!(cc.diagnostics.is_some());
             let diagnostics = cc.diagnostics.as_ref().unwrap();
-            assert!(matches!(diagnostics.logs.level, LogLevel::Trace));
+            assert_eq!(diagnostics.logs.level, "trace".to_string());
 
             // --- Convert the ConnectorConfiguration to MqttConnectionSettings ---
             let conversion_result = artifacts.to_mqtt_connection_settings("-id_suffix");
@@ -135,7 +135,7 @@ fn local_connector_artifacts_no_tls() {
             // NOTE: These values come from the DIAGNOSTICS file
             assert!(cc.diagnostics.is_some());
             let diagnostics = cc.diagnostics.as_ref().unwrap();
-            assert!(matches!(diagnostics.logs.level, LogLevel::Trace));
+            assert_eq!(diagnostics.logs.level, "trace".to_string());
 
             // --- Convert the ConnectorConfiguration to MqttConnectionSettings ---
             let conversion_result = artifacts.to_mqtt_connection_settings("-id_suffix");


### PR DESCRIPTION
This PR:
- stops parsing log level as an enum, since it should be a free-form string to allow specifying different log levels for different modules

Parsing this out in a useful way will come as part of other logging PRs