### PR TITLE
[.NET][Akri] Expose leader election client to connector user

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/AssetAvailableEventArgs.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AssetAvailableEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
+using Azure.Iot.Operations.Services.LeaderElection;
 
 namespace Azure.Iot.Operations.Connector
 {
@@ -26,13 +27,28 @@ namespace Azure.Iot.Operations.Connector
         /// </summary>
         public Asset Asset { get; }
 
-        internal AssetAvailableEventArgs(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset)
+        /// <summary>
+        /// The leader election client used by this connector. It is null if and only if this connector isn't configured to do leader election.
+        /// </summary>
+        /// <remarks>
+        /// When configured to use leader election, <see cref="ConnectorWorker"/> automatically subscribes to notifications about leadership position
+        /// changes using this client and will automatically trigger the cancellation token provided in <see cref="ConnectorWorker.WhileAssetIsAvailable"/>
+        /// if it detects that this connector is no longer the leader.
+        ///
+        /// This client can still be used within <see cref="ConnectorWorker.WhileAssetIsAvailable"/> to check the leadership position manually, though.
+        ///
+        /// Users should not attempt to close or dispose this client as the connector will do that for you when appropriate.
+        /// </remarks>
+        public ILeaderElectionClient? LeaderElectionClient { get; }
+
+        internal AssetAvailableEventArgs(string deviceName, Device device, string inboundEndpointName, string assetName, Asset asset, ILeaderElectionClient? leaderElectionClient)
         {
             DeviceName = deviceName;
             Device = device;
             InboundEndpointName = inboundEndpointName;
             AssetName = assetName;
             Asset = asset;
+            LeaderElectionClient = leaderElectionClient;
         }
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/ConnectorWorker.cs
@@ -404,7 +404,7 @@ namespace Azure.Iot.Operations.Connector
                         {
                             try
                             {
-                                await WhileDeviceIsAvailable.Invoke(new(args.Device, args.InboundEndpointName), deviceTaskCancellationTokenSource.Token);
+                                await WhileDeviceIsAvailable.Invoke(new(args.Device, args.InboundEndpointName, _leaderElectionClient), deviceTaskCancellationTokenSource.Token);
                             }
                             catch (OperationCanceledException)
                             {
@@ -486,13 +486,13 @@ namespace Azure.Iot.Operations.Connector
                 return;
             }
 
-            if (asset == null || asset.Datasets == null)
+            if (asset.Datasets == null)
             {
                 _logger.LogInformation($"Asset with name {assetName} has no datasets to sample");
             }
             else
             {
-                foreach (var dataset in asset!.Datasets!)
+                foreach (var dataset in asset.Datasets)
                 {
                     // This may register a message schema that has already been uploaded, but the schema registry service is idempotent
                     var datasetMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, dataset.Name!, dataset);
@@ -521,7 +521,7 @@ namespace Azure.Iot.Operations.Connector
                 }
             }
 
-            if (asset == null || asset!.Events == null)
+            if (asset.Events == null)
             {
                 _logger.LogInformation($"Asset with name {assetName} has no events to listen for");
             }
@@ -530,7 +530,7 @@ namespace Azure.Iot.Operations.Connector
                 foreach (var assetEvent in asset!.Events)
                 {
                     // This may register a message schema that has already been uploaded, but the schema registry service is idempotent
-                    var eventMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, assetEvent!.Name!, assetEvent);
+                    var eventMessageSchema = await _messageSchemaProviderFactory.GetMessageSchemaAsync(device, asset, assetEvent.Name, assetEvent);
                     if (eventMessageSchema != null)
                     {
                         try
@@ -566,7 +566,7 @@ namespace Azure.Iot.Operations.Connector
                 {
                     try
                     {
-                        await WhileAssetIsAvailable.Invoke(new(deviceName, device, inboundEndpointName, assetName, asset!), assetTaskCancellationTokenSource.Token);
+                        await WhileAssetIsAvailable.Invoke(new(deviceName, device, inboundEndpointName, assetName, asset, _leaderElectionClient), assetTaskCancellationTokenSource.Token);
                     }
                     catch (OperationCanceledException)
                     {

--- a/dotnet/src/Azure.Iot.Operations.Connector/DeviceAvailableEventArgs.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/DeviceAvailableEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Models;
+using Azure.Iot.Operations.Services.LeaderElection;
 
 namespace Azure.Iot.Operations.Connector
 {
@@ -11,10 +12,25 @@ namespace Azure.Iot.Operations.Connector
 
         public string InboundEndpointName { get; }
 
-        internal DeviceAvailableEventArgs(Device device, string inboundEndpointName)
+        /// <summary>
+        /// The leader election client used by this connector. It is null if and only if this connector isn't configured to do leader election.
+        /// </summary>
+        /// <remarks>
+        /// When configured to use leader election, <see cref="ConnectorWorker"/> automatically subscribes to notifications about leadership position
+        /// changes using this client and will automatically trigger the cancellation token provided in <see cref="ConnectorWorker.WhileDeviceIsAvailable"/>
+        /// if it detects that this connector is no longer the leader.
+        ///
+        /// This client can still be used within <see cref="ConnectorWorker.WhileDeviceIsAvailable"/> to check the leadership position manually, though.
+        ///
+        /// Users should not attempt to close or dispose this client as the connector will do that for you when appropriate.
+        /// </remarks>
+        public ILeaderElectionClient? LeaderElectionClient { get; }
+
+        internal DeviceAvailableEventArgs(Device device, string inboundEndpointName, ILeaderElectionClient? leaderElectionClient)
         {
             Device = device;
             InboundEndpointName = inboundEndpointName;
+            LeaderElectionClient = leaderElectionClient;
         }
     }
 }


### PR DESCRIPTION
Some users have expressed interest in checking the leadership position during our "WhileAsset/DeviceIsAvailable" callbacks on top of how connectors already listen for leadership position changes.