### PR TITLE
[Rust][Connector] Re-enable validation of `AZURE_EXTENSION_RESOURCEID`

### DIFF
--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -927,7 +927,7 @@ mod tests {
         );
     }
 
-    #[test_case("AZURE_EXTENSION_RESOURCEID")] //TODO: re-enable test
+    #[test_case("AZURE_EXTENSION_RESOURCEID")]
     #[test_case("CONNECTOR_ID")]
     #[test_case("CONNECTOR_NAMESPACE")]
     #[test_case("CONNECTOR_CONFIGURATION_MOUNT_PATH")]


### PR DESCRIPTION
All valid clusters should now have this variable deployed