### PR TITLE
Fix inconsistency in naming of connector metadata field

### DIFF
--- a/doc/akri_connector/connector-metadata-schema.json
+++ b/doc/akri_connector/connector-metadata-schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "aioConnectorMetadataSchemaVersion": "1.0-preview",
+  "aioConnectorMetadataSchemaVersion": "2.0-preview",
   "properties": {
     "aioConnectorMetadataSchemaVersion": {
       "type": "string",
       "description": "The version of AIO connector metadata schema that this connector metadata file adheres to.",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
-      "default": "1.0-preview"
+      "default": "2.0-preview"
     },
     "name": {
       "type": "string",
@@ -235,7 +235,7 @@
                 "eventConfigurationSchema": {
                   "$ref": "http://json-schema.org/draft-07/schema#"
                 },
-                "eventDataPointConfigSchema": {
+                "eventDataPointConfigurationSchema": {
                   "$ref": "http://json-schema.org/draft-07/schema#"
                 },
                 "streamConfigurationSchema": {

--- a/doc/akri_connector/example-connector-metadata.json
+++ b/doc/akri_connector/example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "1.0-preview",
+  "aioConnectorMetadataSchemaVersion": "2.0-preview",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",

--- a/doc/akri_connector/minimal-example-connector-metadata.json
+++ b/doc/akri_connector/minimal-example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "1.0-preview",
+  "aioConnectorMetadataSchemaVersion": "2.0-preview",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",


### PR DESCRIPTION
All the other fields use the full "configuration"

Bumping the preview schema version since this is a breaking change