### PR TITLE
[Rust][Protocol] Fix lagging receiver on concurrent invokes

### DIFF
--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -12,8 +12,10 @@ use tokio::{
         Mutex, Notify,
         broadcast::{Sender, error::RecvError},
     },
-    task, time,
+    task::{self, JoinHandle},
+    time,
 };
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::common::user_properties::{PARTITION_KEY, validate_invoker_user_properties};
@@ -925,6 +927,8 @@ where
         &self,
         mut request: Request<TReq>,
     ) -> Result<Response<TResp>, AIOProtocolError> {
+        let cancellation_token = CancellationToken::new();
+        let _drop_guard = cancellation_token.clone().drop_guard();
         // Validate parameters. Custom user data, timeout, and payload serialization have already been validated in RequestBuilder
         // Validate message expiry interval
         let message_expiry_interval: u32 = match request.timeout.as_secs().try_into() {
@@ -1031,123 +1035,178 @@ where
             )
             .await;
 
-        match publish_result {
-            Ok(publish_completion_token) => {
-                // Wait for and handle the puback
-                match publish_completion_token.await {
-                    // if puback is Ok, continue and wait for the response
-                    Ok(()) => {}
-                    Err(e) => {
-                        log::error!("[ERROR] puback error: {e}");
-                        return Err(AIOProtocolError::new_mqtt_error(
-                            Some("MQTT Error on command invoke puback".to_string()),
-                            Box::new(e),
-                            Some(self.command_name.clone()),
-                        ));
-                    }
-                }
-            }
-            Err(e) => {
-                log::error!("[ERROR] client error while publishing: {e}");
-                return Err(AIOProtocolError::new_mqtt_error(
-                    Some("Client error on command invoker request publish".to_string()),
-                    Box::new(e),
-                    Some(self.command_name.clone()),
-                ));
-            }
-        }
-
-        // Wait for a response where the correlation id matches
-        loop {
-            // wait for incoming pub
-            match response_rx.recv().await {
-                Ok(rsp_pub) => {
-                    if let Some(rsp_pub) = rsp_pub {
-                        // check correlation id for match, otherwise loop again
-                        if let Some(ref rsp_properties) = rsp_pub.properties {
-                            if let Some(ref response_correlation_data) =
-                                rsp_properties.correlation_data
-                            {
-                                if *response_correlation_data == correlation_data {
-                                    // This is implicit validation of the correlation data - if it's malformed it won't match the request
-                                    // This is the response for this request, validate and parse it and send it back to the application
-                                    let command_result: CommandResult<TResp> =
-                                        rsp_pub.try_into().map_err(|mut e: AIOProtocolError| {
-                                            // Add command name to the error
-                                            e.command_name = Some(self.command_name.clone());
-                                            e
-                                        })?;
-
-                                    match command_result {
-                                        CommandResult::Ok(response) => {
-                                            // Update application HLC
-                                            if let Some(hlc) = &response.timestamp {
-                                                self.application_hlc.update(hlc).map_err(|e| {
-                                                    let mut aio_error: AIOProtocolError = e.into();
-                                                    aio_error.command_name =
-                                                        Some(self.command_name.clone());
-                                                    aio_error
-                                                })?;
-                                            }
-                                            return Ok(response);
-                                        }
-                                        CommandResult::Err(remote_e) => {
-                                            // Update application HLC
-                                            if let Some(hlc) = &remote_e.timestamp {
-                                                self.application_hlc.update(hlc).map_err(|e| {
-                                                    let mut aio_error: AIOProtocolError = e.into();
-                                                    aio_error.command_name =
-                                                        Some(self.command_name.clone());
-                                                    aio_error
-                                                })?;
-                                            }
-                                            // Convert into AIOProtocolError and return
-                                            let mut aio_e: AIOProtocolError = remote_e.into();
-                                            aio_e.command_name = Some(self.command_name.clone());
-                                            return Err(aio_e);
-                                        }
+        // Await for publish to complete in a task that concurrently polls the response_rx
+        // so that the response_tx won't lag if the puback takes long to return
+        // TODO: this could be fixed more elegantly by using a dispatcher instead of a broadcast channel for the response_tx/rx
+        let pub_task = tokio::task::spawn({
+            let command_name = self.command_name.clone();
+            let ct = cancellation_token.clone();
+            async move {
+                match publish_result {
+                    Ok(publish_completion_token) => {
+                        // Wait for and handle the puback
+                        tokio::select! {
+                            () = ct.cancelled() => {
+                                // This error won't actually be returned as this only happens if the invoke has already returned a timeout error
+                                // This branch is just here to make sure this task ends
+                                Err(AIOProtocolError::new_timeout_error(
+                                    false,
+                                    None,
+                                    &command_name,
+                                    request.timeout,
+                                    None,
+                                    Some(command_name.clone()),
+                                ))
+                            },
+                            puback = publish_completion_token => {
+                                match puback {
+                                    // if puback is Ok, continue and wait for the response
+                                    Ok(()) => Ok(()),
+                                    Err(e) => {
+                                        log::error!("[ERROR] puback error: {e}");
+                                        Err(AIOProtocolError::new_mqtt_error(
+                                            Some("MQTT Error on command invoke puback".to_string()),
+                                            Box::new(e),
+                                            Some(command_name),
+                                        ))
                                     }
                                 }
                             }
                         }
-                    } else {
-                        log::error!(
-                            "Command Invoker has been shutdown and will no longer receive a response"
-                        );
-                        return Err(AIOProtocolError::new_cancellation_error(
-                        false,
-                        None,
-                        Some(
-                            "Command Invoker has been shutdown and will no longer receive a response"
-                                .to_string(),
-                        ),
-                        Some(self.command_name.clone()),
-                    ));
                     }
+                    Err(e) => {
+                        log::error!("[ERROR] client error while publishing: {e}");
+                        Err(AIOProtocolError::new_mqtt_error(
+                            Some("Client error on command invoker request publish".to_string()),
+                            Box::new(e),
+                            Some(command_name),
+                        ))
+                    }
+                }
+            }
+        });
+        // task to receive incoming responses and check for the one that is for this request
+        let response_task = tokio::task::spawn({
+            let command_name = self.command_name.clone();
+            let ct = cancellation_token.clone();
+            async move {
+                loop {
+                    // wait for incoming pub
+                    tokio::select! {
+                        () = ct.cancelled() => {
+                            // This error won't be returned as this only happens if the invoke has already returned a timeout error
+                            // This branch is just here to make sure this task ends
+                            return Err(AIOProtocolError::new_timeout_error(
+                                false,
+                                None,
+                                &command_name,
+                                request.timeout,
+                                None,
+                                Some(command_name.clone()),
+                            ));
+                        },
+                        res = response_rx.recv() => {
+                            match res {
+                                Ok(rsp_pub) => {
+                                    if let Some(rsp_pub) = rsp_pub {
+                                        // check correlation id for match, otherwise loop again
+                                        if let Some(ref rsp_properties) = rsp_pub.properties {
+                                            if let Some(ref response_correlation_data) =
+                                                rsp_properties.correlation_data
+                                            {
+                                                if *response_correlation_data == correlation_data {
+                                                    // This is implicit validation of the correlation data - if it's malformed it won't match the request
+                                                    // This is the response for this request, stop listening for more responses and validate and parse it and send it back to the application
+                                                    return Ok(rsp_pub);
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        log::error!(
+                                            "Command Invoker has been shutdown and will no longer receive a response"
+                                        );
+                                        return Err(AIOProtocolError::new_cancellation_error(
+                                            false,
+                                            None,
+                                            Some(
+                                                "Command Invoker has been shutdown and will no longer receive a response"
+                                                    .to_string(),
+                                            ),
+                                            Some(command_name),
+                                        ));
+                                    }
+                                    // If the publish doesn't have properties, correlation_data, or the correlation data doesn't match, keep waiting for the next one
+                                }
+                                Err(RecvError::Lagged(e)) => {
+                                    log::error!(
+                                        "[ERROR] Invoker response receiver lagged. Response may not be received. Number of skipped messages: {e}"
+                                    );
+                                    // Keep waiting for response even though it may have gotten overwritten.
+                                    continue;
+                                }
+                                Err(RecvError::Closed) => {
+                                    log::error!(
+                                        "[ERROR] MQTT Receiver has been cleaned up and will no longer send a response"
+                                    );
+                                    return Err(AIOProtocolError::new_cancellation_error(
+                                        false,
+                                        None,
+                                        Some(
+                                            "MQTT Receiver has been cleaned up and will no longer send a response"
+                                                .to_string(),
+                                        ),
+                                        Some(command_name),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
 
-                    // If the publish doesn't have properties, correlation_data, or the correlation data doesn't match, keep waiting for the next one
+        // wait for pub to be completed and response to be received, immediately returning any errors returned.
+        let rsp_pub = match tokio::try_join!(flatten(pub_task), flatten(response_task)) {
+            Ok(((), rsp_pub)) => rsp_pub,
+            // Return any error that occurs
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
+        // validate and parse the response pub that is for this request
+        let command_result: CommandResult<TResp> =
+            rsp_pub.try_into().map_err(|mut e: AIOProtocolError| {
+                // Add command name to the error
+                e.command_name = Some(self.command_name.clone());
+                e
+            })?;
+
+        match command_result {
+            CommandResult::Ok(response) => {
+                // Update application HLC
+                if let Some(hlc) = &response.timestamp {
+                    self.application_hlc.update(hlc).map_err(|e| {
+                        let mut aio_error: AIOProtocolError = e.into();
+                        aio_error.command_name = Some(self.command_name.clone());
+                        aio_error
+                    })?;
                 }
-                Err(RecvError::Lagged(e)) => {
-                    log::error!(
-                        "[ERROR] Invoker response receiver lagged. Response may not be received: {e}"
-                    );
-                    // Keep waiting for response even though it may have gotten overwritten.
-                    continue;
+                Ok(response)
+            }
+            CommandResult::Err(remote_e) => {
+                // Update application HLC
+                if let Some(hlc) = &remote_e.timestamp {
+                    self.application_hlc.update(hlc).map_err(|e| {
+                        let mut aio_error: AIOProtocolError = e.into();
+                        aio_error.command_name = Some(self.command_name.clone());
+                        aio_error
+                    })?;
                 }
-                Err(RecvError::Closed) => {
-                    log::error!(
-                        "[ERROR] MQTT Receiver has been cleaned up and will no longer send a response"
-                    );
-                    return Err(AIOProtocolError::new_cancellation_error(
-                        false,
-                        None,
-                        Some(
-                            "MQTT Receiver has been cleaned up and will no longer send a response"
-                                .to_string(),
-                        ),
-                        Some(self.command_name.clone()),
-                    ));
-                }
+                // Convert into AIOProtocolError and return
+                let mut aio_e: AIOProtocolError = remote_e.into();
+                aio_e.command_name = Some(self.command_name.clone());
+                Err(aio_e)
             }
         }
     }
@@ -1177,12 +1236,18 @@ where
                         }
                         // Manually ack
                         if let Some(ack_token) = ack_token {
-                            match ack_token.ack().await {
-                                Ok(_) => { },
-                                Err(e) => {
-                                    log::error!("[{command_name}] Error acking message: {e}");
+                            // Ack in separate task to avoid blocking the receiver loop
+                            tokio::task::spawn({
+                                let command_name_clone = command_name.clone();
+                                async move {
+                                    match ack_token.ack().await {
+                                        Ok(_) => { },
+                                        Err(e) => {
+                                            log::error!("[{command_name_clone}] Error acking message: {e}");
+                                        }
+                                    }
                                 }
-                            }
+                            });
                         }
                     } else {
                         // if this fails, it's just because there are no more pending commands, which is fine
@@ -1307,6 +1372,21 @@ async fn drop_unsubscribe<C: ManagedClient + Clone + Send + Sync + 'static>(
 
     // If we successfully unsubscribed or did not need to, we can consider the invoker successfully shutdown
     *invoker_state_mutex_guard = State::ShutdownSuccessful;
+}
+
+/// convenience fn to flatten the result of a `JoinHandle`
+async fn flatten<T>(
+    handle: JoinHandle<Result<T, AIOProtocolError>>,
+) -> Result<T, AIOProtocolError> {
+    match handle.await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(e)) => Err(e),
+        Err(e) => {
+            // tasks can't panic
+            log::error!("Join Error: {e}");
+            unreachable!()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -927,6 +927,7 @@ where
         &self,
         mut request: Request<TReq>,
     ) -> Result<Response<TResp>, AIOProtocolError> {
+        // cancellation token to clean up spawned tasks if the invoke times out
         let cancellation_token = CancellationToken::new();
         let _drop_guard = cancellation_token.clone().drop_guard();
         // Validate parameters. Custom user data, timeout, and payload serialization have already been validated in RequestBuilder


### PR DESCRIPTION
Re-opened from #900 because of branch issues
Cherry pick of https://github.com/Azure/iot-operations-sdks/pull/893 plus additional fix needed

Problem:
One invoke request taking a long time can cause other concurrent requests to not receive their responses because of the lagging receiver problem. The invoker subscribes to the response broadcast channel before it pubs it's request. This makes sense, since it wants to be subscribed before it's ever possible for the response to come in. However, this means that if the publish takes a long time, it isn't recv'ing on its broadcast receiver, causing the lag.

The fix:
The pub completion and checking response publishes now happen concurrently in a tokio try_join!. If the puback takes a long time to receive, broadcast subscription is still being processed, even though the responses will likely not be for this request. A failure in either task will return an error immediately, same as the current behavior.

Most of the code changes are just re-organizing where the logic lives. Some minor log updates.

Problem 2: the receiving loop also does manual ack, which means until a message is ack'd, we can't receive the next message, causing that next response to timeout instead
Fix: manually ack in a separate task to keep the receiver loop continually receiving