### PR TITLE
[Rust][Connector] Making receiving of Asset / Dataset notifications cancellable

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -884,6 +884,8 @@ impl AssetClient {
         let mut unlocked_specification = self.specification.write().unwrap(); // unwrap can't fail unless lock is poisoned
         *unlocked_specification = AssetSpecification::from(updated_asset);
 
+        // Asset update has been fully processed, mark as seen.
+        self.asset_update_watcher_rx.mark_unchanged();
         ClientNotification::Updated
     }
 
@@ -947,6 +949,8 @@ impl AssetClient {
                             Self::unobserve_asset(&connector_context_clone, &asset_ref_clone).await;
                         }
                     );
+                    // Asset update has been fully processed, mark as seen.
+                    self.asset_update_watcher_rx.mark_unchanged();
                     ClientNotification::Deleted
                 }
             },


### PR DESCRIPTION
This PR:
- Addresses a bug where receiving a notification on an asset or dataset would not get fully processed if the receive flow was cancelled.
- Example: If receiving in a select branch and while processing the asset update a different branch takes over, we will lose the update.
- Changes unobserve to happen in a separate task.