### PR TITLE
[Rust][Connector] Make `BaseConnector` ingest `ConnectorArtifacts`

### DIFF
--- a/rust/azure_iot_operations_connector/README.md
+++ b/rust/azure_iot_operations_connector/README.md
@@ -61,12 +61,7 @@ Any AIO Protocol Error is considered a "network error" and retriable. This may n
 |Device endpoint create notification provides a device/endpoint name that returns a device with no inbound endpoint from the service|Y|Unobserve is called, and the create notification is dropped|This is really only possible if the device endpoint gets deleted between the time we receive the notification and the get device call is made, so losing this notification means it was out of date.|
 
 ### Setup
-These errors will retry indefinitely with exponential backoff, hoping new connector artifacts will fix the error
-- errors parsing the Connector Artifacts
-- errors creating the MQTT Session (including creating needed settings)
-- errors creating azure device registry client
-- errors creating state store client
-- note: creating schema registry client doesn't return any errors
+If Connector Artifacts contain invalid or incorrect values, setup of the BaseConnector will return an error indicating the reason.
 
 ### Fatal
 - Creating a new file mount DeviceEndpointCreateObservation is fatal if there's an error. There's no way to recover from this other than restarting the connector. It causes a panic (TODO: we could propogate to the application?)

--- a/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
+++ b/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create an ApplicationContext
     let application_context = ApplicationContextBuilder::default().build()?;
     // Create the BaseConnector
-    let base_connector = BaseConnector::new(connector_artifacts, application_context);
+    let base_connector = BaseConnector::new(connector_artifacts, application_context)?;
 
     let device_creation_observation =
         base_connector.create_device_endpoint_client_create_observation();

--- a/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
+++ b/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
@@ -22,6 +22,7 @@ use azure_iot_operations_connector::{
         },
     },
     data_processor::derived_json,
+    deployment_artifacts::connector::ConnectorArtifacts,
 };
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
 use azure_iot_operations_services::azure_device_registry;
@@ -40,10 +41,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter_module("notify::inotify", log::LevelFilter::Off)
         .init();
 
+    // Create the connector artifacts from the deployment
+    let connector_artifacts = ConnectorArtifacts::new_from_deployment()?;
     // Create an ApplicationContext
     let application_context = ApplicationContextBuilder::default().build()?;
-
-    let base_connector = BaseConnector::new(application_context);
+    // Create the BaseConnector
+    let base_connector = BaseConnector::new(connector_artifacts, application_context);
 
     let device_creation_observation =
         base_connector.create_device_endpoint_client_create_observation();

--- a/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
+++ b/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create an ApplicationContext
     let application_context = ApplicationContextBuilder::default().build()?;
     // Create the BaseConnector
-    let base_connector = BaseConnector::new(connector_artifacts, application_context)?;
+    let base_connector = BaseConnector::new(application_context, connector_artifacts)?;
 
     let device_creation_observation =
         base_connector.create_device_endpoint_client_create_observation();

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -65,7 +65,7 @@ impl BaseConnector {
             .to_mqtt_connection_settings("0")
             .map_err(|e| e.to_string())?;
         let session_options = SessionOptionsBuilder::default()
-            .connection_settings(mqtt_connection_settings.clone())
+            .connection_settings(mqtt_connection_settings)
             // TODO: reconnect policy
             // TODO: outgoing_max
             .build()

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -39,7 +39,7 @@ pub(crate) struct ConnectorContext {
 impl std::fmt::Debug for ConnectorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConnectorContext")
-            .field("connector_artifacts", &self.connector_artifacts)
+            //.field("connector_artifacts", &self.connector_artifacts)
             .field("debounce_duration", &self.debounce_duration)
             .field("default_timeout", &self.default_timeout)
             .finish()
@@ -58,66 +58,58 @@ impl BaseConnector {
     /// with exponential backoff. This allows for new configuration to be deployed to fix any
     /// errors without needing to restart the connector.
     #[must_use]
-    pub fn new(application_context: ApplicationContext) -> Self {
+    pub fn new(
+        connector_artifacts: ConnectorArtifacts,
+        application_context: ApplicationContext,
+    ) -> Self {
         // if any of these operations fail, wait and try again in case connector configuration has changed
-        let (
-            connector_artifacts,
-            azure_device_registry_client,
-            schema_registry_client,
-            state_store_client,
-            session,
-        ) = operation_with_retries::<(_, _, _, _, _), String>(|| {
-            // Get Connector Artifacts
-            let connector_artifacts =
-                ConnectorArtifacts::new_from_deployment().map_err(|e| e.to_string())?;
-
-            // Create Session
-            let mqtt_connection_settings = connector_artifacts
-                .clone()
-                .to_mqtt_connection_settings("0")
-                .map_err(|e| e.to_string())?;
-            let session_options = SessionOptionsBuilder::default()
-                .connection_settings(mqtt_connection_settings.clone())
-                // TODO: reconnect policy
-                // TODO: outgoing_max
-                .build()
-                .map_err(|e| e.to_string())?;
-            let session = Session::new(session_options).map_err(|e| e.to_string())?;
-
-            // Create clients
-            // Create Azure Device Registry Client
-            let azure_device_registry_client = azure_device_registry::Client::new(
-                application_context.clone(),
-                session.create_managed_client(),
-                azure_device_registry::ClientOptions::default(),
-            )
-            .map_err(|e| e.to_string())?;
-
-            // Create Schema Registry Client
-            let schema_registry_client = schema_registry::Client::new(
-                application_context.clone(),
-                &session.create_managed_client(),
-            );
-
-            // Create State Store Client
-            let state_store_client = state_store::Client::new(
-                application_context.clone(),
-                session.create_managed_client(),
-                session.create_connection_monitor(),
-                state_store::ClientOptionsBuilder::default()
+        let (azure_device_registry_client, schema_registry_client, state_store_client, session) =
+            operation_with_retries::<(_, _, _, _), String>(|| {
+                // Create Session
+                let mqtt_connection_settings = connector_artifacts
+                    .to_mqtt_connection_settings("0")
+                    .map_err(|e| e.to_string())?;
+                let session_options = SessionOptionsBuilder::default()
+                    .connection_settings(mqtt_connection_settings.clone())
+                    // TODO: reconnect policy
+                    // TODO: outgoing_max
                     .build()
-                    .map_err(|e| e.to_string())?,
-            )
-            .map_err(|e| e.to_string())?;
+                    .map_err(|e| e.to_string())?;
+                let session = Session::new(session_options).map_err(|e| e.to_string())?;
 
-            Ok((
-                connector_artifacts,
-                azure_device_registry_client,
-                schema_registry_client,
-                state_store_client,
-                session,
-            ))
-        });
+                // Create clients
+                // Create Azure Device Registry Client
+                let azure_device_registry_client = azure_device_registry::Client::new(
+                    application_context.clone(),
+                    session.create_managed_client(),
+                    azure_device_registry::ClientOptions::default(),
+                )
+                .map_err(|e| e.to_string())?;
+
+                // Create Schema Registry Client
+                let schema_registry_client = schema_registry::Client::new(
+                    application_context.clone(),
+                    &session.create_managed_client(),
+                );
+
+                // Create State Store Client
+                let state_store_client = state_store::Client::new(
+                    application_context.clone(),
+                    session.create_managed_client(),
+                    session.create_connection_monitor(),
+                    state_store::ClientOptionsBuilder::default()
+                        .build()
+                        .map_err(|e| e.to_string())?,
+                )
+                .map_err(|e| e.to_string())?;
+
+                Ok((
+                    azure_device_registry_client,
+                    schema_registry_client,
+                    state_store_client,
+                    session,
+                ))
+            });
         Self {
             connector_context: Arc::new(ConnectorContext {
                 // TODO: validate these timeouts here once they come from somewhere
@@ -155,11 +147,6 @@ impl BaseConnector {
     /// Creates a handle to use the [`BaseConnector`]'s Azure Device Registry client for discovery operations.
     pub fn discovery_client(&self) -> adr_discovery::Client {
         adr_discovery::Client::new(self.connector_context.clone())
-    }
-
-    /// Returns a copy of the connector artifacts
-    pub fn connector_artifacts(&self) -> ConnectorArtifacts {
-        self.connector_context.connector_artifacts.clone()
     }
 }
 

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -138,18 +138,3 @@ impl BaseConnector {
         adr_discovery::Client::new(self.connector_context.clone())
     }
 }
-
-/// Helper function to perform any operation with retries.
-fn operation_with_retries<T, E: std::fmt::Debug>(operation: impl Fn() -> Result<T, E>) -> T {
-    let mut retry_duration = Duration::from_secs(1);
-    loop {
-        match operation() {
-            Ok(result) => return result,
-            Err(e) => {
-                log::error!("Operation failed, retrying: {e:?}");
-                retry_duration = retry_duration.saturating_mul(2);
-                std::thread::sleep(retry_duration);
-            }
-        }
-    }
-}

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -56,7 +56,6 @@ impl BaseConnector {
     ///
     /// # Errors
     /// Returns a String error if any of the setup fails, detailing the cause.
-    #[must_use]
     pub fn new(
         application_context: ApplicationContext,
         connector_artifacts: ConnectorArtifacts,

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -58,8 +58,8 @@ impl BaseConnector {
     /// Returns a String error if any of the setup fails, detailing the cause.
     #[must_use]
     pub fn new(
-        connector_artifacts: ConnectorArtifacts,
         application_context: ApplicationContext,
+        connector_artifacts: ConnectorArtifacts,
     ) -> Result<Self, String> {
         // Create Session
         let mqtt_connection_settings = connector_artifacts

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -39,7 +39,6 @@ pub(crate) struct ConnectorContext {
 impl std::fmt::Debug for ConnectorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConnectorContext")
-            //.field("connector_artifacts", &self.connector_artifacts)
             .field("debounce_duration", &self.debounce_duration)
             .field("default_timeout", &self.default_timeout)
             .finish()


### PR DESCRIPTION
Partial solution to the problem of artifact portability.

May need to combine connector arguments into some kind of context or options, depending on the eventual OTEL metrics integration.

Also still need to unify ADR artifacts with everything else.