### PR TITLE
[Rust] Clean up Redundant Clones

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -73,11 +73,9 @@ impl BaseConnector {
 
             // Create Session
             let mqtt_connection_settings = connector_artifacts
-                .clone()
-                .to_mqtt_connection_settings("0")
-                .map_err(|e| e.to_string())?;
+                .to_mqtt_connection_settings("0")?;
             let session_options = SessionOptionsBuilder::default()
-                .connection_settings(mqtt_connection_settings.clone())
+                .connection_settings(mqtt_connection_settings)
                 // TODO: reconnect policy
                 // TODO: outgoing_max
                 .build()

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -72,8 +72,7 @@ impl BaseConnector {
                 ConnectorArtifacts::new_from_deployment().map_err(|e| e.to_string())?;
 
             // Create Session
-            let mqtt_connection_settings = connector_artifacts
-                .to_mqtt_connection_settings("0")?;
+            let mqtt_connection_settings = connector_artifacts.to_mqtt_connection_settings("0")?;
             let session_options = SessionOptionsBuilder::default()
                 .connection_settings(mqtt_connection_settings)
                 // TODO: reconnect policy

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2175,8 +2175,7 @@ mod tests {
             }]),
             ..Default::default()
         };
-        let new_status_base =
-            AssetClient::current_status_to_modify(&current_status, spec_version);
+        let new_status_base = AssetClient::current_status_to_modify(&current_status, spec_version);
         if expect_keep_received {
             assert_eq!(new_status_base, current_status);
         } else {

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2176,7 +2176,7 @@ mod tests {
             ..Default::default()
         };
         let new_status_base =
-            AssetClient::current_status_to_modify(&current_status.clone(), spec_version);
+            AssetClient::current_status_to_modify(&current_status, spec_version);
         if expect_keep_received {
             assert_eq!(new_status_base, current_status);
         } else {

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/azure_device_registry.rs
@@ -75,7 +75,7 @@ impl DeviceEndpointCreateObservation {
         let (create_device_tx, create_device_rx) = mpsc::unbounded_channel();
 
         // Tracks devices and assets in the file mount.
-        let mut file_mount_map = FileMountMap::new(create_device_tx.clone(), mount_path.clone());
+        let mut file_mount_map = FileMountMap::new(create_device_tx, mount_path.clone());
 
         // Get all the current devices
         let device_endpoints = get_device_endpoint_names(&mount_path)?;
@@ -628,7 +628,7 @@ mod tests {
         file_mount_manager.add_device_endpoint(&device1_endpoint1, &device1_endpoint1_assets);
 
         let device1_endpoint1_assets_set: HashSet<AssetRef> =
-            HashSet::from_iter(device1_endpoint1_assets.clone());
+            HashSet::from_iter(device1_endpoint1_assets);
 
         temp_env::with_vars(
             [(

--- a/rust/azure_iot_operations_connector/tests/artifact_tests.rs
+++ b/rust/azure_iot_operations_connector/tests/artifact_tests.rs
@@ -99,7 +99,7 @@ fn local_connector_artifacts_tls() {
 
             // --- Create a Session from the MqttConnectionSettings ---
             let session_options = SessionOptionsBuilder::default()
-                .connection_settings(mcs.clone())
+                .connection_settings(mcs)
                 .build()
                 .unwrap();
             assert!(Session::new(session_options).is_ok());
@@ -168,7 +168,7 @@ fn local_connector_artifacts_no_tls() {
 
             // --- Create a Session from the MqttConnectionSettings ---
             let session_options = SessionOptionsBuilder::default()
-                .connection_settings(mcs.clone())
+                .connection_settings(mcs)
                 .build()
                 .unwrap();
             assert!(Session::new(session_options).is_ok());

--- a/rust/azure_iot_operations_mqtt/src/session/receiver.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/receiver.rs
@@ -1134,7 +1134,7 @@ mod tests {
         ); // Type 4
 
         // Register a new filter again
-        let topic_filter8 = topic_filter7; // Type 4
+        let topic_filter8 = topic_filter7.clone(); // Type 4
         let filter_rx8 = manager
             .lock()
             .unwrap()

--- a/rust/azure_iot_operations_mqtt/src/session/receiver.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/receiver.rs
@@ -1134,7 +1134,7 @@ mod tests {
         ); // Type 4
 
         // Register a new filter again
-        let topic_filter8 = topic_filter7.clone(); // Type 4
+        let topic_filter8 = topic_filter7; // Type 4
         let filter_rx8 = manager
             .lock()
             .unwrap()

--- a/rust/azure_iot_operations_protocol/src/common/aio_protocol_error.rs
+++ b/rust/azure_iot_operations_protocol/src/common/aio_protocol_error.rs
@@ -221,7 +221,7 @@ impl AIOProtocolError {
                 AIOProtocolError::new_configuration_invalid_error(
                     Some(Box::new(error)),
                     &token,
-                    Value::String(replacement.to_string()),
+                    Value::String(replacement),
                     Some(err_msg),
                     None,
                 )

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1182,14 +1182,14 @@ where
             if let Some(name) = response_arguments.invalid_property_name {
                 user_properties.push((
                     UserProperty::InvalidPropertyName.to_string(),
-                    name.to_string(),
+                    name,
                 ));
             }
 
             if let Some(value) = response_arguments.invalid_property_value {
                 user_properties.push((
                     UserProperty::InvalidPropertyValue.to_string(),
-                    value.to_string(),
+                    value,
                 ));
             }
 

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1180,17 +1180,11 @@ where
             }
 
             if let Some(name) = response_arguments.invalid_property_name {
-                user_properties.push((
-                    UserProperty::InvalidPropertyName.to_string(),
-                    name,
-                ));
+                user_properties.push((UserProperty::InvalidPropertyName.to_string(), name));
             }
 
             if let Some(value) = response_arguments.invalid_property_value {
-                user_properties.push((
-                    UserProperty::InvalidPropertyValue.to_string(),
-                    value,
-                ));
+                user_properties.push((UserProperty::InvalidPropertyValue.to_string(), value));
             }
 
             if let Some(supported_protocol_major_versions) =

--- a/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
+++ b/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
@@ -152,7 +152,7 @@ impl CloudEvent {
         if let Some(data_schema) = self.data_schema {
             headers.push((
                 CloudEventFields::DataSchema.to_string(),
-                data_schema.to_string(),
+                data_schema,
             ));
         }
         headers

--- a/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
+++ b/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
@@ -150,10 +150,7 @@ impl CloudEvent {
             ));
         }
         if let Some(data_schema) = self.data_schema {
-            headers.push((
-                CloudEventFields::DataSchema.to_string(),
-                data_schema,
-            ));
+            headers.push((CloudEventFields::DataSchema.to_string(), data_schema));
         }
         headers
     }

--- a/rust/azure_iot_operations_protocol/tests/metl/command_invoker_tester.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/command_invoker_tester.rs
@@ -245,7 +245,7 @@ where
                     if let Some(request_value) = default_invoke_command.request_value.clone() {
                         command_request_builder
                             .payload(TestPayload {
-                                payload: Some(request_value.clone()),
+                                payload: Some(request_value),
                                 out_content_type: tci.serializer.out_content_type.clone(),
                                 accept_content_types: tci.serializer.accept_content_types.clone(),
                                 indicate_character_data: tci.serializer.indicate_character_data,
@@ -580,7 +580,7 @@ where
                 .await
                 .expect("test timeout in await_publish");
             if let Some(correlation_index) = correlation_index {
-                correlation_ids.insert(*correlation_index, correlation_id.clone());
+                correlation_ids.insert(*correlation_index, correlation_id);
             }
         } else {
             panic!("internal logic error");

--- a/rust/azure_iot_operations_protocol/tests/metl/mqtt_hub.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/mqtt_hub.rs
@@ -205,7 +205,7 @@ impl MqttHub {
                     _properties: _,
                     ack_tx,
                 } => {
-                    self.subscribed_topics.insert(topic.clone());
+                    self.subscribed_topics.insert(topic);
                     if let Some(ack_kind) = self.suback_queue.pop_front() {
                         ack_tx.send(ack_kind).unwrap();
                     } else {

--- a/rust/azure_iot_operations_protocol/tests/metl/telemetry_sender_tester.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/telemetry_sender_tester.rs
@@ -219,7 +219,7 @@ where
                     if let Some(telemetry_value) = default_send_telemetry.telemetry_value.clone() {
                         telemetry_message_builder
                             .payload(TestPayload {
-                                payload: Some(telemetry_value.clone()),
+                                payload: Some(telemetry_value),
                                 out_content_type: tcs.serializer.out_content_type.clone(),
                                 accept_content_types: tcs.serializer.accept_content_types.clone(),
                                 indicate_character_data: tcs.serializer.indicate_character_data,

--- a/rust/azure_iot_operations_protocol/tests/metl/test_payload.rs
+++ b/rust/azure_iot_operations_protocol/tests/metl/test_payload.rs
@@ -28,7 +28,7 @@ impl PayloadSerialize for TestPayload {
             } else {
                 Vec::new()
             },
-            content_type: self.out_content_type.unwrap().to_string(),
+            content_type: self.out_content_type.unwrap(),
             format_indicator: if self.indicate_character_data {
                 FormatIndicator::Utf8EncodedCharacterData
             } else {

--- a/rust/sample_applications/event_driven_app/output_client/src/main.rs
+++ b/rust/sample_applications/event_driven_app/output_client/src/main.rs
@@ -235,7 +235,7 @@ pub struct WindowData {
 
 impl From<Vec<f64>> for WindowSensorData {
     fn from(sensor_data: Vec<f64>) -> Self {
-        let mut sensor_data: Vec<f64> = sensor_data.clone();
+        let mut sensor_data: Vec<f64> = sensor_data;
 
         sensor_data.sort_by(|a, b| a.partial_cmp(b).expect("f64 comparison should not fail"));
         let count: i64 = sensor_data


### PR DESCRIPTION
Did a quick pass with [Clippy Lint Redundant Clone](https://rust-lang.github.io/rust-clippy/master/#redundant_clone) set to warn and fixed all of the correct warnings that came up. We can't leave this on by default because it isn't super stable and detects some needed clones, but can be used as a local tool to help with reducing extra `clone()`s. Note that this also doesn't catch everything, so there may be more that could be cleaned up, and this still needs to be manually thought about, even if this warning is on