### PR TITLE
[Rust][State Store CLI] Updating State Store CLI

### DIFF
--- a/tools/statestore-cli/Cargo.toml
+++ b/tools/statestore-cli/Cargo.toml
@@ -12,9 +12,9 @@ readme = "readme.md"
 publish = true
 
 [dependencies]
-azure_iot_operations_protocol = { version = "0.8", path = "../../rust/azure_iot_operations_protocol", registry = "aio-sdks" }
-azure_iot_operations_mqtt = { version = "0.8", path = "../../rust/azure_iot_operations_mqtt", registry = "aio-sdks" }
-azure_iot_operations_services = { version = "0.7", path = "../../rust/azure_iot_operations_services", registry = "aio-sdks", features = ["state_store"]}
+azure_iot_operations_protocol = { version = "0.9", path = "../../rust/azure_iot_operations_protocol", registry = "aio-sdks" }
+azure_iot_operations_mqtt = { version = "0.9", path = "../../rust/azure_iot_operations_mqtt", registry = "aio-sdks" }
+azure_iot_operations_services = { version = "0.8", path = "../../rust/azure_iot_operations_services", registry = "aio-sdks", features = ["state_store"]}
 log = "0.4.21"
 tokio = { version = "1.41", features = ["rt", "time", "sync"] }
 clap = { version = "4.0", features = ["derive"] }

--- a/tools/statestore-cli/src/main.rs
+++ b/tools/statestore-cli/src/main.rs
@@ -121,7 +121,7 @@ async fn main() {
         .connection_settings(connection_settings)
         .build()
         .unwrap();
-    let mut session = Session::new(session_options).unwrap();
+    let session = Session::new(session_options).unwrap();
 
     let application_context = ApplicationContextBuilder::default().build().unwrap();
 


### PR DESCRIPTION
This PR updates the references of the state store cli tool to the current version of the mqtt, services, and protocol crates.