### PR TITLE
[.NET][Akri] Fix template's worker reference

### DIFF
--- a/dotnet/templates/EventDrivenTelemetryConnector/Program.cs
+++ b/dotnet/templates/EventDrivenTelemetryConnector/Program.cs
@@ -16,7 +16,7 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton(MessageSchemaProvider.Factory);
         services.AddSingleton<IAdrClientWrapperProvider>(AdrClientWrapperProvider.Factory);
         services.AddSingleton(LeaderElectionConfigurationProvider.Factory); // If no leader election is needed, delete this line
-        services.AddHostedService<ConnectorWorker>();
+        services.AddHostedService<TemplateConnectorWorker>();
     })
     .Build();
 


### PR DESCRIPTION
Use the worker service defined in the template (which extends ConnectorWorker)