### PR TITLE
Add Property support to .NET AIO SDK

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Protocol/PropertyTopicAttribute.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/PropertyTopicAttribute.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Iot.Operations.Protocol
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class PropertyTopicAttribute(string topic) : Attribute
+    {
+        public string Topic { get; set; } = topic;
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyConsumer.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyConsumer.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Iot.Operations.Protocol.Models;
+using Azure.Iot.Operations.Protocol.RPC;
+using Azure.Iot.Operations.Protocol.Telemetry;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public abstract class PropertyConsumer<TProp, TBool> : IAsyncDisposable
+        where TProp : class
+        where TBool : class
+    {
+        private bool _isDisposed;
+
+        public PropertyWriteRequester<TProp, TBool> PropertyWriteRequester { get; }
+
+        public PropertyReadRequester<TProp, TBool> PropertyReadRequester { get; }
+
+        public PropertyWatchRequester<TBool> PropertyWatchRequester { get; }
+
+        public PropertyUnwatchRequester<TBool> PropertyUnwatchRequester { get; }
+
+        public PropertyListener<TProp> PropertyListener { get; }
+
+        public required Func<string, TProp, IncomingTelemetryMetadata, Task> OnNotifyReceived { get; set; }
+
+        public string? TopicNamespace
+        {
+            get => PropertyListener.TopicNamespace;
+
+            set
+            {
+                PropertyWriteRequester.TopicNamespace = value;
+                PropertyReadRequester.TopicNamespace = value;
+                PropertyWatchRequester.TopicNamespace = value;
+                PropertyUnwatchRequester.TopicNamespace = value;
+                PropertyListener.TopicNamespace = value;
+            }
+        }
+
+        public string? ResponseTopicPrefix
+        {
+            get => PropertyWriteRequester.ResponseTopicPrefix;
+
+            set
+            {
+                PropertyWriteRequester.ResponseTopicPrefix = value;
+                PropertyReadRequester.ResponseTopicPrefix = value;
+                PropertyWatchRequester.ResponseTopicPrefix = value;
+                PropertyUnwatchRequester.ResponseTopicPrefix = value;
+            }
+        }
+
+        public string? ResponseTopicSuffix
+        {
+            get => PropertyWriteRequester.ResponseTopicSuffix;
+
+            set
+            {
+                PropertyWriteRequester.ResponseTopicSuffix = value;
+                PropertyReadRequester.ResponseTopicSuffix = value;
+                PropertyWatchRequester.ResponseTopicSuffix = value;
+                PropertyUnwatchRequester.ResponseTopicSuffix = value;
+            }
+        }
+
+        public string? ResponseTopicPattern
+        {
+            get => PropertyWriteRequester.ResponseTopicPattern;
+
+            set
+            {
+                PropertyWriteRequester.ResponseTopicPattern = value;
+                PropertyReadRequester.ResponseTopicPattern = value;
+                PropertyWatchRequester.ResponseTopicPattern = value;
+                PropertyUnwatchRequester.ResponseTopicPattern = value;
+            }
+        }
+
+        public PropertyConsumer(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string>? topicTokenMap = null)
+        {
+            string topicPattern = AttributeRetriever.GetAttribute<PropertyTopicAttribute>(this)?.Topic ?? string.Empty;
+            topicTokenMap ??= new Dictionary<string, string>();
+
+            PropertyWriteRequester = new PropertyWriteRequester<TProp, TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern };
+            PropertyReadRequester = new PropertyReadRequester<TProp, TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern };
+            PropertyWatchRequester = new PropertyWatchRequester<TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern };
+            PropertyUnwatchRequester = new PropertyUnwatchRequester<TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern };
+            PropertyListener = new PropertyListener<TProp>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { TopicPattern = topicPattern, OnTelemetryReceived = ReceiveNotificationInt };
+        }
+
+        public Task<ExtendedResponse<TBool>> WriteAsync(TProp request, CommandRequestMetadata? metadata = null, Dictionary<string, string>? additionalTopicTokenMap = null, TimeSpan? writeTimeout = default, CancellationToken cancellationToken = default)
+        {
+            return PropertyWriteRequester.InvokeCommandAsync(request, metadata, additionalTopicTokenMap, writeTimeout, cancellationToken);
+        }
+
+        public Task<ExtendedResponse<TProp>> ReadAsync(TBool request, CommandRequestMetadata? metadata = null, Dictionary<string, string>? additionalTopicTokenMap = null, TimeSpan? readTimeout = default, CancellationToken cancellationToken = default)
+        {
+            return PropertyReadRequester.InvokeCommandAsync(request, metadata, additionalTopicTokenMap, readTimeout, cancellationToken);
+        }
+
+        public Task<ExtendedResponse<TBool>> WatchAsync(TBool request, CommandRequestMetadata? metadata = null, Dictionary<string, string>? additionalTopicTokenMap = null, TimeSpan? watchTimeout = default, CancellationToken cancellationToken = default)
+        {
+            return PropertyWatchRequester.InvokeCommandAsync(request, metadata, additionalTopicTokenMap, watchTimeout, cancellationToken);
+        }
+
+        public Task<ExtendedResponse<TBool>> UnwatchAsync(TBool request, CommandRequestMetadata? metadata = null, Dictionary<string, string>? additionalTopicTokenMap = null, TimeSpan? unwatchTimeout = default, CancellationToken cancellationToken = default)
+        {
+            return PropertyUnwatchRequester.InvokeCommandAsync(request, metadata, additionalTopicTokenMap, unwatchTimeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Begin accepting notifications.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            await PropertyListener.StartAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task ReceiveNotificationInt(string senderId, TProp telemetry, IncomingTelemetryMetadata metadata)
+        {
+            return OnNotifyReceived(senderId, telemetry, metadata);
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            await PropertyListener.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore(false).ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync(bool disposing)
+        {
+            await DisposeAsyncCore(disposing).ConfigureAwait(false);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    await PropertyWriteRequester.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyReadRequester.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyWatchRequester.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyUnwatchRequester.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyListener.DisposeAsync(disposing).ConfigureAwait(false);
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyListener.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyListener.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.Telemetry;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyListener<TProp> : TelemetryReceiver<TProp>
+        where TProp : class
+    {
+        public PropertyListener(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "notify" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyMaintainer.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyMaintainer.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Iot.Operations.Protocol.Models;
+using Azure.Iot.Operations.Protocol.RPC;
+using Azure.Iot.Operations.Protocol.Telemetry;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public abstract class PropertyMaintainer<TProp, TBool> : IAsyncDisposable
+        where TProp : class
+        where TBool : class
+    {
+        private bool _isDisposed;
+
+        public PropertyWriteResponder<TProp, TBool> PropertyWriteResponder { get; }
+
+        public PropertyReadResponder<TProp, TBool> PropertyReadResponder { get; }
+
+        public PropertyWatchResponder<TBool> PropertyWatchResponder { get; }
+
+        public PropertyUnwatchResponder<TBool> PropertyUnwatchResponder { get; }
+
+        public PropertyNotifier<TProp> PropertyNotifier { get; }
+
+        public required Func<ExtendedRequest<TProp>, CancellationToken, Task<ExtendedResponse<TBool>>> OnWriteReceived { get; set; }
+
+        public required Func<ExtendedRequest<TBool>, CancellationToken, Task<ExtendedResponse<TProp>>> OnReadReceived { get; set; }
+
+        public required Func<ExtendedRequest<TBool>, CancellationToken, Task<ExtendedResponse<TBool>>> OnWatchReceived { get; set; }
+
+        public required Func<ExtendedRequest<TBool>, CancellationToken, Task<ExtendedResponse<TBool>>> OnUnwatchReceived { get; set; }
+
+        public string? TopicNamespace
+        {
+            get => PropertyNotifier.TopicNamespace;
+
+            set
+            {
+                PropertyWriteResponder.TopicNamespace = value;
+                PropertyReadResponder.TopicNamespace = value;
+                PropertyWatchResponder.TopicNamespace = value;
+                PropertyUnwatchResponder.TopicNamespace = value;
+                PropertyNotifier.TopicNamespace = value;
+            }
+        }
+
+        public PropertyMaintainer(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string>? topicTokenMap = null)
+        {
+            string topicPattern = AttributeRetriever.GetAttribute<PropertyTopicAttribute>(this)?.Topic ?? string.Empty;
+            topicTokenMap ??= new Dictionary<string, string>();
+
+            PropertyWriteResponder = new PropertyWriteResponder<TProp, TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern, OnCommandReceived = WriteInt, IsIdempotent = false };
+            PropertyReadResponder = new PropertyReadResponder<TProp, TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern, OnCommandReceived = ReadInt, IsIdempotent = true };
+            PropertyWatchResponder = new PropertyWatchResponder<TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern, OnCommandReceived = WatchInt, IsIdempotent = true };
+            PropertyUnwatchResponder = new PropertyUnwatchResponder<TBool>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { RequestTopicPattern = topicPattern, OnCommandReceived = UnwatchInt, IsIdempotent = true };
+            PropertyNotifier = new PropertyNotifier<TProp>(applicationContext, mqttClient, serializer, actionTopicToken, topicTokenMap) { TopicPattern = topicPattern };
+        }
+
+        public async Task NotifyAsync(TProp state, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? notifyTimeout = null, CancellationToken cancellationToken = default)
+        {
+            await PropertyNotifier.SendTelemetryAsync(state, metadata, additionalTopicTokenMap, qos, notifyTimeout, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task StartAsync(int? preferredDispatchConcurrency = null, CancellationToken cancellationToken = default)
+        {
+            await Task.WhenAll(
+                PropertyWriteResponder.StartAsync(preferredDispatchConcurrency, cancellationToken),
+                PropertyReadResponder.StartAsync(preferredDispatchConcurrency, cancellationToken),
+                PropertyWatchResponder.StartAsync(preferredDispatchConcurrency, cancellationToken),
+                PropertyUnwatchResponder.StartAsync(preferredDispatchConcurrency, cancellationToken)).ConfigureAwait(false);
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.WhenAll(
+                PropertyWriteResponder.StopAsync(cancellationToken),
+                PropertyReadResponder.StopAsync(cancellationToken),
+                PropertyWatchResponder.StopAsync(cancellationToken),
+                PropertyUnwatchResponder.StopAsync(cancellationToken)).ConfigureAwait(false);
+        }
+
+        private Task<ExtendedResponse<TBool>> WriteInt(ExtendedRequest<TProp> request, CancellationToken cancellationToken)
+        {
+            return OnWriteReceived(request, cancellationToken);
+        }
+
+        private Task<ExtendedResponse<TProp>> ReadInt(ExtendedRequest<TBool> request, CancellationToken cancellationToken)
+        {
+            return OnReadReceived(request, cancellationToken);
+        }
+
+        private Task<ExtendedResponse<TBool>> WatchInt(ExtendedRequest<TBool> request, CancellationToken cancellationToken)
+        {
+            return OnWatchReceived(request, cancellationToken);
+        }
+
+        private Task<ExtendedResponse<TBool>> UnwatchInt(ExtendedRequest<TBool> request, CancellationToken cancellationToken)
+        {
+            return OnUnwatchReceived(request, cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore(false).ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync(bool disposing)
+        {
+            await DisposeAsyncCore(disposing).ConfigureAwait(false);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    await PropertyWriteResponder.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyReadResponder.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyWatchResponder.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyUnwatchResponder.DisposeAsync(disposing).ConfigureAwait(false);
+                    await PropertyNotifier.DisposeAsync(disposing).ConfigureAwait(false);
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyNotifier.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyNotifier.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.Telemetry;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyNotifier<TProp> : TelemetrySender<TProp>
+        where TProp : class
+    {
+        public PropertyNotifier(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "notify" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyReadRequester.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyReadRequester.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyReadRequester<TProp, TBool> : CommandInvoker<TBool, TProp>
+        where TProp : class
+        where TBool : class
+    {
+        public PropertyReadRequester(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "read", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "read" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyReadResponder.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyReadResponder.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyReadResponder<TProp, TBool> : CommandExecutor<TBool, TProp>
+        where TProp : class
+        where TBool : class
+    {
+        public PropertyReadResponder(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "read", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "read" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyUnwatchRequester.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyUnwatchRequester.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyUnwatchRequester<TBool> : CommandInvoker<TBool, TBool>
+        where TBool : class
+    {
+        public PropertyUnwatchRequester(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "unwatch", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "unwatch" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyUnwatchResponder.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyUnwatchResponder.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyUnwatchResponder<TBool> : CommandExecutor<TBool, TBool>
+        where TBool : class
+    {
+        public PropertyUnwatchResponder(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "unwatch", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "unwatch" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWatchRequester.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWatchRequester.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyWatchRequester<TBool> : CommandInvoker<TBool, TBool>
+        where TBool : class
+    {
+        public PropertyWatchRequester(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "watch", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "watch" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWatchResponder.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWatchResponder.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyWatchResponder<TBool> : CommandExecutor<TBool, TBool>
+        where TBool : class
+    {
+        public PropertyWatchResponder(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "watch", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "watch" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWriteRequester.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWriteRequester.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyWriteRequester<TProp, TBool> : CommandInvoker<TProp, TBool>
+        where TProp : class
+        where TBool : class
+    {
+        public PropertyWriteRequester(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "write", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "write" } };
+        }
+    }
+}

--- a/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWriteResponder.cs
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/State/PropertyWriteResponder.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Iot.Operations.Protocol.RPC;
+
+namespace Azure.Iot.Operations.Protocol.State
+{
+    public class PropertyWriteResponder<TProp, TBool> : CommandExecutor<TProp, TBool>
+        where TProp : class
+        where TBool : class
+    {
+        public PropertyWriteResponder(ApplicationContext applicationContext, IMqttPubSubClient mqttClient, IPayloadSerializer serializer, string actionTopicToken, Dictionary<string, string> topicTokenMap)
+            : base(applicationContext, mqttClient, "write", serializer)
+        {
+            TopicTokenMap = new(topicTokenMap) { { actionTopicToken, "write" } };
+        }
+    }
+}


### PR DESCRIPTION
Still awaiting approval of the [ADR 23](https://github.com/Azure/iot-operations-sdks/pull/922), which defines SDK support for Property.  In parallel, this PR implements Property support in the .NET AIO SDK.