### PR TITLE
[Rust][Connector] Dataset cancel safe fix

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -680,8 +680,10 @@ pub struct AssetClient {
     asset_update_observation: azure_device_registry::AssetUpdateObservation,
     /// Internal watcher receiver that holds a snapshot of the latest update and whether it has
     /// been fully processed or not
+    #[getter(skip)]
     asset_update_watcher_rx: watch::Receiver<Asset>,
     /// Internal watcher sender that sends the latest update
+    #[getter(skip)]
     asset_update_watcher_tx: watch::Sender<Asset>,
     /// Internal sender for when new datasets are created
     #[getter(skip)]
@@ -1629,6 +1631,7 @@ impl DatasetClient {
 
         // wait until the update has been released. If the watch sender has been dropped, this means the Asset has been deleted/dropped
         if watch_receiver.changed().await.is_err() {
+            self.dataset_update_watcher_rx.mark_unchanged();
             return DatasetNotification::Deleted;
         }
         // create new forwarder, in case destination has changed
@@ -1674,6 +1677,7 @@ impl DatasetClient {
                 });
                 // notify the application to not use this dataset until a new update is received
                 self.dataset_definition = updated_dataset;
+                self.dataset_update_watcher_rx.mark_unchanged();
                 return DatasetNotification::UpdatedInvalid;
             }
         };


### PR DESCRIPTION
Problem: If a dataset had an invalid destination, it would return UpdateInvalid to the application, but it wouldn't mark the update notification as processed, so it would get processed indefinitely. This PR correctly marks it as processed so that it only gets processed once and then waits for the next update