### PR TITLE
[.NET][Akri] Fix DAsset action configuration field still being a JsonDocument

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/DiscoveredAsset.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/DiscoveredAsset.cs
@@ -86,7 +86,7 @@ public class DiscoveredAssetManagementGroup
 
 public class DiscoveredAssetManagementGroupAction
 {
-    public JsonDocument? ActionConfiguration { get; set; } = default;
+    public string? ActionConfiguration { get; set; } = default;
 
     public AssetManagementGroupActionType ActionType { get; set; } = default!;
 

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ProtocolConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ProtocolConverter.cs
@@ -175,7 +175,7 @@ internal static class ProtocolConverter
     return new AdrBaseService.DiscoveredAssetManagementGroupAction
     {
         Name = source.Name,
-        ActionConfiguration = source.ActionConfiguration?.RootElement.ToString(),
+        ActionConfiguration = source.ActionConfiguration,
         ActionType = source.ActionType.ToProtocol(),
         LastUpdatedOn = source.LastUpdatedOn,
         TypeRef = source.TypeRef,


### PR DESCRIPTION
The other similar fields were converted to strings a while ago, but I missed this one.