### PR TITLE
[.NET][Akri] Make asset file monitor filter out symlink files

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
@@ -366,7 +366,7 @@ namespace Azure.Iot.Operations.Connector.Files
         private bool isDeviceFile(string fileName)
         {
             // Ignore any symlink files like "..data" and ignore any files that don't look like {deviceName}_{inboundEndpointName}
-            return !fileName.StartsWith(".") && fileName.Contains("_");
+            return !fileName.StartsWith("..") && fileName.Contains("_");
         }
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Files/AssetFileMonitor.cs
@@ -156,7 +156,7 @@ namespace Azure.Iot.Operations.Connector.Files
                 _deviceDirectoryMonitor = _filesMonitorFactory.Create();
                 _deviceDirectoryMonitor.OnFileChanged += (sender, args) =>
                 {
-                    if (args.FileName.Contains("_"))
+                    if (isDeviceFile(args.FileName))
                     {
                         splitCompositeName(Path.GetFileName(args.FileName), out string foundDeviceName, out string foundInboundEndpointName);
 
@@ -220,7 +220,7 @@ namespace Azure.Iot.Operations.Connector.Files
                 foreach (string fileNameWithPath in files)
                 {
                     string fileName = Path.GetFileName(fileNameWithPath);
-                    if (fileName.Contains("_"))
+                    if (isDeviceFile(fileName))
                     {
                         splitCompositeName(Path.GetFileName(fileNameWithPath), out string foundDeviceName, out string foundInboundEndpointName);
                         if (foundDeviceName.Equals(deviceName))
@@ -245,7 +245,7 @@ namespace Azure.Iot.Operations.Connector.Files
                 foreach (string fileNameWithPath in files)
                 {
                     string fileName = Path.GetFileName(fileNameWithPath);
-                    if (fileName.Contains("_"))
+                    if (isDeviceFile(fileName))
                     {
                         splitCompositeName(Path.GetFileName(fileNameWithPath), out string foundDeviceName, out string foundInboundEndpointName);
                         deviceNames.Add(foundDeviceName);
@@ -266,7 +266,7 @@ namespace Azure.Iot.Operations.Connector.Files
                 foreach (string fileNameWithPath in files)
                 {
                     string fileName = Path.GetFileName(fileNameWithPath);
-                    if (fileName.Contains("_"))
+                    if (isDeviceFile(fileName))
                     {
                         compositeDeviceNames.Add(fileName);
                     }
@@ -361,6 +361,12 @@ namespace Azure.Iot.Operations.Connector.Files
 
             deviceName = compositeName.Substring(0, indexOfFirstUnderscore);
             inboundEndpointName = compositeName.Substring(indexOfFirstUnderscore + 1);
+        }
+
+        private bool isDeviceFile(string fileName)
+        {
+            // Ignore any symlink files like "..data" and ignore any files that don't look like {deviceName}_{inboundEndpointName}
+            return !fileName.StartsWith(".") && fileName.Contains("_");
         }
     }
 }

--- a/eng/test/test-connector-mount-files/adr-resources/..2025_22_7
+++ b/eng/test/test-connector-mount-files/adr-resources/..2025_22_7
@@ -1,0 +1,1 @@
+This test file simulates how symlinks manifest in kubernetes. It should not be treated as a device by any file monitor

--- a/eng/test/test-connector-mount-files/adr-resources/..data
+++ b/eng/test/test-connector-mount-files/adr-resources/..data
@@ -1,0 +1,1 @@
+This test file simulates how symlinks manifest in kubernetes. It should not be treated as a device by any file monitor


### PR DESCRIPTION
Any file in the adr resources folder that starts with ".." such as "..data" shouldn't be read as a device file

Add some example symlink files to the unit test directory that contains the actual device file we test with. Existing tests already validate the number of expected devices, so no change is needed in the unit tests themselves