### PR TITLE
[.NET] Expose RPC layer timeout in LE/LL APIs

### DIFF
--- a/dotnet/samples/Services/LeasedLockClient/Program.cs
+++ b/dotnet/samples/Services/LeasedLockClient/Program.cs
@@ -53,6 +53,7 @@ internal sealed class Program
                 await leasedLockClient.AcquireLockAsync(
                     leaseDuration,
                     null,
+                    null,
                     cancellationToken).ConfigureAwait(false);
 
             HybridLogicalClock fencingToken = response.FencingToken!;
@@ -87,6 +88,6 @@ internal sealed class Program
         }
 
         // nothing more to do while owning the lock, so release it
-        await leasedLockClient.ReleaseLockAsync(null, cancellationToken).ConfigureAwait(false);
+        await leasedLockClient.ReleaseLockAsync(null, null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/dotnet/samples/Services/PassiveReplication/PassiveReplicationNode.cs
+++ b/dotnet/samples/Services/PassiveReplication/PassiveReplicationNode.cs
@@ -12,7 +12,7 @@ namespace Azure.Iot.Operations.Services.PassiveReplicationSample
 {
     public class PassiveReplicationNode : BackgroundService, IAsyncDisposable
     {
-        private readonly StateStoreKey SharedResourceKeyToUpdate = new("someKeyToUpdate");
+        private readonly StateStoreKey _sharedResourceKeyToUpdate = new("someKeyToUpdate");
         private static readonly TimeSpan _electionTerm = TimeSpan.FromSeconds(1);
         private string? _lastKnownLeader;
 
@@ -102,6 +102,7 @@ namespace Azure.Iot.Operations.Services.PassiveReplicationSample
                 CampaignResponse campaignResponse = await _leaderElectionClient.CampaignAsync(
                     _electionTerm,
                     null,
+                    null,
                     cancellationToken);
 
                 _logger.LogInformation("Node {0} was elected leader. Current timestamp: {1} Fencing token: {2}", _leaderElectionClient.CandidateName, new HybridLogicalClock(), campaignResponse.FencingToken);
@@ -142,7 +143,7 @@ namespace Azure.Iot.Operations.Services.PassiveReplicationSample
                 // and try to alter a shared resource. By that point, another node will have acquired the lock and
                 // a newer fencing token will have been created.
                 StateStoreSetResponse setResponse = await _stateStoreClient.SetAsync(
-                    SharedResourceKeyToUpdate,
+                    _sharedResourceKeyToUpdate,
                     new StateStoreValue(Guid.NewGuid().ToString()),
                     new StateStoreSetRequestOptions()
                     {

--- a/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/ILeaderElectionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/ILeaderElectionClient.cs
@@ -65,6 +65,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// </summary>
         /// <param name="electionTerm">How long the client will be leader if elected. This value only has millisecond-level precision.</param>
         /// <param name="options">The optional parameters for this request.</param>
+        /// <param name="timeout">The maximum amount of time to wait for a service response to this request. By default, this is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The result of the campaign.</returns>
         /// <remarks>
@@ -73,13 +74,14 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// with <see cref="AutomaticRenewalOptions"/>, though.
         /// </para>
         /// </remarks>
-        Task<CampaignResponse> TryCampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, CancellationToken cancellationToken = default);
+        Task<CampaignResponse> TryCampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Await until this client is elected leader or cancellation is requested.
         /// </summary>
         /// <param name="electionTerm">How long the client will be leader if elected. This value only has millisecond-level precision.</param>
         /// <param name="options">The optional parameters for this request.</param>
+        /// <param name="timeoutPerRequest">The maximum amount of time to wait for a service response to each request sent during this method. The default value is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The result of the campaign.</returns>
         /// <remarks>
@@ -88,7 +90,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// with <see cref="AutomaticRenewalOptions"/>, though.
         /// </para>
         /// </remarks>
-        Task<CampaignResponse> CampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, CancellationToken cancellationToken = default);
+        Task<CampaignResponse> CampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, TimeSpan? timeoutPerRequest = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Block until elected leader, update the value of the state store resource based on
@@ -106,31 +108,35 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// it is possible that this client is interrupted or encounters a fatal exception. By setting a low value for this field,
         /// you limit how long the leadership position can be acquired for before it is released automatically by the service.
         /// </param>
+        /// <param name="timeoutPerRequest">The maximum amount of time to wait for a service response to each request sent during this method. The default value is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>
         /// This function will always resign from the leadership position if it was elected. Even if cancellation is requested
         /// after being elected leader, this function will resign from that position.
         /// </remarks>
-        Task CampaignAndUpdateValueAsync(StateStoreKey key, Func<StateStoreValue?, StateStoreValue?> updateValueFunc, TimeSpan? maximumTermLength = null, CancellationToken cancellationToken = default);
+        Task CampaignAndUpdateValueAsync(StateStoreKey key, Func<StateStoreValue?, StateStoreValue?> updateValueFunc, TimeSpan? maximumTermLength = null, TimeSpan? timeoutPerRequest = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get the name of the current leader.
         /// </summary>
+        /// <param name="timeout">The maximum amount of time to wait for a service response to this request. By default, this is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The details about the current leader.</returns>
-        Task<GetCurrentLeaderResponse> GetCurrentLeaderAsync(CancellationToken cancellationToken = default);
+        Task<GetCurrentLeaderResponse> GetCurrentLeaderAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Resign from being the leader.
         /// </summary>
         /// <param name="options">The optional parameters for this request.</param>
+        /// <param name="timeout">The maximum amount of time to wait for a service response to this request. By default, this is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The result of the attempted resignation.</returns>
-        Task<ResignationResponse> ResignAsync(ResignationRequestOptions? options = null, CancellationToken cancellationToken = default);
+        Task<ResignationResponse> ResignAsync(ResignationRequestOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Start receiving notifications when the leader changes.
         /// </summary>
+        /// <param name="timeout">The maximum amount of time to wait for a service response to this request. By default, this is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>
         /// Users who want to watch lock holder change events must first set one or more handlers on
@@ -138,11 +144,12 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// To stop watching lock holder change events, call <see cref="UnobserveLeadershipChangesAsync(CancellationToken)"/>
         /// and then remove any handlers from <see cref="LeadershipChangeEventReceivedAsync"/>.
         /// </remarks>
-        Task ObserveLeadershipChangesAsync(CancellationToken cancellationToken = default);
+        Task ObserveLeadershipChangesAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stop receiving notifications when the leader changes.
         /// </summary>
+        /// <param name="timeout">The maximum amount of time to wait for a service response to this request. By default, this is 10 seconds.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>
         /// Users who want to watch lock holder change events must first set one or more handlers on
@@ -150,6 +157,6 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         /// To stop watching lock holder change events, call this function
         /// and then remove any handlers from <see cref="LeadershipChangeEventReceivedAsync"/>.
         /// </remarks>
-        Task UnobserveLeadershipChangesAsync(CancellationToken cancellationToken = default);
+        Task UnobserveLeadershipChangesAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/LeaderElectionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/LeaderElection/LeaderElectionClient.cs
@@ -144,7 +144,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         }
 
         /// <inheritdoc/>
-        public virtual async Task<CampaignResponse> TryCampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<CampaignResponse> TryCampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
@@ -165,6 +165,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
                 await _leasedLockClient.TryAcquireLockAsync(
                     electionTerm,
                     acquireLockOptions,
+                    timeout,
                     cancellationToken).ConfigureAwait(false);
 
             return new CampaignResponse(
@@ -173,7 +174,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         }
 
         /// <inheritdoc/>
-        public virtual async Task<CampaignResponse> CampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<CampaignResponse> CampaignAsync(TimeSpan electionTerm, CampaignRequestOptions? options = null, TimeSpan? timeoutPerRequest = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
@@ -195,6 +196,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
                 await _leasedLockClient.AcquireLockAsync(
                     electionTerm,
                     acquireLockOptions,
+                    timeoutPerRequest,
                     cancellationToken).ConfigureAwait(false);
 
             return new CampaignResponse(
@@ -203,19 +205,19 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         }
 
         /// <inheritdoc/>
-        public async Task CampaignAndUpdateValueAsync(StateStoreKey key, Func<StateStoreValue?, StateStoreValue?> updateValueFunc, TimeSpan? maximumTermLength = null, CancellationToken cancellationToken = default)
+        public async Task CampaignAndUpdateValueAsync(StateStoreKey key, Func<StateStoreValue?, StateStoreValue?> updateValueFunc, TimeSpan? maximumTermLength = null, TimeSpan? timeoutPerRequest = null, CancellationToken cancellationToken = default)
         {
-            await _leasedLockClient.AcquireLockAndUpdateValueAsync(key, updateValueFunc, maximumTermLength, cancellationToken);
+            await _leasedLockClient.AcquireLockAndUpdateValueAsync(key, updateValueFunc, maximumTermLength, timeoutPerRequest, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public virtual async Task<GetCurrentLeaderResponse> GetCurrentLeaderAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<GetCurrentLeaderResponse> GetCurrentLeaderAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
 
             GetLockHolderResponse getLockHolderResponse =
-                await _leasedLockClient.GetLockHolderAsync(cancellationToken).ConfigureAwait(false);
+                await _leasedLockClient.GetLockHolderAsync(timeout, cancellationToken).ConfigureAwait(false);
 
             if (getLockHolderResponse.LockHolder == null)
             {
@@ -226,7 +228,7 @@ namespace Azure.Iot.Operations.Services.LeaderElection
         }
 
         /// <inheritdoc/>
-        public virtual async Task<ResignationResponse> ResignAsync(ResignationRequestOptions? options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<ResignationResponse> ResignAsync(ResignationRequestOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
@@ -240,27 +242,27 @@ namespace Azure.Iot.Operations.Services.LeaderElection
             };
 
             ReleaseLockResponse releaseLockResponse =
-                await _leasedLockClient.ReleaseLockAsync(releaseLockOptions, cancellationToken).ConfigureAwait(false);
+                await _leasedLockClient.ReleaseLockAsync(releaseLockOptions, timeout, cancellationToken).ConfigureAwait(false);
 
             return new ResignationResponse(releaseLockResponse.Success);
         }
 
         /// <inheritdoc/>
-        public virtual async Task ObserveLeadershipChangesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task ObserveLeadershipChangesAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            await _leasedLockClient.ObserveLockAsync(cancellationToken).ConfigureAwait(false);
+            await _leasedLockClient.ObserveLockAsync(timeout, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public virtual async Task UnobserveLeadershipChangesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task UnobserveLeadershipChangesAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            await _leasedLockClient.UnobserveLockAsync(cancellationToken).ConfigureAwait(false);
+            await _leasedLockClient.UnobserveLockAsync(timeout, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask DisposeAsync()

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeaderElection/LeaderElectionClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeaderElection/LeaderElectionClientTests.cs
@@ -26,6 +26,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock => mock.TryAcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(acquireLockResponse));
 
@@ -37,6 +38,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock.TryAcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
             Assert.True(response.IsLeader);
@@ -59,6 +61,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock => mock.TryAcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(acquireLockResponse));
 
@@ -70,6 +73,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock.TryAcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
 
@@ -93,6 +97,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock => mock.AcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(acquireLockResponse));
 
@@ -104,6 +109,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock.AcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
             Assert.True(response.IsLeader);
@@ -126,6 +132,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock => mock.AcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(acquireLockResponse));
 
@@ -137,6 +144,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
                 mock.AcquireLockAsync(
                     expectedDuration,
                     It.IsAny<AcquireLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
 
@@ -157,16 +165,16 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
 
             mockedLeasedLockClient.Setup(
                 mock => mock.GetLockHolderAsync(
-                    tokenSource.Token))
+                    null, tokenSource.Token))
                 .Returns(Task.FromResult(getLockHolderResponse));
 
 
             // act
-            GetCurrentLeaderResponse response = await leaderElectionClient.GetCurrentLeaderAsync(tokenSource.Token);
+            GetCurrentLeaderResponse response = await leaderElectionClient.GetCurrentLeaderAsync(null, tokenSource.Token);
 
             // assert
             mockedLeasedLockClient.Verify(mock =>
-                mock.GetLockHolderAsync(tokenSource.Token),
+                mock.GetLockHolderAsync(null, tokenSource.Token),
                 Times.Once());
             Assert.NotNull(response.CurrentLeader);
             Assert.Equal("somePreviousValue", response.CurrentLeader.GetString());
@@ -187,6 +195,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             mockedLeasedLockClient.Setup(
                 mock => mock.ReleaseLockAsync(
                     It.IsAny<ReleaseLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(releaseLockHolderResponse));
 
@@ -196,12 +205,13 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             };
 
             // act
-            ResignationResponse response = await leaderElectionClient.ResignAsync(options, tokenSource.Token);
+            ResignationResponse response = await leaderElectionClient.ResignAsync(options, null, tokenSource.Token);
 
             // assert
             mockedLeasedLockClient.Verify(mock =>
                 mock.ReleaseLockAsync(
                     It.IsAny<ReleaseLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
 
@@ -223,6 +233,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             mockedLeasedLockClient.Setup(
                 mock => mock.ReleaseLockAsync(
                     It.IsAny<ReleaseLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token))
                 .Returns(Task.FromResult(releaseLockHolderResponse));
 
@@ -232,12 +243,13 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             };
 
             // act
-            ResignationResponse response = await leaderElectionClient.ResignAsync(options, tokenSource.Token);
+            ResignationResponse response = await leaderElectionClient.ResignAsync(options, null, tokenSource.Token);
 
             // assert
             mockedLeasedLockClient.Verify(mock =>
                 mock.ReleaseLockAsync(
                     It.IsAny<ReleaseLockRequestOptions>(),
+                    It.IsAny<TimeSpan?>(),
                     tokenSource.Token),
                 Times.Once());
 
@@ -349,7 +361,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
 
             // act, assert
             await Assert.ThrowsAsync<ObjectDisposedException>(
-                async () => await leaderElectionClient.GetCurrentLeaderAsync(tokenSource.Token));
+                async () => await leaderElectionClient.GetCurrentLeaderAsync(null, tokenSource.Token));
         }
 
         [Fact]
@@ -376,14 +388,15 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
 
             mockedLeasedLockClient.Setup(
                 mock => mock.ObserveLockAsync(
-                    tokenSource.Token));
+                    null, tokenSource.Token));
 
             // act
-            await leaderElectionClient.ObserveLeadershipChangesAsync(tokenSource.Token);
+            await leaderElectionClient.ObserveLeadershipChangesAsync(null, tokenSource.Token);
 
             // assert
             mockedLeasedLockClient.Verify(mock =>
                 mock.ObserveLockAsync(
+                    null,
                     tokenSource.Token),
                 Times.Once());
 
@@ -399,14 +412,14 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeaderElection
             var leaderElectionClient = new LeaderElectionClient(mockedLeasedLockClient.Object);
 
             mockedLeasedLockClient.Setup(
-                mock => mock.UnobserveLockAsync(tokenSource.Token));
+                mock => mock.UnobserveLockAsync(null, tokenSource.Token));
 
             // act
-            await leaderElectionClient.UnobserveLeadershipChangesAsync(tokenSource.Token);
+            await leaderElectionClient.UnobserveLeadershipChangesAsync(null, tokenSource.Token);
 
             // assert
             mockedLeasedLockClient.Verify(mock =>
-                mock.UnobserveLockAsync(tokenSource.Token),
+                mock.UnobserveLockAsync(null, tokenSource.Token),
                 Times.Once());
 
             await leaderElectionClient.DisposeAsync();

--- a/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/LeasedLockClientTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.UnitTests/LeasedLock/LeasedLockClientTests.cs
@@ -219,7 +219,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                     tokenSource.Token))
                         .Returns(Task.FromResult(getResponse));
 
-            GetLockHolderResponse response = await leasedLockClient.GetLockHolderAsync(tokenSource.Token);
+            GetLockHolderResponse response = await leasedLockClient.GetLockHolderAsync(null, tokenSource.Token);
             Assert.NotNull(response.LockHolder);
             Assert.Equal(expectedValue.GetString(), response.LockHolder.GetString());
 
@@ -250,7 +250,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 SessionId = "someSessionId"
             };
 
-            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, tokenSource.Token);
+            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, null, tokenSource.Token);
 
             Assert.True(response.Success);
 
@@ -281,7 +281,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 SessionId = "someSessionId"
             };
 
-            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, tokenSource.Token);
+            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, null, tokenSource.Token);
 
             Assert.False(response.Success);
 
@@ -311,7 +311,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 CancelAutomaticRenewal = false,
             };
 
-            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, tokenSource.Token);
+            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, null, tokenSource.Token);
 
             Assert.True(response.Success);
 
@@ -341,7 +341,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 CancelAutomaticRenewal = false,
             };
 
-            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, tokenSource.Token);
+            ReleaseLockResponse response = await leasedLockClient.ReleaseLockAsync(options, null, tokenSource.Token);
 
             Assert.False(response.Success);
 
@@ -451,7 +451,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
 
             // act, assert
             await Assert.ThrowsAsync<ObjectDisposedException>(
-                async () => await leasedLockClient.GetLockHolderAsync(tokenSource.Token));
+                async () => await leasedLockClient.GetLockHolderAsync(null, tokenSource.Token));
         }
 
         [Fact]
@@ -484,7 +484,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 .Returns(Task.CompletedTask);
 
             // act
-            await leasedLockClient.ObserveLockAsync(tokenSource.Token);
+            await leasedLockClient.ObserveLockAsync(null, tokenSource.Token);
 
             // assert
             mockStateStoreClient.Verify(
@@ -513,7 +513,7 @@ namespace Azure.Iot.Operations.Services.Test.Unit.StateStore.LeasedLock
                 .Returns(Task.CompletedTask);
 
             // act
-            await leasedLockClient.UnobserveLockAsync(tokenSource.Token);
+            await leasedLockClient.UnobserveLockAsync(null, tokenSource.Token);
 
             // assert
             mockStateStoreClient.Verify(


### PR DESCRIPTION
Without this, all LE/LL RPC calls have an un-overridable 10 second timeout