### PR TITLE
[Rust][Connector] Add OTEL utilities to ConnectorArtifacts

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -15,12 +15,15 @@ publish = true
 azure_iot_operations_protocol = { version = "0.10.0-alpha.2", path = "../azure_iot_operations_protocol", registry = "aio-sdks"  }
 azure_iot_operations_services = { version = "0.9.0-alpha.4", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "0.10.0-alpha.1", path = "../azure_iot_operations_mqtt", registry = "aio-sdks"  }
+azure_iot_operations_otel = { version = "0.2.1", registry = "aio-sdks" }
 chrono.workspace = true
 derive-getters.workspace = true
 jmespath = "0.3.0"
 log.workspace = true
 notify.workspace = true
 notify-debouncer-full.workspace = true
+opentelemetry = { version = "0.24", features = ["metrics", "logs"]}
+opentelemetry_sdk =  {version = "0.24", features = ["metrics", "logs", "rt-tokio", "logs_level_enabled"]}
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -314,6 +314,7 @@ impl ConnectorArtifacts {
 
     /// Creates an [`azure_iot_operations_otel::config::Config`] struct from the values in the
     /// artifacts, given an OTEL tag and default log level.
+    #[must_use]
     pub fn to_otel_config(&self, otel_tag: &str, default_log_level: &str) -> aio_otel::config::Config {
 
         let mut log_targets = vec![];
@@ -1411,10 +1412,10 @@ mod tests {
         let otel_config = connector_artifacts
             .to_otel_config(OTEL_TAG, DEFAULT_LOG_LEVEL);
         assert_eq!(otel_config.service_name, OTEL_TAG);
-        assert_eq!(otel_config.emit_metrics_to_stdout, false);
-        assert_eq!(otel_config.emit_logs_to_stderr, true);
-        assert!(otel_config.metrics_export_targets.is_some_and(|targets| targets.len() == 0));
-        assert!(otel_config.log_export_targets.is_some_and(|targets| targets.len() == 0));
+        assert!(!otel_config.emit_metrics_to_stdout);
+        assert!(otel_config.emit_logs_to_stderr);
+        assert!(otel_config.metrics_export_targets.is_some_and(|targets| targets.is_empty()));
+        assert!(otel_config.log_export_targets.is_some_and(|targets| targets.is_empty()));
         assert!(otel_config.resource_attributes.is_some_and(|attrs| {
             attrs.len() == 1 &&
                 attrs[0].key == OTEL_RESOURCE_ID_KEY &&
@@ -1475,8 +1476,8 @@ mod tests {
         let otel_config = connector_artifacts
             .to_otel_config(OTEL_TAG, DEFAULT_LOG_LEVEL);
         assert_eq!(otel_config.service_name, OTEL_TAG);
-        assert_eq!(otel_config.emit_metrics_to_stdout, false);
-        assert_eq!(otel_config.emit_logs_to_stderr, true);
+        assert!(!otel_config.emit_metrics_to_stdout);
+        assert!(otel_config.emit_logs_to_stderr);
         assert!(otel_config.metrics_export_targets.is_some_and(|targets| {
             targets.len() == 1 &&
                 targets[0].url == GRPC_METRIC_ENDPOINT &&

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -361,11 +361,6 @@ impl ConnectorArtifacts {
                 key: OTEL_RESOURCE_ID_KEY.to_string(),
                 value: self.azure_extension_resource_id.clone(),
             },
-            // TODO: enable this
-            // aio_otel::config::Attribute {
-            //     key: CONNECTOR_ID_KEY.to_string(),
-            //     value: self.connector_id.clone(),
-            // },
         ];
         
         aio_otel::config::Config {

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -11,9 +11,15 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use azure_iot_operations_mqtt as aio_mqtt;
+use azure_iot_operations_otel as aio_otel;
+use opentelemetry::logs::Severity;
+use opentelemetry_sdk::metrics::data::Temporality;
 use serde::Deserialize;
 use serde_json;
 use thiserror::Error;
+
+const MICROSOFT_ENTERPRISE_NUMBER: &str = "311";
+const OTEL_RESOURCE_ID_KEY: &str = "microsoft.resourceId";
 
 /// Indicates an error occurred while parsing the artifacts in an Akri deployment
 #[derive(Error, Debug)]
@@ -201,8 +207,8 @@ impl ConnectorArtifacts {
         })
     }
 
-    /// Converts the value to an [`azure_iot_operations_mqtt::MqttConnectionSettings`] struct,
-    /// given a suffix for the client ID.
+    /// Creates an [`azure_iot_operations_mqtt::MqttConnectionSettings`] struct given a suffix for,
+    /// the client ID.
     ///
     /// # Errors
     /// Returns a string indicating the cause of the error
@@ -304,6 +310,75 @@ impl ConnectorArtifacts {
             .build()
             .map_err(|e| format!("{e}"))?;
         Ok(c)
+    }
+
+    /// Creates an [`azure_iot_operations_otel::config::Config`] struct from the values in the
+    /// artifacts, given an OTEL tag and default log level.
+    pub fn to_otel_config(&self, otel_tag: &str, default_log_level: &str) -> aio_otel::config::Config {
+
+        let mut log_targets = vec![];
+        let mut metric_targets = vec![];
+
+        // 1P logs
+        if let Some(log_endpoint) = &self.grpc_log_endpoint {
+            log_targets.push(aio_otel::config::LogsExportTarget {
+                url: log_endpoint.clone(),
+                interval_secs: 1,
+                timeout: 5,
+                export_severity: Some(Severity::Error),
+                ca_cert_path: self
+                    .grpc_log_collector_1p_ca_mount
+                    .clone()
+                    .and_then(|mount| mount.to_str().map(std::string::ToString::to_string)),
+                bearer_token_provider_fn: None,
+            });
+        }
+        // NOTE: HTTP currently unsupported for logs
+
+        // 1P metrics
+        if let Some(metric_endpoint) = &self.grpc_metric_endpoint {
+            metric_targets.push(aio_otel::config::MetricsExportTarget {
+                url: metric_endpoint.clone(),
+                interval_secs: 30,
+                timeout: 5,
+                temporality: Some(Temporality::Delta),
+                ca_cert_path: self
+                    .grpc_metric_collector_1p_ca_mount
+                    .clone()
+                    .and_then(|mount| mount.to_str().map(std::string::ToString::to_string)),
+                bearer_token_provider_fn: None,
+            });
+        }
+        // NOTE: HTTP currently unsupported for metrics
+
+        let level = match &self.connector_configuration.diagnostics {
+            Some(diagnostics) => diagnostics.logs.level.clone(),
+            None => default_log_level.to_string(),
+        };
+
+        let resource_attributes = vec![
+            aio_otel::config::Attribute {
+                key: OTEL_RESOURCE_ID_KEY.to_string(),
+                value: self.azure_extension_resource_id.clone(),
+            },
+            // TODO: enable this
+            // aio_otel::config::Attribute {
+            //     key: CONNECTOR_ID_KEY.to_string(),
+            //     value: self.connector_id.clone(),
+            // },
+        ];
+        
+        aio_otel::config::Config {
+            service_name: otel_tag.to_string(),
+            emit_metrics_to_stdout: false,
+            emit_logs_to_stderr: true,
+            metrics_export_targets: Some(metric_targets),
+            log_export_targets: Some(log_targets),
+            resource_attributes: Some(resource_attributes),
+            level,
+            prometheus_config: None,
+            enterprise_number: Some(MICROSOFT_ENTERPRISE_NUMBER.to_string()),
+        }
     }
 }
 
@@ -581,6 +656,10 @@ mod tests {
     const AZURE_EXTENSION_RESOURCE_ID: &str = "/subscriptions/extension/resource/id";
     const CONNECTOR_ID: &str = "connector_id";
     const CONNECTOR_NAMESPACE: &str = "connector_namespace";
+    const HOST: &str = "someHostName:1234";
+    const OTEL_TAG: &str = "otel_tag";
+    const LOG_LEVEL: &str = "debug";
+    const DEFAULT_LOG_LEVEL: &str = "warn,azure_iot_operations_rest_connector=info,azure_iot_operations_connector=info";
 
     // Stopgap env var constants
     const GRPC_METRIC_ENDPOINT: &str = "grpcs://metric.endpoint";
@@ -1294,6 +1373,144 @@ mod tests {
                 .is_err()
         );
     }
+
+    #[test]
+    fn convert_to_otel_config_minmum() {
+        let connector_artifacts = ConnectorArtifacts {
+            azure_extension_resource_id: AZURE_EXTENSION_RESOURCE_ID.to_string(),
+            connector_id: CONNECTOR_ID.to_string(),
+            connector_namespace: CONNECTOR_NAMESPACE.to_string(),
+            connector_configuration: ConnectorConfiguration {
+                mqtt_connection_configuration: MqttConnectionConfiguration {
+                    host: HOST.to_string(),
+                    keep_alive_seconds: 60,
+                    max_inflight_messages: 100,
+                    protocol: Protocol::Mqtt,
+                    session_expiry_seconds: 3600,
+                    tls: Tls {
+                        mode: TlsMode::Disabled,
+                    },
+                },
+                diagnostics: None,
+                persistent_volumes: vec![],
+                additional_configuration: None,
+            },
+            connector_secrets_metadata_mount: None,
+            connector_trust_settings_mount: None,
+            broker_trust_bundle_mount: None,
+            broker_sat_mount: None,
+            device_endpoint_trust_bundle_mount: None,
+            device_endpoint_credentials_mount: None,
+            // stopgaps
+            grpc_metric_endpoint: None,
+            grpc_log_endpoint: None,
+            grpc_trace_endpoint: None,
+            grpc_metric_collector_1p_ca_mount: None,
+            grpc_log_collector_1p_ca_mount: None,
+            http_metric_endpoint: None,
+            http_log_endpoint: None,
+            http_trace_endpoint: None,
+        };
+
+        // Convert to Otel config
+        let otel_config = connector_artifacts
+            .to_otel_config(OTEL_TAG, DEFAULT_LOG_LEVEL);
+        assert_eq!(otel_config.service_name, OTEL_TAG);
+        assert_eq!(otel_config.emit_metrics_to_stdout, false);
+        assert_eq!(otel_config.emit_logs_to_stderr, true);
+        assert!(otel_config.metrics_export_targets.is_some_and(|targets| targets.len() == 0));
+        assert!(otel_config.log_export_targets.is_some_and(|targets| targets.len() == 0));
+        assert!(otel_config.resource_attributes.is_some_and(|attrs| {
+            attrs.len() == 1 &&
+                attrs[0].key == OTEL_RESOURCE_ID_KEY &&
+                attrs[0].value == AZURE_EXTENSION_RESOURCE_ID
+        }));
+        assert_eq!(otel_config.level, DEFAULT_LOG_LEVEL);
+        assert!(otel_config.prometheus_config.is_none());
+        assert!(otel_config.enterprise_number.is_some_and(|v| v == MICROSOFT_ENTERPRISE_NUMBER));
+    }
+
+    #[test]
+    fn convert_to_otel_config_maximum() {
+        // NOTE: there do not need to be files in these stopgap mounts... I think
+        let grpc_metric_collector_1p_ca_mount = TempMount::new("1p_metrics_ca");
+        let grpc_log_collector_1p_ca_mount = TempMount::new("1p_logs_ca");
+
+        let connector_artifacts = ConnectorArtifacts {
+            azure_extension_resource_id: AZURE_EXTENSION_RESOURCE_ID.to_string(),
+            connector_id: CONNECTOR_ID.to_string(),
+            connector_namespace: CONNECTOR_NAMESPACE.to_string(),
+            connector_configuration: ConnectorConfiguration {
+                mqtt_connection_configuration: MqttConnectionConfiguration {
+                    host: HOST.to_string(),
+                    keep_alive_seconds: 60,
+                    max_inflight_messages: 100,
+                    protocol: Protocol::Mqtt,
+                    session_expiry_seconds: 3600,
+                    tls: Tls {
+                        mode: TlsMode::Disabled,
+                    },
+                },
+                diagnostics: Some(Diagnostics {
+                    logs: Logs {
+                        level: LOG_LEVEL.to_string()
+                    }
+                }),
+                persistent_volumes: vec![],
+                additional_configuration: None,
+            },
+            connector_secrets_metadata_mount: None,
+            connector_trust_settings_mount: None,
+            broker_trust_bundle_mount: None,
+            broker_sat_mount: None,
+            device_endpoint_trust_bundle_mount: None,
+            device_endpoint_credentials_mount: None,
+            // stopgaps
+            grpc_metric_endpoint: Some(GRPC_METRIC_ENDPOINT.to_string()),
+            grpc_log_endpoint: Some(GRPC_LOG_ENDPOINT.to_string()),
+            grpc_trace_endpoint: Some(GRPC_TRACE_ENDPOINT.to_string()),     // Unused
+            grpc_metric_collector_1p_ca_mount: Some(grpc_metric_collector_1p_ca_mount.path().to_path_buf()),
+            grpc_log_collector_1p_ca_mount: Some(grpc_log_collector_1p_ca_mount.path().to_path_buf()),
+            http_metric_endpoint: Some(HTTP_METRIC_ENDPOINT.to_string()),   // Unused
+            http_log_endpoint: Some(HTTP_LOG_ENDPOINT.to_string()),         // Unused
+            http_trace_endpoint: Some(HTTP_TRACE_ENDPOINT.to_string()),     // Unused
+        };
+
+        // Convert to Otel config
+        let otel_config = connector_artifacts
+            .to_otel_config(OTEL_TAG, DEFAULT_LOG_LEVEL);
+        assert_eq!(otel_config.service_name, OTEL_TAG);
+        assert_eq!(otel_config.emit_metrics_to_stdout, false);
+        assert_eq!(otel_config.emit_logs_to_stderr, true);
+        assert!(otel_config.metrics_export_targets.is_some_and(|targets| {
+            targets.len() == 1 &&
+                targets[0].url == GRPC_METRIC_ENDPOINT &&
+                targets[0].interval_secs == 30 &&
+                targets[0].timeout == 5 &&
+                targets[0].temporality == Some(Temporality::Delta) &&
+                targets[0].ca_cert_path == Some(grpc_metric_collector_1p_ca_mount.path().to_str().unwrap().to_string()) &&
+                targets[0].bearer_token_provider_fn.is_none()
+        }));
+        assert!(otel_config.log_export_targets.is_some_and(|targets| {
+            targets.len() == 1 &&
+                targets[0].url == GRPC_LOG_ENDPOINT &&
+                targets[0].interval_secs == 1 &&
+                targets[0].timeout == 5 &&
+                targets[0].export_severity == Some(Severity::Error) &&
+                targets[0].ca_cert_path == Some(grpc_log_collector_1p_ca_mount.path().to_str().unwrap().to_string()) &&
+                targets[0].bearer_token_provider_fn.is_none()
+        }));
+        assert!(otel_config.resource_attributes.is_some_and(|attrs| {
+            attrs.len() == 1 &&
+                attrs[0].key == OTEL_RESOURCE_ID_KEY &&
+                attrs[0].value == AZURE_EXTENSION_RESOURCE_ID
+        }));
+        assert_eq!(otel_config.level, LOG_LEVEL);
+        assert_ne!(otel_config.level, DEFAULT_LOG_LEVEL);
+        assert!(otel_config.prometheus_config.is_none());
+        assert!(otel_config.enterprise_number.is_some_and(|v| v == MICROSOFT_ENTERPRISE_NUMBER));
+    }
+
 
     // TODO: Simulate permissions issues in mounts
 }

--- a/rust/azure_iot_operations_connector/tests/artifact_tests.rs
+++ b/rust/azure_iot_operations_connector/tests/artifact_tests.rs
@@ -5,6 +5,7 @@ use azure_iot_operations_connector::deployment_artifacts::connector::{
     ConnectorArtifacts, Protocol, TlsMode,
 };
 use azure_iot_operations_mqtt::session::{Session, SessionOptionsBuilder};
+use azure_iot_operations_otel::Otel;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -103,6 +104,27 @@ fn local_connector_artifacts_tls() {
                 .build()
                 .unwrap();
             assert!(Session::new(session_options).is_ok());
+
+            // --- Create a Otel Config from the ConnectorArtifacts ---
+            let otel_config = artifacts.to_otel_config("my_otel_tag", "debug");
+            assert_eq!(otel_config.service_name, "my_otel_tag");
+            assert!(!otel_config.emit_metrics_to_stdout);
+            assert!(otel_config.emit_logs_to_stderr);
+            assert!(otel_config.metrics_export_targets.as_ref().is_some_and(Vec::is_empty));
+            assert!(otel_config.log_export_targets.as_ref().is_some_and(Vec::is_empty));
+            assert!(otel_config.resource_attributes.as_ref().is_some_and(|attrs| {
+                attrs.len() == 1 &&
+                attrs[0].key == "microsoft.resourceId" &&
+                attrs[0].value == "/subscriptions/extension/resource/id"
+            }));
+            assert_eq!(otel_config.level, "trace");
+            assert!(otel_config.prometheus_config.is_none());
+            assert_eq!(otel_config.enterprise_number, Some("311".to_string()));
+
+            // --- Create an Otel from the Otel Config ---
+            // NOTE: nothing to test here - the constructor can't fail. If that changes, expand.
+            let _ = Otel::new(otel_config);
+
         },
     );
 }
@@ -172,6 +194,27 @@ fn local_connector_artifacts_no_tls() {
                 .build()
                 .unwrap();
             assert!(Session::new(session_options).is_ok());
+
+            // --- Create a Otel Config from the ConnectorArtifacts ---
+            let otel_config = artifacts.to_otel_config("my_otel_tag", "debug");
+            assert_eq!(otel_config.service_name, "my_otel_tag");
+            assert!(!otel_config.emit_metrics_to_stdout);
+            assert!(otel_config.emit_logs_to_stderr);
+            assert!(otel_config.metrics_export_targets.as_ref().is_some_and(Vec::is_empty));
+            assert!(otel_config.log_export_targets.as_ref().is_some_and(Vec::is_empty));
+            assert!(otel_config.resource_attributes.as_ref().is_some_and(|attrs| {
+                attrs.len() == 1 &&
+                attrs[0].key == "microsoft.resourceId" &&
+                attrs[0].value == "/subscriptions/extension/resource/id"
+            }));
+            assert_eq!(otel_config.level, "trace");
+            assert!(otel_config.prometheus_config.is_none());
+            assert_eq!(otel_config.enterprise_number, Some("311".to_string()));
+
+            // --- Create an Otel from the Otel Config ---
+            // NOTE: nothing to test here - the constructor can't fail. If that changes, expand.
+            let _ = Otel::new(otel_config);
+
         },
     );
 }


### PR DESCRIPTION
- Added a dependency on the new `azure_iot_operations_otel` crate
- Added a `to_otel_config` method to `ConnectorArtifacts` that converts into `azure_iot_operations_otel::config::Config`