### PR TITLE
[.NET] Bump versions for first release since feature/akri merge

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>0.10.9-akri</VersionPrefix>
+    <VersionPrefix>0.11.0</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/Azure.Iot.Operations.Mqtt.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/Azure.Iot.Operations.Mqtt.csproj
@@ -7,7 +7,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>0.10.4-akri</VersionPrefix>
+    <VersionPrefix>0.11.0</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>0.10.5-akri</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <Nullable>enable</Nullable>
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -6,7 +6,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>0.10.8-akri</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>


### PR DESCRIPTION
Some versions on main eclipsed the versions on feature/akri, so they have all been bumped to the newest available minor version