### PR TITLE
[Codegen][Rust] Removing cacheable duration from generated code

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Command/t4/RustCommandExecutor.tt
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompiler/T4/communication/rust/Command/t4/RustCommandExecutor.tt
@@ -138,15 +138,6 @@ where
         let executor_options = executor_options_builder
             .request_topic_pattern(REQUEST_TOPIC_PATTERN)
             .command_name("<#=this.commandName.AsGiven#>")
-<# if (this.ttl != null) { #>
-            .cacheable_duration(
-                "<#=this.ttl#>"
-                    .parse::<iso8601_duration::Duration>()
-                    .unwrap()
-                    .to_std()
-                    .expect("TTL defined in DTDL schema exceeded maximum value"),
-            )
-<# } #>
             .is_idempotent(<#=this.isIdempotent ? "true" : "false"#>)
             .topic_token_map(topic_token_map)
 <# if (this.useSharedSubscription) { #>


### PR DESCRIPTION
- Cacheable duration no longer exists in the command executor options resulting in generated code that doesn't compile. Removing the generation in codegen.