### PR TITLE
[Rust][Services][Connector][Protocol] Version bump for 07-30-25 release

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -13,7 +13,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "0.11.0", path = "../azure_iot_operations_protocol", registry = "aio-sdks"  }
-azure_iot_operations_services = { version = "0.10.0", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "0.11.0", path = "../azure_iot_operations_services", registry = "aio-sdks", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "0.10.0", path = "../azure_iot_operations_mqtt", registry = "aio-sdks"  }
 azure_iot_operations_otel = { version = "0.2.1", registry = "aio-sdks" }
 chrono.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Services"


### PR DESCRIPTION
`services` 0.10.0 -> 0.11.0

`0.10.0` is an invalid version of the services crate.

In #969 

`protocol` 0.10.0 -> 0.11.0

In #968 

`services` 0.9.0 -> 0.10.0
`connector` 0.1.0 -> 0.2.0