### PR TITLE
[Rust][CI] fix machete version and remove unused deps

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -18,7 +18,6 @@ azure_iot_operations_mqtt = { version = "0.10.0", path = "../azure_iot_operation
 azure_iot_operations_otel = { version = "0.2.1", registry = "aio-sdks" }
 chrono.workspace = true
 derive-getters.workspace = true
-jmespath = "0.3.0"
 log.workspace = true
 notify.workspace = true
 notify-debouncer-full.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -44,7 +44,6 @@ derive_builder.workspace = true
 log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
 data-encoding = "2.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_repr = "0.1"

--- a/rust/ci/build-deps.sh
+++ b/rust/ci/build-deps.sh
@@ -24,6 +24,6 @@ cargo install \
     cargo-llvm-cov
 
 cargo install \
-    --version '^0.6' \
+    --version '^0.7' \
     --locked \
     cargo-machete

--- a/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
+++ b/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
@@ -12,10 +12,8 @@ azure_iot_operations_otel = { version = "0.2.1", registry = "aio-sdks" }
 azure_iot_operations_protocol = { version = "0.10.0", registry = "aio-sdks"  }
 env_logger = "0.11.3"
 log = "0.4.21"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.41", features = ["full"] }
-tokio-util = "0.7.11"
 
 [lints.rust]
 rust_2018_idioms = "deny"


### PR DESCRIPTION
Problem:
cargo machete wasn't running properly because the version we had didn't work with rust 2024 edition
Fix:
update to newer cargo machete version and update unused deps that it now catches