### PR TITLE
[Rust][Protocol][Services] Fix obfuscated error messages

### DIFF
--- a/rust/azure_iot_operations_protocol/src/common/topic_processor.rs
+++ b/rust/azure_iot_operations_protocol/src/common/topic_processor.rs
@@ -50,7 +50,7 @@ impl std::fmt::Display for TopicPatternError {
 #[derive(thiserror::Error, Debug)]
 pub enum TopicPatternErrorKind {
     /// The topic pattern is invalid
-    #[error("Topic pattern '{0}' is invalid")]
+    #[error("Invalid topic pattern: {0}")]
     Pattern(String),
     /// The share name is invalid
     #[error("Share name '{0}' is invalid")]

--- a/rust/azure_iot_operations_services/src/azure_device_registry.rs
+++ b/rust/azure_iot_operations_services/src/azure_device_registry.rs
@@ -142,7 +142,7 @@ pub struct ConfigStatus {
 
 // TODO: we cannot make a meaningful error message if everything is optional.
 #[derive(Clone, Debug, Default, PartialEq, Error)]
-#[error("{}", message.as_ref().unwrap_or(&"Unknown configuration error".to_string()))]
+#[error("{}", message.as_deref().unwrap_or("Unknown configuration error"))]
 /// Represents an error in the configuration of an asset or device.
 pub struct ConfigError {
     /// Error code for classification of errors (ex: '400', '404', '500', etc.).


### PR DESCRIPTION
This PR:
- fixes a bug where an ADR ConfigError would get logged always as "Configuration error" even when we had more details available
- fixes a double log that would happen on TopicPatternError
- updates TopicPatternErrorKind Pattern invalid to include the topic as part of the context to match other errors