### PR TITLE
[Connector metadata] Do not require any supported modeling

### DIFF
--- a/doc/akri_connector/connector-metadata-schema.json
+++ b/doc/akri_connector/connector-metadata-schema.json
@@ -717,7 +717,6 @@
           "additionalProperties": false,
           "required": [
             "endpointType",
-            "supportedModeling",
             "fields"
           ]
         }


### PR DESCRIPTION
The MQTT connector does not support any dataset/event/stream/etc modeling, so our schema should allow for that