### PR TITLE
Address more connector metadata schema feedback

### DIFF
--- a/doc/akri_connector/connector-metadata-schema.json
+++ b/doc/akri_connector/connector-metadata-schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/aio-connector-metadata-5.0-preview.json",
+  "$id": "https://json.schemastore.org/aio-connector-metadata-6.0-preview.json",
   "type": "object",
-  "title": "JSON schema for Azure IoT Operations Connector Metadata 5.0-preview",
+  "title": "JSON schema for Azure IoT Operations Connector Metadata 6.0-preview",
   "description": "Schema that defines how to write a connector metadata document when writing connectors for Azure IoT Operations solutions",
   "definitions": {
     "modelLimits": {
@@ -34,7 +34,7 @@
         },
         "topic": {
           "type": "string",
-          "description": "The default MQTT topic that will be published to"
+          "description": "The default MQTT topic that will be published to. Values are allowed to contain deploy-time parameters like \"mqtt/{deviceName}/{inboundEndpointName}/myMessages\". The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {connectorClientId}, {namespace}, and {endpointType}."
         },
         "qos": {
           "type": "integer",
@@ -66,7 +66,7 @@
         },
         "key": {
           "type": "string",
-          "description": "The default broker state store key that will be published to"
+          "description": "The default broker state store key that will be published to. Values are allowed to contain deploy-time parameters like \"dss/{deviceName}/{inboundEndpointName}\". The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {connectorClientId}, {namespace}, and {endpointType}."
         }
       },
       "additionalProperties": false,
@@ -83,7 +83,7 @@
         },
         "path": {
           "type": "string",
-          "description": "The default path that storage will use"
+          "description": "The default path that storage will use.  Values are allowed to contain deploy-time parameters like \"storage/{deviceName}/{inboundEndpointName}\". The supported parameter tokens are: {deviceName}, {inboundEndpointName}, {assetName}, {connectorClientId}, {namespace}, and {endpointType}."
         }
       },
       "additionalProperties": false,
@@ -138,7 +138,7 @@
       "type": "string",
       "description": "The version of AIO connector metadata schema that this connector metadata file adheres to.",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
-      "default": "5.0-preview"
+      "default": "6.0-preview"
     },
     "name": {
       "type": "string",
@@ -390,307 +390,279 @@
               "type": "string",
               "description": "The version of the protocol of this inbound endpoint."
             },
-            "supportedModeling": {
+            "events": {
               "type": "object",
-              "description": "The list of models that this connector supports using and additional details for how to use each model. If a model type is not present, that indicates this connector doesn't support using that model at all. A connector must support at least one type of modeling. A connector may support more than one type of modeling.",
+              "description": "If present, this connector supports using events.",
               "properties": {
-                "events": {
+                "limits": { "$ref": "#/definitions/modelLimits" },
+                "dataPoints": {
                   "type": "object",
-                  "description": "If present, this connector supports using events.",
+                  "description": "If present, this connector supports using event datapoints.",
                   "properties": {
                     "limits": { "$ref": "#/definitions/modelLimits" },
-                    "supportedModeling": {
-                      "type": "object",
-                      "description": "The list of event-specific models that this connector supports using and additional details for how to use each model. If a model type is not present, that indicates this connector doesn't support using that model at all. If this field isn't present, then this connector does not support modeling of any sub-event types like event datapoints.",
-                      "properties": {
-                        "dataPoints": {
-                          "type": "object",
-                          "description": "If present, this connector supports using event datapoints.",
-                          "properties": {
-                            "limits": { "$ref": "#/definitions/modelLimits" },
-                            "dataPointConfigurationSchema": {
-                              "$ref": "http://json-schema.org/draft-07/schema#",
-                              "description": "The JSON schema for the \"dataPointConfigurationSchema\" field on an event's datapoint."
-                            },
-                            "alternativeTypeName": {
-                              "$ref": "#/definitions/alternativeTypeName",
-                              "description": "The alternative name to the type \"dataPoints\" within an event"
-                            },
-                            "fields": {
-                              "type": "object",
-                              "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                              "properties": {
-                                "dataSource": {
-                                  "$ref": "#/definitions/fieldNecessity"
-                                }
-                              },
-                              "required": ["dataSource"],
-                              "additionalProperties": false
-                            }
-                          },
-                          "required": ["fields", "limits"]
-                        }
-                      },
-                      "additionalProperties": false
+                    "dataPointConfigurationSchema": {
+                      "$ref": "http://json-schema.org/draft-07/schema#",
+                      "description": "The JSON schema for the \"dataPointConfigurationSchema\" field on an event's datapoint."
                     },
                     "alternativeTypeName": {
                       "$ref": "#/definitions/alternativeTypeName",
-                      "description": "The alternative name to the type \"events\" within an asset"
-                    },
-                    "eventConfigurationSchema": {
-                      "$ref": "http://json-schema.org/draft-07/schema#",
-                      "description": "The JSON schema for the \"eventConfigurationSchema\" field on an event."
+                      "description": "The alternative name to the type \"dataPoints\" within an event"
                     },
                     "fields": {
                       "type": "object",
-                      "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                      "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
                       "properties": {
-                        "eventNotifier": {
+                        "dataSource": {
                           "$ref": "#/definitions/fieldNecessity"
-                        },
-                        "typeRef": { "$ref": "#/definitions/fieldNecessity" }
-                      },
-                      "required": ["eventNotifier", "typeRef"],
-                      "additionalProperties": false
-                    },
-                    "destinations": {
-                      "type": "object",
-                      "description": "Information about the supported and default destinations for asset events",
-                      "properties": {
-                        "supportedDestinations": {
-                          "type": "array",
-                          "description": "The array of destinations that this asset's events supports.",
-                          "items": {
-                            "type": "string",
-                            "enum": ["Mqtt", "Storage"]
-                          }
-                        },
-                        "defaultDestination": {
-                          "description": "The destination that this asset's events will go to by default unless specified otherwise in the asset or the event.",
-                          "oneOf": [
-                            { "$ref": "#/definitions/mqttDestinationDefaults" },
-                            {
-                              "$ref": "#/definitions/storageDestinationDefaults"
-                            }
-                          ]
                         }
                       },
-                      "additionalProperties": false,
-                      "required": ["supportedDestinations"]
+                      "required": ["dataSource"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["fields", "limits"]
+                },
+                "alternativeTypeName": {
+                  "$ref": "#/definitions/alternativeTypeName",
+                  "description": "The alternative name to the type \"events\" within an asset"
+                },
+                "eventConfigurationSchema": {
+                  "$ref": "http://json-schema.org/draft-07/schema#",
+                  "description": "The JSON schema for the \"eventConfigurationSchema\" field on an event."
+                },
+                "fields": {
+                  "type": "object",
+                  "description": "Describes if this connector expects these fields to be provided in the event definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                  "properties": {
+                    "eventNotifier": {
+                      "$ref": "#/definitions/fieldNecessity"
+                    },
+                    "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                  },
+                  "required": ["eventNotifier", "typeRef"],
+                  "additionalProperties": false
+                },
+                "destinations": {
+                  "type": "object",
+                  "description": "Information about the supported and default destinations for asset events",
+                  "properties": {
+                    "supportedDestinations": {
+                      "type": "array",
+                      "description": "The array of destinations that this asset's events supports.",
+                      "items": {
+                        "type": "string",
+                        "enum": ["Mqtt", "Storage"]
+                      }
+                    },
+                    "defaultDestination": {
+                      "description": "The destination that this asset's events will go to by default unless specified otherwise in the asset or the event.",
+                      "oneOf": [
+                        { "$ref": "#/definitions/mqttDestinationDefaults" },
+                        {
+                          "$ref": "#/definitions/storageDestinationDefaults"
+                        }
+                      ]
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["limits", "fields"]
+                  "required": ["supportedDestinations"]
+                }
+              },
+              "additionalProperties": false,
+              "required": ["limits", "fields"]
+            },
+            "datasets": {
+              "type": "object",
+              "description": "If present, this connector supports using datasets.",
+              "properties": {
+                "limits": { "$ref": "#/definitions/modelLimits" },
+                "datasetConfigurationSchema": {
+                  "$ref": "http://json-schema.org/draft-07/schema#",
+                  "description": "The JSON schema for the \"datasetConfigurationSchema\" field on a dataset."
                 },
-                "datasets": {
+                "dataPoints": {
                   "type": "object",
-                  "description": "If present, this connector supports using datasets.",
+                  "description": "If present, this connector supports using dataset datapoints.",
                   "properties": {
                     "limits": { "$ref": "#/definitions/modelLimits" },
-                    "datasetConfigurationSchema": {
+                    "dataPointConfigurationSchema": {
                       "$ref": "http://json-schema.org/draft-07/schema#",
-                      "description": "The JSON schema for the \"datasetConfigurationSchema\" field on a dataset."
-                    },
-                    "supportedModeling": {
-                      "type": "object",
-                      "description": "The list of dataset-specific models that this connector supports using and additional details for how to use each model. If a model type is not present, that indicates this connector doesn't support using that model at all. If this field isn't present, then this connector does not support modeling of any sub-dataset types like dataset datapoints.",
-                      "properties": {
-                        "dataPoints": {
-                          "type": "object",
-                          "description": "If present, this connector supports using dataset datapoints.",
-                          "properties": {
-                            "limits": { "$ref": "#/definitions/modelLimits" },
-                            "dataPointConfigurationSchema": {
-                              "$ref": "http://json-schema.org/draft-07/schema#",
-                              "description": "The JSON schema for the \"dataPointConfigurationSchema\" field on a dataset's datapoint."
-                            },
-                            "alternativeTypeName": {
-                              "$ref": "#/definitions/alternativeTypeName",
-                              "description": "The alternative name to the type \"dataPoints\" within a dataset"
-                            },
-                            "fields": {
-                              "type": "object",
-                              "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                              "properties": {
-                                "dataSource": {
-                                  "$ref": "#/definitions/fieldNecessity"
-                                },
-                                "typeRef": {
-                                  "$ref": "#/definitions/fieldNecessity"
-                                }
-                              },
-                              "required": ["dataSource", "typeRef"],
-                              "additionalProperties": false
-                            }
-                          }
-                        }
-                      },
-                      "additionalProperties": false
+                      "description": "The JSON schema for the \"dataPointConfigurationSchema\" field on a dataset's datapoint."
                     },
                     "alternativeTypeName": {
                       "$ref": "#/definitions/alternativeTypeName",
-                      "description": "The alternative name to the type \"datasets\" within an asset"
+                      "description": "The alternative name to the type \"dataPoints\" within a dataset"
                     },
                     "fields": {
                       "type": "object",
-                      "description": "Describes if this connector expects these fields to be provided in the dataset definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                      "description": "Describes if this connector expects these fields to be provided in the data point definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
                       "properties": {
                         "dataSource": {
                           "$ref": "#/definitions/fieldNecessity"
                         },
-                        "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                        "typeRef": {
+                          "$ref": "#/definitions/fieldNecessity"
+                        }
                       },
                       "required": ["dataSource", "typeRef"],
                       "additionalProperties": false
+                    }
+                  }
+                },
+                "alternativeTypeName": {
+                  "$ref": "#/definitions/alternativeTypeName",
+                  "description": "The alternative name to the type \"datasets\" within an asset"
+                },
+                "fields": {
+                  "type": "object",
+                  "description": "Describes if this connector expects these fields to be provided in the dataset definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                  "properties": {
+                    "dataSource": {
+                      "$ref": "#/definitions/fieldNecessity"
                     },
-                    "destinations": {
-                      "type": "object",
-                      "description": "Information about the supported and default destinations for asset datasets",
-                      "properties": {
-                        "supportedDestinations": {
-                          "type": "array",
-                          "description": "The array of destinations that this asset's datasets supports.",
-                          "items": {
-                            "type": "string",
-                            "enum": ["Mqtt", "BrokerStateStore", "Storage"]
-                          }
+                    "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                  },
+                  "required": ["dataSource", "typeRef"],
+                  "additionalProperties": false
+                },
+                "destinations": {
+                  "type": "object",
+                  "description": "Information about the supported and default destinations for asset datasets",
+                  "properties": {
+                    "supportedDestinations": {
+                      "type": "array",
+                      "description": "The array of destinations that this asset's datasets supports.",
+                      "items": {
+                        "type": "string",
+                        "enum": ["Mqtt", "BrokerStateStore", "Storage"]
+                      }
+                    },
+                    "defaultDestination": {
+                      "description": "The destination that this asset's datasets will go to by default unless specified otherwise in the asset or the dataset.",
+                      "oneOf": [
+                        { "$ref": "#/definitions/mqttDestinationDefaults" },
+                        {
+                          "$ref": "#/definitions/storageDestinationDefaults"
                         },
-                        "defaultDestination": {
-                          "description": "The destination that this asset's datasets will go to by default unless specified otherwise in the asset or the dataset.",
-                          "oneOf": [
-                            { "$ref": "#/definitions/mqttDestinationDefaults" },
-                            {
-                              "$ref": "#/definitions/storageDestinationDefaults"
-                            },
-                            {
-                              "$ref": "#/definitions/brokerStateStoreDestinationDefaults"
-                            }
-                          ]
+                        {
+                          "$ref": "#/definitions/brokerStateStoreDestinationDefaults"
                         }
-                      },
-                      "additionalProperties": false,
-                      "required": ["supportedDestinations"]
+                      ]
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["limits", "fields"]
-                },
-                "managementGroups": {
-                  "type": "object",
-                  "description": "If present, this connector supports using management groups.",
-                  "properties": {
-                    "limits": { "$ref": "#/definitions/modelLimits" },
-                    "managementGroupConfigurationSchema": {
-                      "$ref": "http://json-schema.org/draft-07/schema#",
-                      "description": "The JSON schema for the \"managementGroupConfigurationSchema\" field on a management group."
-                    },
-                    "alternativeTypeName": {
-                      "$ref": "#/definitions/alternativeTypeName",
-                      "description": "The alternative name to the type \"managementGroups\" within an asset"
-                    },
-                    "supportedModeling": {
-                      "type": "object",
-                      "description": "The list of management group-specific models that this connector supports using and additional details for how to use each model. If a model type is not present, that indicates this connector doesn't support using that model at all. If this field isn't present, then this connector does not support modeling of any sub-management group types like management group actions.",
-                      "properties": {
-                        "managementGroupActions": {
-                          "type": "object",
-                          "description": "If present, this connector supports using management group actions.",
-                          "properties": {
-                            "limits": { "$ref": "#/definitions/modelLimits" },
-                            "actionConfigurationSchema": {
-                              "$ref": "http://json-schema.org/draft-07/schema#",
-                              "description": "The JSON schema for the \"actionConfigurationSchema\" field on a management group's action."
-                            },
-                            "alternativeTypeName": {
-                              "$ref": "#/definitions/alternativeTypeName",
-                              "description": "The alternative name to the type \"actions\" within a management group"
-                            },
-                            "fields": {
-                              "type": "object",
-                              "description": "Describes if this connector expects these fields to be provided in the management group action definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                              "properties": {
-                                "targetUri": {
-                                  "$ref": "#/definitions/fieldNecessity"
-                                },
-                                "typeRef": {
-                                  "$ref": "#/definitions/fieldNecessity"
-                                }
-                              },
-                              "required": ["targetUri", "typeRef"],
-                              "additionalProperties": false
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": ["limits", "fields"]
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "fields": {
-                      "type": "object",
-                      "description": "Describes if this connector expects these fields to be provided in the management group definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                      "properties": {
-                        "typeRef": { "$ref": "#/definitions/fieldNecessity" }
-                      },
-                      "required": ["typeRef"],
-                      "additionalProperties": false
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": ["limits", "fields"]
-                },
-                "streams": {
-                  "type": "object",
-                  "description": "If present, this connector supports using streams.",
-                  "properties": {
-                    "limits": { "$ref": "#/definitions/modelLimits" },
-                    "streamConfigurationSchema": {
-                      "$ref": "http://json-schema.org/draft-07/schema#",
-                      "description": "The JSON schema for the \"streamConfigurationSchema\" field on a stream."
-                    },
-                    "alternativeTypeName": {
-                      "$ref": "#/definitions/alternativeTypeName",
-                      "description": "The alternative name to the type \"stream\" within an asset"
-                    },
-                    "fields": {
-                      "type": "object",
-                      "description": "Describes if this connector expects these fields to be provided in the stream definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
-                      "properties": {
-                        "typeRef": { "$ref": "#/definitions/fieldNecessity" }
-                      },
-                      "required": ["typeRef"],
-                      "additionalProperties": false
-                    },
-                    "destinations": {
-                      "type": "object",
-                      "description": "Information about the supported and default destinations for asset streams",
-                      "properties": {
-                        "supportedDestinations": {
-                          "type": "array",
-                          "description": "The array of destinations that this asset's streams supports.",
-                          "items": {
-                            "type": "string",
-                            "enum": ["Mqtt", "Storage"]
-                          }
-                        },
-                        "defaultDestination": {
-                          "description": "The destination that this asset's streams will go to by default unless unless specified otherwise in the asset or the stream.",
-                          "oneOf": [
-                            { "$ref": "#/definitions/mqttDestinationDefaults" },
-                            {
-                              "$ref": "#/definitions/storageDestinationDefaults"
-                            }
-                          ]
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": ["supportedDestinations"]
-                    }
-                  },
-                  "required": ["fields", "limits"]
+                  "required": ["supportedDestinations"]
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": false,
+              "required": ["limits", "fields"]
+            },
+            "managementGroups": {
+              "type": "object",
+              "description": "If present, this connector supports using management groups.",
+              "properties": {
+                "limits": { "$ref": "#/definitions/modelLimits" },
+                "managementGroupConfigurationSchema": {
+                  "$ref": "http://json-schema.org/draft-07/schema#",
+                  "description": "The JSON schema for the \"managementGroupConfigurationSchema\" field on a management group."
+                },
+                "alternativeTypeName": {
+                  "$ref": "#/definitions/alternativeTypeName",
+                  "description": "The alternative name to the type \"managementGroups\" within an asset"
+                },
+                "managementGroupActions": {
+                  "type": "object",
+                  "description": "If present, this connector supports using management group actions.",
+                  "properties": {
+                    "limits": { "$ref": "#/definitions/modelLimits" },
+                    "actionConfigurationSchema": {
+                      "$ref": "http://json-schema.org/draft-07/schema#",
+                      "description": "The JSON schema for the \"actionConfigurationSchema\" field on a management group's action."
+                    },
+                    "alternativeTypeName": {
+                      "$ref": "#/definitions/alternativeTypeName",
+                      "description": "The alternative name to the type \"actions\" within a management group"
+                    },
+                    "fields": {
+                      "type": "object",
+                      "description": "Describes if this connector expects these fields to be provided in the management group action definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                      "properties": {
+                        "targetUri": {
+                          "$ref": "#/definitions/fieldNecessity"
+                        },
+                        "typeRef": {
+                          "$ref": "#/definitions/fieldNecessity"
+                        }
+                      },
+                      "required": ["targetUri", "typeRef"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["limits", "fields"]
+                },
+                "fields": {
+                  "type": "object",
+                  "description": "Describes if this connector expects these fields to be provided in the management group definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                  "properties": {
+                    "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                  },
+                  "required": ["typeRef"],
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false,
+              "required": ["limits", "fields"]
+            },
+            "streams": {
+              "type": "object",
+              "description": "If present, this connector supports using streams.",
+              "properties": {
+                "limits": { "$ref": "#/definitions/modelLimits" },
+                "streamConfigurationSchema": {
+                  "$ref": "http://json-schema.org/draft-07/schema#",
+                  "description": "The JSON schema for the \"streamConfigurationSchema\" field on a stream."
+                },
+                "alternativeTypeName": {
+                  "$ref": "#/definitions/alternativeTypeName",
+                  "description": "The alternative name to the type \"stream\" within an asset"
+                },
+                "fields": {
+                  "type": "object",
+                  "description": "Describes if this connector expects these fields to be provided in the stream definition when deploying the connector. Also describes the expected shape of these values if they are supported.",
+                  "properties": {
+                    "typeRef": { "$ref": "#/definitions/fieldNecessity" }
+                  },
+                  "required": ["typeRef"],
+                  "additionalProperties": false
+                },
+                "destinations": {
+                  "type": "object",
+                  "description": "Information about the supported and default destinations for asset streams",
+                  "properties": {
+                    "supportedDestinations": {
+                      "type": "array",
+                      "description": "The array of destinations that this asset's streams supports.",
+                      "items": {
+                        "type": "string",
+                        "enum": ["Mqtt", "Storage"]
+                      }
+                    },
+                    "defaultDestination": {
+                      "description": "The destination that this asset's streams will go to by default unless unless specified otherwise in the asset or the stream.",
+                      "oneOf": [
+                        { "$ref": "#/definitions/mqttDestinationDefaults" },
+                        {
+                          "$ref": "#/definitions/storageDestinationDefaults"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": ["supportedDestinations"]
+                }
+              },
+              "required": ["fields", "limits"]
             }
           },
           "additionalProperties": false,

--- a/doc/akri_connector/example-connector-metadata.json
+++ b/doc/akri_connector/example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "5.0-preview",
+  "aioConnectorMetadataSchemaVersion": "6.0-preview",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",
@@ -35,8 +35,107 @@
           "description": "The HTTP address to connect to"
         }
       },
-      "supportedModeling": {
-        "datasets" : {
+      "supportedAuthenticationTypes": ["usernamePassword", "x509", "anonymous"],
+      "datasets" : {
+        "limits": { 
+          "minimum": 0
+        },
+        "fields": {
+          "dataSource": {
+            "input": "required",
+            "exampleValue": "some/path"
+          },
+          "typeRef": {
+            "input": "unsupported"
+          }
+        },
+        "destinations": {
+          "supportedDestinations" : ["Mqtt", "BrokerStateStore"],
+          "defaultDestination" : {
+            "destination": "BrokerStateStore",
+            "key": "{deviceName}/{inboundEndpointName}/{assetName}/someDssKey"
+          }
+        },
+        "datasetConfigurationSchema" : {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "$id": "https://contoso.com/datasetConfig.schema.json",
+          "title": "Dataset Config Schema",
+          "description": "The JSON schema for both the default dataset configuration field and all individual dataset-specific configuration fields",
+          "type": "object",
+          "properties": {
+            "SamplingInterval": {
+              "description": "How frequently to sample each dataset by default (in milliseconds)",
+              "type": "integer"
+            }
+          }
+        },
+        "dataPoints": {
+          "limits": { 
+            "minimum": 0
+          },
+          "dataSource": {
+            "input": "required",
+            "exampleValue": "some/path"
+          },
+          "typeRef": {
+            "input": "unsupported"
+          },
+          "dataPointConfigurationSchema" : {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "https://contoso.com/dataPointConfig.schema.json",
+            "title": "Datapoint Config Schema",
+            "description": "The JSON schema for both the default datapoint configuration field and all individual datapoint-specific configuration fields",
+            "type": "object",
+            "properties": {
+              "SamplingInterval": {
+                "description": "How frequently to sample each datapoint by default (in milliseconds)",
+                "type": "integer"
+              }
+            }
+          },
+          "alternativeTypeName": {
+            "singular": "tag",
+            "plural": "tags"
+          }
+        }
+      },
+      "events": {
+        "limits": { 
+          "minimum": 1
+        },
+        "fields": {
+          "eventNotifier": {
+            "input": "required",
+            "exampleValue": "some/path"
+          },
+          "typeRef": {
+            "input": "unsupported"
+          }
+        },
+        "destinations": {
+          "supportedDestinations" : ["Mqtt"],
+          "defaultDestination" : {
+            "destination": "Mqtt",
+            "topic": "{namespace}/{deviceName}/myDefaultPath",
+            "qos": 1,
+            "ttl": 10,
+            "retain": "never"
+          }
+        },
+        "eventConfigurationSchema" : {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "$id": "https://contoso.com/eventConfig.schema.json",
+          "title": "Event Config Schema",
+          "description": "The JSON schema for both the default event configuration field and all event-specific configuration fields",
+          "type": "object",
+          "properties": {
+            "SomeEventsProperty": {
+              "description": "Some configuration that is relevant to events",
+              "type": "integer"
+            }
+          }
+        },
+        "dataPoints": {
           "limits": { 
             "minimum": 0
           },
@@ -44,91 +143,13 @@
             "dataSource": {
               "input": "required",
               "exampleValue": "some/path"
-            },
-            "typeRef": {
-              "input": "unsupported"
             }
           },
-          "destinations": {
-            "supportedDestinations" : ["Mqtt", "BrokerStateStore"],
-            "defaultDestination" : {
-              "destination": "BrokerStateStore",
-              "key": "someDssKey"
-            }
-          },
-          "datasetConfigurationSchema" : {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": "https://contoso.com/datasetConfig.schema.json",
-            "title": "Dataset Config Schema",
-            "description": "The JSON schema for both the default dataset configuration field and all individual dataset-specific configuration fields",
-            "type": "object",
-            "properties": {
-              "SamplingInterval": {
-                "description": "How frequently to sample each dataset by default (in milliseconds)",
-                "type": "integer"
-              }
-            }
-          },
-          "supportedModeling": {
-            "dataPoints": {
-              "limits": { 
-                "minimum": 0
-              },
-              "dataSource": {
-                "input": "required",
-                "exampleValue": "some/path"
-              },
-              "typeRef": {
-                "input": "unsupported"
-              },
-              "dataPointConfigurationSchema" : {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "$id": "https://contoso.com/dataPointConfig.schema.json",
-                "title": "Datapoint Config Schema",
-                "description": "The JSON schema for both the default datapoint configuration field and all individual datapoint-specific configuration fields",
-                "type": "object",
-                "properties": {
-                  "SamplingInterval": {
-                    "description": "How frequently to sample each datapoint by default (in milliseconds)",
-                    "type": "integer"
-                  }
-                }
-              },
-              "alternativeTypeName": {
-                "singular": "tag",
-                "plural": "tags"
-              }
-            }
-          }
-        },
-        "events": {
-          "limits": { 
-            "minimum": 0
-          },
-          "fields": {
-            "eventNotifier": {
-              "input": "required",
-              "exampleValue": "some/path"
-            },
-            "typeRef": {
-              "input": "unsupported"
-            }
-          },
-          "destinations": {
-            "supportedDestinations" : ["Mqtt"],
-            "defaultDestination" : {
-              "destination": "Mqtt",
-              "topic": "some/mqtt/path",
-              "qos": 1,
-              "ttl": 10,
-              "retain": "never"
-            }
-          },
-          "eventConfigurationSchema" : {
+          "dataPointConfigurationSchema" : {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "$id": "https://contoso.com/eventConfig.schema.json",
-            "title": "Event Config Schema",
-            "description": "The JSON schema for both the default event configuration field and all event-specific configuration fields",
+            "title": "Event Datapoint Config Schema",
+            "description": "The JSON schema for both the default event datapoint configuration field and all event-specific datapoint configuration fields",
             "type": "object",
             "properties": {
               "SomeEventsProperty": {
@@ -136,50 +157,24 @@
                 "type": "integer"
               }
             }
-          },
-          "supportedModeling":{
-            "dataPoints": {
-              "limits": { 
-                "minimum": 0
-              },
-              "fields": {
-                "dataSource": {
-                  "input": "required",
-                  "exampleValue": "some/path"
-                }
-              },
-              "dataPointConfigurationSchema" : {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "$id": "https://contoso.com/eventConfig.schema.json",
-                "title": "Event Datapoint Config Schema",
-                "description": "The JSON schema for both the default event datapoint configuration field and all event-specific datapoint configuration fields",
-                "type": "object",
-                "properties": {
-                  "SomeEventsProperty": {
-                    "description": "Some configuration that is relevant to events",
-                    "type": "integer"
-                  }
-                }
-              }
-            }
+          }
+        }
+      },
+      "streams": {
+        "limits" : { 
+          "minimum": 0
+        },
+        "fields": {
+          "typeRef": {
+            "input": "required",
+            "exampleValue": "someTypeRef"
           }
         },
-        "streams": {
-          "limits" : { 
-            "minimum": 0
-          },
-          "fields": {
-            "typeRef": {
-              "input": "required",
-              "exampleValue": "someTypeRef"
-            }
-          },
-          "destinations": {
-            "supportedDestinations" : ["Mqtt", "Storage"],
-            "defaultDestination" : {
-              "destination": "Storage",
-              "path": "some/storage/path"
-            }
+        "destinations": {
+          "supportedDestinations" : ["Mqtt", "Storage"],
+          "defaultDestination" : {
+            "destination": "Storage",
+            "path": "{assetName}/some/storage/path"
           }
         }
       }

--- a/doc/akri_connector/minimal-example-connector-metadata.json
+++ b/doc/akri_connector/minimal-example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "5.0-preview",
+  "aioConnectorMetadataSchemaVersion": "6.0-preview",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",
@@ -20,46 +20,44 @@
           "description": "The HTTP address to connect to"
         }
       },
-      "supportedModeling": {
-        "datasets" : {
-          "limits": { 
-            "minimum": 0
+      "datasets" : {
+        "limits": { 
+          "minimum": 0
+        },
+        "fields": {
+          "dataSource": {
+            "input": "required",
+            "exampleValue": "some/http/path"
           },
-          "fields": {
-            "dataSource": {
-              "input": "required",
-              "exampleValue": "some/http/path"
+          "typeRef": {
+            "input": "unsupported"
+          }
+        },
+        "datasetConfigurationSchema" : {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "$id": "https://contoso.com/datasetConfig.schema.json",
+          "title": "Dataset Config Schema",
+          "description": "The JSON schema for both the default dataset configuration field and all individual dataset-specific configuration fields",
+          "type": "object",
+          "properties": {
+            "SamplingInterval": {
+              "description": "How frequently to sample each dataset by default (in milliseconds)",
+              "type": "integer"
+            }
+          }
+        },
+        "supportedModeling": {
+          "dataPoints" : { 
+            "limits" : { 
+              "minimum":0
             },
-            "typeRef": {
-              "input": "unsupported"
-            }
-          },
-          "datasetConfigurationSchema" : {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": "https://contoso.com/datasetConfig.schema.json",
-            "title": "Dataset Config Schema",
-            "description": "The JSON schema for both the default dataset configuration field and all individual dataset-specific configuration fields",
-            "type": "object",
-            "properties": {
-              "SamplingInterval": {
-                "description": "How frequently to sample each dataset by default (in milliseconds)",
-                "type": "integer"
-              }
-            }
-          },
-          "supportedModeling": {
-            "dataPoints" : { 
-              "limits" : { 
-                "minimum":0
+            "fields": {
+              "dataSource": {
+                "input": "optional",
+                "exampleValue": "some/http/path"
               },
-              "fields": {
-                "dataSource": {
-                  "input": "optional",
-                  "exampleValue": "some/http/path"
-                },
-                "typeRef": {
-                  "input": "optional"
-                }
+              "typeRef": {
+                "input": "optional"
               }
             }
           }


### PR DESCRIPTION
- Allow for parameterized tokens such as {assetName} and {namespace} in the default MQTT topic + default dss key, + default storage path
- Un-nest the "supportedModeling" types