### PR TITLE
[Rust][Connector][Services] Integrate new separate key and intermediate cert secret

### DIFF
--- a/eng/dtdl/adr-base-service.json
+++ b/eng/dtdl/adr-base-service.json
@@ -988,6 +988,18 @@
                                       "name": "certificateSecretName",
                                       "description": "The name of the secret containing the certificate and private key (e.g. stored as .der/.pem or .der/.pfx).",
                                       "schema": "string"
+                                    },
+                                    {
+                                      "@type": "Field",
+                                      "name": "intermediateCertificatesSecretName",
+                                      "description": "A reference to the secret containing the combined intermediate certificates in PEM format.",
+                                      "schema": "string"
+                                    },
+                                    {
+                                      "@type": "Field",
+                                      "name": "keySecretName",
+                                      "description": "A reference to the secret containing the certificate private key in PEM or DER format.",
+                                      "schema": "string"
                                     }
                                   ]
                                 }

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2853,8 +2853,17 @@ impl DeviceSpecification {
             adr_models::Authentication::Anonymous => Authentication::Anonymous,
             adr_models::Authentication::Certificate {
                 certificate_secret_name,
+                intermediate_certificates_secret_name,
+                key_secret_name,
             } => Authentication::Certificate {
                 certificate_path: device_endpoint_credentials_mount_path.expect("device_endpoint_credentials_mount_path must be present if Authentication is Certificate").as_path().join(certificate_secret_name),
+                intermediate_certificates_path: intermediate_certificates_secret_name.map(|intermediate_cert_secret_name| {
+                    device_endpoint_credentials_mount_path.expect("device_endpoint_credentials_mount_path must be present if Authentication is Certificate").as_path().join(intermediate_cert_secret_name)
+                }),
+                key_path: key_secret_name.map(|key_secret_name| {
+                    device_endpoint_credentials_mount_path.expect("device_endpoint_credentials_mount_path must be present if Authentication is Certificate").as_path().join(key_secret_name)
+                }),
+
             },
             adr_models::Authentication::UsernamePassword {
                 password_secret_name,
@@ -2930,8 +2939,12 @@ pub enum Authentication {
     Anonymous,
     /// Represents authentication using a certificate.
     Certificate {
-        /// The 'certificateSecretName' Field.
+        /// The path to a file containing containing the client certificate in PEM format.
         certificate_path: PathBuf, // different from adr
+        /// The path to a file containing the private key in PEM or DER format.
+        key_path: Option<PathBuf>, // different from adr
+        /// The path to a file containing the combined intermediate certificates in PEM format (if any).
+        intermediate_certificates_path: Option<PathBuf>, // different from adr
     },
     /// Represents authentication using a username and password.
     UsernamePassword {

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2941,10 +2941,10 @@ pub enum Authentication {
     Certificate {
         /// The path to a file containing containing the client certificate in PEM format.
         certificate_path: PathBuf, // different from adr
-        /// The path to a file containing the private key in PEM or DER format.
-        key_path: Option<PathBuf>, // different from adr
         /// The path to a file containing the combined intermediate certificates in PEM format (if any).
         intermediate_certificates_path: Option<PathBuf>, // different from adr
+        /// The path to a file containing the private key in PEM or DER format.
+        key_path: Option<PathBuf>, // different from adr
     },
     /// Represents authentication using a username and password.
     UsernamePassword {

--- a/rust/azure_iot_operations_services/src/azure_device_registry/adr_base_gen/adr_base_service/x509credentials_schema.rs
+++ b/rust/azure_iot_operations_services/src/azure_device_registry/adr_base_gen/adr_base_service/x509credentials_schema.rs
@@ -16,4 +16,16 @@ pub struct X509credentialsSchema {
     /// The name of the secret containing the certificate and private key (e.g. stored as .der/.pem or .der/.pfx).
     #[serde(rename = "certificateSecretName")]
     pub certificate_secret_name: String,
+
+    /// A reference to the secret containing the combined intermediate certificates in PEM format.
+    #[serde(rename = "intermediateCertificatesSecretName")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "None")]
+    pub intermediate_certificates_secret_name: Option<String>,
+
+    /// A reference to the secret containing the certificate private key in PEM or DER format.
+    #[serde(rename = "keySecretName")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "None")]
+    pub key_secret_name: Option<String>,
 }


### PR DESCRIPTION
This PR incorporates changes to ADR which add a separate key and intermediate certificate as optional fields when specifying authentication as x509Certificate.