### PR TITLE
Update connector metadata schema to version 8.0-preview

### DIFF
--- a/doc/akri_connector/connector-metadata-schema.json
+++ b/doc/akri_connector/connector-metadata-schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/aio-connector-metadata-7.0-preview.json",
+  "$id": "https://json.schemastore.org/aio-connector-metadata-8.0-preview.json",
   "type": "object",
-  "title": "JSON schema for Azure IoT Operations Connector Metadata 7.0-preview",
+  "title": "JSON schema for Azure IoT Operations Connector Metadata 8.0-preview",
   "description": "Schema that defines how to write a connector metadata document when writing connectors for Azure IoT Operations solutions",
   "definitions": {
     "modelLimits": {
@@ -134,11 +134,10 @@
     }
   },
   "properties": {
-    "aioConnectorMetadataSchemaVersion": {
+    "$schema": {
       "type": "string",
-      "description": "The version of AIO connector metadata schema that this connector metadata file adheres to.",
-      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
-      "default": "6.0-preview"
+      "description": "The address of the AIO connector metadata schema that this connector metadata file adheres to.",
+      "default": "https://raw.githubusercontent.com/Azure/iot-operations-sdks/refs/heads/main/doc/akri_connector/connector-metadata-schema.json"
     },
     "name": {
       "type": "string",
@@ -264,7 +263,6 @@
         }
       ],
       "minItems": 1,
-      "additionalItems": false,
       "uniqueItems": true
     },
     "sourceCode": {

--- a/doc/akri_connector/example-connector-metadata.json
+++ b/doc/akri_connector/example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "7.0-preview",
+  "$schema": "./connector-metadata-schema.json",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",
@@ -9,7 +9,7 @@
     "imageName": "RestConnector",
     "tag": "1.0.0"
   },
-  "supportedArchitectures": ["linux/amd64"],
+  "supportedArchitectures": ["linux/amd64", "linux/arm64"],
   "sourceCode": {
     "language": ".NET",
     "languageVersion": ".NET 8.0",

--- a/doc/akri_connector/minimal-example-connector-metadata.json
+++ b/doc/akri_connector/minimal-example-connector-metadata.json
@@ -1,5 +1,5 @@
 {
-  "aioConnectorMetadataSchemaVersion": "7.0-preview",
+  "$schema": "./connector-metadata-schema.json",
   "name": "RestConnector",
   "description": "Connector for polling a REST server for information",
   "version": "1.0.0",


### PR DESCRIPTION
- Fix bug where multiple supported architectures could not be specified
- Specify pointer to schema doc rather than specifying version of the schema to use
    - This gives most JSON editors the ability to check schema validity while writing it