### PR TITLE
[Rust][Connector] Add log for invalid destination on new data operation

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2177,7 +2177,7 @@ impl DataOperationClient {
             }
         }
         .inspect_err(|e| {
-            log::error!("Invalid destination for data_operation: {data_operation_ref:?} {e:?}")
+            log::error!("Invalid destination for data_operation: {data_operation_ref:?} {e:?}");
         })?;
         Ok(Self {
             data_operation_ref,


### PR DESCRIPTION
Problem:
If an invalid topic is specified as an MQTT destination for a dataset or event as an asset update, it's logged as an error. However, if this is part of the original asset definition, no error is logged and it isn't clear to the customer why data isn't flowing.
Note: the error status is still reported to ADR, so the correct error state can be found there.

This PR adds logging for this scenario