### PR TITLE
[Rust][Connector] Bump crate version invalid destination on new data operation log

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"


### PR DESCRIPTION
connector 0.5.1 -> 0.5.2