### PR TITLE
[.NET] Don't unsubscribe from notifications from a freshly deleted asset/device

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/AzureDeviceRegistryClientWrapper.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/AzureDeviceRegistryClientWrapper.cs
@@ -204,7 +204,7 @@ namespace Azure.Iot.Operations.Connector
         {
             if (e.ChangeType == FileChangeType.Deleted)
             {
-                // Do not set notification preference for asset updates to "off" for this asset because the ADR service no longers knows this asset. Notifications will cease automatically.
+                // Do not set notification preference for asset updates to "off" for this asset because the ADR service no longer knows this asset. Notifications will cease automatically.
                 AssetChanged?.Invoke(this, new(e.DeviceName, e.InboundEndpointName, e.AssetName, ChangeType.Deleted, null));
             }
             else if (e.ChangeType == FileChangeType.Created)
@@ -236,7 +236,7 @@ namespace Azure.Iot.Operations.Connector
         {
             if (e.ChangeType == FileChangeType.Deleted)
             {
-                // Do not set notification preference for device updates to "off" for this device because the ADR service no longers knows this device. Notifications will cease automatically.
+                // Do not set notification preference for device updates to "off" for this device because the ADR service no longer knows this device. Notifications will cease automatically.
                 DeviceChanged?.Invoke(this, new(e.DeviceName, e.InboundEndpointName, ChangeType.Deleted, null));
             }
             else if (e.ChangeType == FileChangeType.Created)


### PR DESCRIPTION
Builds on what turns out to only be a partial fix in #1019 

Should fix #1130

Context: The ADR service will return a 404 error if you try to set notification preferences for a device or asset that once existed but now does not exist. The SDK used to try to unsubscribe from notifications once a device or asset was deleted, but now it won't.