### PR TITLE
Enhance pod readiness checks for connectors in CI workflow

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -150,17 +150,31 @@ jobs:
       run: |
         echo "Waiting for rest-server-deployment to be ready..."
         kubectl rollout status deployment/rest-server-deployment -n azure-iot-operations --timeout=120s
-        echo "Waiting for connector pod to be ready..."
-        kubectl wait --for=condition=ready pod -l akri.iotoperations.azure.com/deviceinboundendpointtype=rest-thermostat-endpoint-type -n azure-iot-operations --timeout=120s || true
-        kubectl get pods -n azure-iot-operations -l akri.iotoperations.azure.com/deviceinboundendpointtype=rest-thermostat-endpoint-type
+        echo "Waiting for connector pod to appear and be ready..."
+        for i in {1..30}; do
+          if kubectl get pods -n azure-iot-operations | grep -q "rest-ctemplate.*Running"; then
+            echo "Connector pod is running"
+            break
+          fi
+          echo "Waiting for connector pod... ($i/30)"
+          sleep 2
+        done
+        kubectl get pods -n azure-iot-operations | grep rest-ctemplate || echo "No rest-ctemplate pods found"
 
     - name: Wait for Event Driven TCP Connector to be ready
       run: |
         echo "Waiting for tcp-service-deployment to be ready..."
         kubectl rollout status deployment/tcp-service-deployment -n azure-iot-operations --timeout=120s
-        echo "Waiting for connector pod to be ready..."
-        kubectl wait --for=condition=ready pod -l 'akri.iotoperations.azure.com/deviceinboundendpointtype=Microsoft.Tcp' -n azure-iot-operations --timeout=120s || true
-        kubectl get pods -n azure-iot-operations -l 'akri.iotoperations.azure.com/deviceinboundendpointtype=Microsoft.Tcp'
+        echo "Waiting for connector pod to appear and be ready..."
+        for i in {1..30}; do
+          if kubectl get pods -n azure-iot-operations | grep -q "tcp-ctemplate.*Running"; then
+            echo "Connector pod is running"
+            break
+          fi
+          echo "Waiting for connector pod... ($i/30)"
+          sleep 2
+        done
+        kubectl get pods -n azure-iot-operations | grep tcp-ctemplate || echo "No tcp-ctemplate pods found"
 
     - name: Wait for SQL Connector to be ready
       run: |
@@ -168,9 +182,16 @@ jobs:
         kubectl rollout status deployment/mssql-deployment -n azure-iot-operations --timeout=180s
         echo "Waiting for SQL pod to be fully initialized..."
         kubectl wait --for=condition=ready pod -l app=mssql -n azure-iot-operations --timeout=120s
-        echo "Waiting for connector pod to be ready..."
-        kubectl wait --for=condition=ready pod -l akri.iotoperations.azure.com/deviceinboundendpointtype=qualityanalyzer-profile-sql-server -n azure-iot-operations --timeout=120s || true
-        kubectl get pods -n azure-iot-operations -l akri.iotoperations.azure.com/deviceinboundendpointtype=qualityanalyzer-profile-sql-server
+        echo "Waiting for connector pod to appear and be ready..."
+        for i in {1..30}; do
+          if kubectl get pods -n azure-iot-operations | grep -q "sql-ctemplate.*Running"; then
+            echo "Connector pod is running"
+            break
+          fi
+          echo "Waiting for connector pod... ($i/30)"
+          sleep 2
+        done
+        kubectl get pods -n azure-iot-operations | grep sql-ctemplate || echo "No sql-ctemplate pods found"
 
     - name: Verify all connector pods are running
       run: |
@@ -178,7 +199,10 @@ jobs:
         kubectl get pods -n azure-iot-operations
         echo ""
         echo "=== Connector Pods Status ==="
-        kubectl get pods -n azure-iot-operations -l akri.iotoperations.azure.com/connector-name
+        kubectl get pods -n azure-iot-operations | grep ctemplate || echo "No connector pods found"
+        echo ""
+        echo "=== Service Pods Status ==="
+        kubectl get pods -n azure-iot-operations | grep -E "(rest-server|tcp-service|mssql)" || echo "No service pods found"
         echo ""
         echo "Giving connectors additional time to stabilize..."
         sleep 10


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/ci-dotnet.yml` to improve the reliability of waiting for connector pods to be ready. Instead of relying solely on label-based readiness checks, it now uses a loop to actively poll for pods matching expected names and running status, and adds additional status output for better visibility.

Improvements to pod readiness checks:

* Replaced label-based `kubectl wait` commands with a polling loop that checks for connector pods (`rest-ctemplate`, `tcp-ctemplate`, `sql-ctemplate`) to appear and reach the `Running` state, improving robustness against timing issues.

Enhancements to status reporting:

* Updated connector pod status checks to use `grep ctemplate` for more direct verification, and added explicit output for service pods (`rest-server`, `tcp-service`, `mssql`) to improve visibility into pod states during CI runs.