### PR TITLE
[Rust][Services][Connector] Version bump for 01-08-2026 release candidate

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "1.0.0"
+version = "1.1.0-rc1"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"
@@ -13,7 +13,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.0", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "1.1.0-rc1", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "1.0", path = "../azure_iot_operations_mqtt" }
 chrono.workspace = true
 derive_builder.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "1.0.0"
+version = "1.1.0-rc1"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Services"


### PR DESCRIPTION
`services`: `1.0.0` -> `1.1.0-rc1`
`connector`: `1.0.0` -> `1.1.0-rc1`
