### PR TITLE
Fix missing DataSource serialization in DiscoveredAssetManagementGroup.ToProtocol()

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ProtocolConverter.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Models/ProtocolConverter.cs
@@ -161,19 +161,19 @@ internal static class ProtocolConverter
     }
 
     internal static AdrBaseService.DiscoveredAssetManagementGroup ToProtocol(this DiscoveredAssetManagementGroup source)
-{
-    return new AdrBaseService.DiscoveredAssetManagementGroup
     {
-        Actions = source.Actions?.Select(x => x.ToProtocol()).ToList(),
-        DefaultTimeoutInSeconds = source.DefaultTimeoutInSeconds,
-        DefaultTopic = source.DefaultTopic,
-        LastUpdatedOn = source.LastUpdatedOn,
-        ManagementGroupConfiguration = source.ManagementGroupConfiguration,
-        Name = source.Name,
-        TypeRef = source.TypeRef,
-
-    };
-}
+        return new AdrBaseService.DiscoveredAssetManagementGroup
+        {
+            Actions = source.Actions?.Select(x => x.ToProtocol()).ToList(),
+            DataSource = source.DataSource,
+            DefaultTimeoutInSeconds = source.DefaultTimeoutInSeconds,
+            DefaultTopic = source.DefaultTopic,
+            LastUpdatedOn = source.LastUpdatedOn,
+            ManagementGroupConfiguration = source.ManagementGroupConfiguration,
+            Name = source.Name,
+            TypeRef = source.TypeRef,
+        };
+    }
 
     internal static AdrBaseService.DiscoveredAssetManagementGroupAction ToProtocol(this DiscoveredAssetManagementGroupAction source)
 {


### PR DESCRIPTION
This pull request introduces a minor update to the protocol conversion logic for asset management groups. The main change is the inclusion of the `DataSource` property when converting to the protocol model, ensuring that this information is now correctly transferred.

* Protocol conversion update:
  * Added mapping of the `DataSource` property from the source object to the protocol object in the `ToProtocol` method in `ProtocolConverter.cs`.