### PR TITLE
[Rust][Connector] Expose reconnect policy in base connector options

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -86,7 +86,7 @@ pub struct Options {
     #[builder(default = "Duration::from_secs(5)")]
     filemount_debounce_duration: Duration,
 
-    /// Reconnect policy for the MQTT Session
+    /// Reconnect policy used by the MQTT Session.
     #[builder(default = "Box::new(ExponentialBackoffWithJitter::default())")]
     reconnect_policy: Box<dyn ReconnectPolicy>,
 }


### PR DESCRIPTION
This PR exposes the reconnect policy of the underlying session in the base connector. This change is needed to be able to stop reconnect attempts and signal an unhealthy connection to MQ.