### PR TITLE
[.NET] Bump services package version for RC release

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -6,7 +6,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.1.0-rc</VersionPrefix>
+    <VersionPrefix>1.1.0-rc2</VersionPrefix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>


### PR DESCRIPTION
This release includes all the bug fixes imported from main that were included in the 1.0.1 services package release. We are re-releasing from this branch so that users can ingest those bug fixes + the event groups destination bug fix which lives in this feature branch.