### PR TITLE
use enum converter from System.Text.Json instead of Macross

### DIFF
--- a/codegen2/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Project/t4/DotNetProject.cs
+++ b/codegen2/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Project/t4/DotNetProject.cs
@@ -26,18 +26,9 @@ namespace Azure.Iot.Operations.EnvoyGenerator
  // Licensed under the MIT License 
             this.Write("<Project Sdk=\"Microsoft.NET.Sdk\">\r\n\r\n  <PropertyGroup>\r\n    <TargetFramework>");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.targetFramework));
-            this.Write(@"</TargetFramework>
-    <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <Nullable>enable</Nullable>
-    <NoWarn>SA0001,SA1101,SA1633</NoWarn>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include=""Macross.Json.Extensions"" Version=""3.0.0"" />
-  </ItemGroup>
-
-  <ItemGroup>
-");
+            this.Write("</TargetFramework>\r\n    <AnalysisLevel>latest-recommended</AnalysisLevel>\r\n    <N" +
+                    "ullable>enable</Nullable>\r\n    <NoWarn>SA0001,SA1101,SA1633</NoWarn>\r\n  </Proper" +
+                    "tyGroup>\r\n\r\n  <ItemGroup>\r\n");
  if (this.sdkProjPath != null) { 
             this.Write("    <ProjectReference Include=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.sdkProjPath));

--- a/codegen2/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Project/t4/DotNetProject.tt
+++ b/codegen2/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Project/t4/DotNetProject.tt
@@ -11,10 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
 <# if (this.sdkProjPath != null) { #>
     <ProjectReference Include="<#=this.sdkProjPath#>" />
 <# } else { #>

--- a/codegen2/src/Azure.Iot.Operations.TypeGenerator/dotnet/t4/DotNetEnum.cs
+++ b/codegen2/src/Azure.Iot.Operations.TypeGenerator/dotnet/t4/DotNetEnum.cs
@@ -38,23 +38,20 @@ namespace Azure.Iot.Operations.TypeGenerator
             this.Write(this.ToStringHelper.ToStringWithCulture(this.projectName));
             this.Write(".");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.genNamespace.GetNamespaceName(TargetLanguage.CSharp)));
-            this.Write("\r\n{\r\n    using System.Runtime.Serialization;\r\n    using System.Text.Json.Serializ" +
-                    "ation;\r\n\r\n");
+            this.Write("\r\n{\r\n    using System.Text.Json.Serialization;\r\n\r\n");
  if (this.enumType.Description != null) { 
             this.Write("    /// <summary>\r\n    /// ");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.enumType.Description));
             this.Write("\r\n    /// </summary>\r\n");
  } 
-            this.Write("    [JsonConverter(typeof(JsonStringEnumMemberConverter))]\r\n    [System.CodeDom.C" +
-                    "ompiler.GeneratedCode(\"Azure.Iot.Operations.ProtocolCompilerLib\", \"");
+            this.Write("    [JsonConverter(typeof(JsonStringEnumConverter))]\r\n    [System.CodeDom.Compile" +
+                    "r.GeneratedCode(\"Azure.Iot.Operations.ProtocolCompilerLib\", \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(System.Reflection.Assembly.GetExecutingAssembly().GetName().Version));
             this.Write("\")]\r\n    public enum ");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.enumType.SchemaName.AsGiven));
             this.Write("\r\n    {\r\n");
  foreach (var enumValue in this.enumType.EnumValues) { 
-            this.Write("        [EnumMember(Value = @\"");
-            this.Write(this.ToStringHelper.ToStringWithCulture(enumValue.AsGiven));
-            this.Write("\")]\r\n        ");
+            this.Write("        ");
             this.Write(this.ToStringHelper.ToStringWithCulture(enumValue.AsGiven));
             this.Write(",\r\n");
  } 

--- a/codegen2/src/Azure.Iot.Operations.TypeGenerator/dotnet/t4/DotNetEnum.tt
+++ b/codegen2/src/Azure.Iot.Operations.TypeGenerator/dotnet/t4/DotNetEnum.tt
@@ -13,7 +13,6 @@
 
 namespace <#=this.projectName#>.<#=this.genNamespace.GetNamespaceName(TargetLanguage.CSharp)#>
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
 <# if (this.enumType.Description != null) { #>
@@ -21,12 +20,11 @@ namespace <#=this.projectName#>.<#=this.genNamespace.GetNamespaceName(TargetLang
     /// <#=this.enumType.Description#>
     /// </summary>
 <# } #>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "<#=System.Reflection.Assembly.GetExecutingAssembly().GetName().Version#>")]
     public enum <#=this.enumType.SchemaName.AsGiven#>
     {
 <# foreach (var enumValue in this.enumType.EnumValues) { #>
-        [EnumMember(Value = @"<#=enumValue.AsGiven#>")]
         <#=enumValue.AsGiven#>,
 <# } #>
     }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/AssetManagementGroupActionType.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/AssetManagementGroupActionType.g.cs
@@ -4,21 +4,17 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// Type of the action.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum AssetManagementGroupActionType
     {
-        [EnumMember(Value = @"Call")]
         Call,
-        [EnumMember(Value = @"Read")]
         Read,
-        [EnumMember(Value = @"Write")]
         Write,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/CodeSchema.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/CodeSchema.g.cs
@@ -4,25 +4,19 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// The error code that identifies the error.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum CodeSchema
     {
-        [EnumMember(Value = @"BadRequest")]
         BadRequest,
-        [EnumMember(Value = @"InternalError")]
         InternalError,
-        [EnumMember(Value = @"KubeError")]
         KubeError,
-        [EnumMember(Value = @"SerializationError")]
         SerializationError,
-        [EnumMember(Value = @"Unauthorized")]
         Unauthorized,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DatasetTarget.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DatasetTarget.g.cs
@@ -4,21 +4,17 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// The target destination.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum DatasetTarget
     {
-        [EnumMember(Value = @"BrokerStateStore")]
         BrokerStateStore,
-        [EnumMember(Value = @"Mqtt")]
         Mqtt,
-        [EnumMember(Value = @"Storage")]
         Storage,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/EventStreamTarget.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/EventStreamTarget.g.cs
@@ -4,19 +4,16 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// The target destination.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum EventStreamTarget
     {
-        [EnumMember(Value = @"Mqtt")]
         Mqtt,
-        [EnumMember(Value = @"Storage")]
         Storage,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/MethodSchema.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/MethodSchema.g.cs
@@ -4,21 +4,17 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// Defines the method to authenticate the user of the client at the server.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum MethodSchema
     {
-        [EnumMember(Value = @"Anonymous")]
         Anonymous,
-        [EnumMember(Value = @"Certificate")]
         Certificate,
-        [EnumMember(Value = @"UsernamePassword")]
         UsernamePassword,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/NotificationPreference.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/NotificationPreference.g.cs
@@ -4,16 +4,13 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum NotificationPreference
     {
-        [EnumMember(Value = @"Off")]
         Off,
-        [EnumMember(Value = @"On")]
         On,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/Qos.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/Qos.g.cs
@@ -4,19 +4,16 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// The MQTT QoS setting.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum Qos
     {
-        [EnumMember(Value = @"Qos0")]
         Qos0,
-        [EnumMember(Value = @"Qos1")]
         Qos1,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/Retain.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/Retain.g.cs
@@ -4,19 +4,16 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// When set to 'Keep', messages published to an MQTT broker will have the retain flag set.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum Retain
     {
-        [EnumMember(Value = @"Keep")]
         Keep,
-        [EnumMember(Value = @"Never")]
         Never,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/DeviceDiscoveryService/CodeSchema.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/DeviceDiscoveryService/CodeSchema.g.cs
@@ -4,25 +4,19 @@
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.DeviceDiscoveryService
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// The error code that identifies the error.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum CodeSchema
     {
-        [EnumMember(Value = @"BadRequest")]
         BadRequest,
-        [EnumMember(Value = @"InternalError")]
         InternalError,
-        [EnumMember(Value = @"KubeError")]
         KubeError,
-        [EnumMember(Value = @"SerializationError")]
         SerializationError,
-        [EnumMember(Value = @"Unauthorized")]
         Unauthorized,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Generated/SchemaType.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/Generated/SchemaType.g.cs
@@ -4,17 +4,15 @@
 
 namespace Azure.Iot.Operations.Services.SchemaRegistry.Generated
 {
-    using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
 
     /// <summary>
     /// Type of the schema.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     [System.CodeDom.Compiler.GeneratedCode("Azure.Iot.Operations.ProtocolCompilerLib", "1.0.0.0")]
     public enum SchemaType
     {
-        [EnumMember(Value = @"MessageSchema")]
         MessageSchema,
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/schemas/GetResponseSchema.schema.json
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/schemas/GetResponseSchema.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "getError": {
+    "error": {
       "description": "Read error for the 'get' Action.",
       "$ref": "SchemaRegistryError.schema.json"
     },

--- a/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/schemas/PutResponseSchema.schema.json
+++ b/dotnet/src/Azure.Iot.Operations.Services/SchemaRegistry/schemas/PutResponseSchema.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "putError": {
+    "error": {
       "description": "Read error for the 'put' Action.",
       "$ref": "SchemaRegistryError.schema.json"
     },


### PR DESCRIPTION
This change replaces the change made in PR https://github.com/Azure/iot-operations-sdks/pull/1225.  Since enum string values are not being renamed, there is no need for the external dependency on Macross.

@timtay-microsoft, can you verify that this works in cross-language service tests?