### PR TITLE
[Rust][Services][Connector] Remove -rc version suffixes for 2603 release

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.0.0-rc3"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"
@@ -13,7 +13,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.2.0-rc4", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "1.2.0", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "1.0", path = "../azure_iot_operations_mqtt" }
 chrono.workspace = true
 derive_builder.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "1.2.0-rc4"
+version = "1.2.0"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Services"


### PR DESCRIPTION
services: 1.2.0-rc4 -> 1.2.0
connector: 2.0.0-rc3 -> 2.0.0

Bumping the version for the release before cutting the 2603 release branch (although we will still wait to release the crates with these versions)