### PR TITLE
[Rust][Connectors] Enable storage destination with validation error on forwarding

### DIFF
--- a/rust/azure_iot_operations_connector/src/destination_endpoint.rs
+++ b/rust/azure_iot_operations_connector/src/destination_endpoint.rs
@@ -228,7 +228,7 @@ impl Forwarder {
     /// [`struct@Error`] of kind [`MissingMessageSchema`](ErrorKind::MissingMessageSchema)
     /// if the [`MessageSchema`] has not been reported yet. This is required before forwarding any data
     ///
-    /// [`struct@Error`] of kind [`DataValidationError`](ErrorKind::MqttTelemetryError)
+    /// [`struct@Error`] of kind [`MqttTelemetryError`](ErrorKind::MqttTelemetryError)
     /// if the [`Data`] isn't valid.
     ///
     /// [`struct@Error`] of kind [`BrokerStateStoreError`](ErrorKind::BrokerStateStoreError)


### PR DESCRIPTION
This PR:
- Enables Storage destination creation instead of rejecting it as a config error
- Replaces `unimplemented!()` panic with a `ValidationError` return when data is forwarded to a Storage destination