### PR TITLE
[Rust][Connector] Version bump for 03-20-2026 release candidate [Cherry-pick]

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.0.0"
+version = "2.0.1-rc1"
 edition = "2024"
 license = "MIT"
 description = "Azure IoT Operations Connector"


### PR DESCRIPTION
Cherry-pick. See #1277

`connector`: `2.0.0` -> `2.0.1-rc1`