### PR TITLE
[Rust][Connector] Structural changes for ConfigMap support

### DIFF
--- a/rust/azure_iot_operations_connector/src/deployment_artifacts.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts.rs
@@ -3,19 +3,14 @@
 
 //! Utilities for extracting data from filemounts in an Akri deployment
 
+mod atomic_writer_volume_debouncer;
 pub mod azure_device_registry;
 pub mod connector;
-pub mod connector_configuration;    // TODO: Not sure this should be pub
+mod connector_configuration;
 mod filemount;
-mod projected_volume_debouncer;
 mod secrets;
 
 pub use connector::DeploymentArtifactError; // TODO: move implementation out here
-// TODO: not sure if all this needs exposing, revisit
-pub use connector_configuration::{
-    ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls,
-    TlsMode,
-};
 pub use filemount::FileMount;
 pub use secrets::{Secret, Secrets};
 

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts.rs
@@ -5,11 +5,17 @@
 
 pub mod azure_device_registry;
 pub mod connector;
+pub mod connector_configuration;    // TODO: Not sure this should be pub
 mod filemount;
 mod projected_volume_debouncer;
 mod secrets;
 
 pub use connector::DeploymentArtifactError; // TODO: move implementation out here
+// TODO: not sure if all this needs exposing, revisit
+pub use connector_configuration::{
+    ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls,
+    TlsMode,
+};
 pub use filemount::FileMount;
 pub use secrets::{Secret, Secrets};
 

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/atomic_writer_volume_debouncer.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/atomic_writer_volume_debouncer.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! A debouncer for Kubernetes projected volume and config map mounts.
+//! A debouncer for Kubernetes atomic-writer volume mounts
+//! (i.e. Projected volumes, ConfigMap volumes, Secret volumes).
 //!
 //! Wraps [`notify_debouncer_full`] and detects changes via the atomic `..data` symlink
-//! swap that Kubernetes performs when updating projected volumes.
+//! swap that Kubernetes performs when updating atomic-writer volumes.
 //!
 //! Instead of exposing raw filesystem events (which include internal K8S plumbing like
 //! `..data`, `..data_tmp`, and timestamped snapshot directories), this debouncer produces
@@ -13,7 +14,7 @@
 //!
 //! # Why there is no user-configurable debounce window
 //!
-//! The kubelet already batches all projected volume changes into a single atomic symlink
+//! The kubelet already batches all atomic-writer volume changes into a single atomic symlink
 //! swap per sync cycle. Multiple updates between sync ticks are delivered as one swap.
 //! Consecutive swaps are therefore separated by tens of seconds at minimum, so there is
 //! nothing meaningful  for the caller to aggregate. The internal debounce window only
@@ -47,36 +48,36 @@ const _: () = assert!(
     "DEBOUNCE_WINDOW must be greater than TICK_RATE"
 );
 
-/// Error from the [`ProjectedVolumeDebouncer`].
+/// Error from the [`AtomicWriterVolumeDebouncer`].
 #[derive(Debug, thiserror::Error)]
-pub enum ProjectedVolumeError {
+pub enum AtomicWriterVolumeError {
     /// An error from the underlying filesystem watcher.
     #[error(transparent)]
     Notify(#[from] notify::Error),
-    /// An I/O error occurred while scanning the projected volume directory.
-    #[error("failed to snapshot projected volume: {0}")]
+    /// An I/O error occurred while scanning the atomic-writer volume directory.
+    #[error("failed to snapshot atomic-writer volume: {0}")]
     Snapshot(std::io::Error),
 }
 
-/// The kind of change detected in a projected volume.
+/// The kind of change detected in a atomic-writer volume.
 ///
 /// This is a purpose-built enum covering only the event kinds that the
-/// [`ProjectedVolumeDebouncer`] can produce.
+/// [`AtomicWriterVolumeDebouncer`] can produce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProjectedVolumeEventKind {
-    /// A file was added to the projected volume.
+pub enum AtomicWriterVolumeEventKind {
+    /// A file was added to the atomic-writer volume.
     FileCreated,
     /// A file's content changed (detected via SHA-256 hash comparison).
     FileModified,
-    /// A file was removed from the projected volume.
+    /// A file was removed from the atomic-writer volume.
     FileRemoved,
-    /// A directory was added to the projected volume.
+    /// A directory was added to the atomic-writer volume.
     DirCreated,
-    /// A directory was removed from the projected volume.
+    /// A directory was removed from the atomic-writer volume.
     DirRemoved,
 }
 
-/// A synthetic filesystem event representing a change in a projected volume.
+/// A synthetic filesystem event representing a change in a atomic-writer volume.
 ///
 /// Unlike raw [`notify`] events, the `path` field contains a clean absolute path
 /// to the affected entry (e.g., `/etc/akri/secrets/my-dir/my-key`), with all
@@ -85,20 +86,20 @@ pub enum ProjectedVolumeEventKind {
 /// **Renames are never emitted.** Kubernetes secrets and Config Maps have no
 /// concept of renaming a key — deleting a key and adding a new one are
 /// independent operations even if the content is identical. Such changes are
-/// reported as a [`DirRemoved`](ProjectedVolumeEventKind::DirRemoved) /
-/// [`FileRemoved`](ProjectedVolumeEventKind::FileRemoved) followed by a
-/// [`DirCreated`](ProjectedVolumeEventKind::DirCreated) /
-/// [`FileCreated`](ProjectedVolumeEventKind::FileCreated).
+/// reported as a [`DirRemoved`](AtomicWriterVolumeEventKind::DirRemoved) /
+/// [`FileRemoved`](AtomicWriterVolumeEventKind::FileRemoved) followed by a
+/// [`DirCreated`](AtomicWriterVolumeEventKind::DirCreated) /
+/// [`FileCreated`](AtomicWriterVolumeEventKind::FileCreated).
 ///
 /// **Metadata changes are never emitted.** Permissions and ownership in a
-/// projected volume are set by the kubelet when it writes the volume and do not
+/// atomic-writer volume are set by the kubelet when it writes the volume and do not
 /// change independently of content. File timestamps always differ across
 /// updates regardless of whether content changed, so reporting them would be
 /// noise rather than a meaningful signal.
 #[derive(Debug, Clone)]
-pub struct ProjectedVolumeEvent {
+pub struct AtomicWriterVolumeEvent {
     /// The kind of change detected.
-    pub kind: ProjectedVolumeEventKind,
+    pub kind: AtomicWriterVolumeEventKind,
     /// The absolute path of the affected entry.
     pub path: PathBuf,
     /// When the change was detected.
@@ -108,9 +109,10 @@ pub struct ProjectedVolumeEvent {
 }
 
 /// Result type passed to the handler closure.
-pub type ProjectedVolumeEventResult = Result<Vec<ProjectedVolumeEvent>, ProjectedVolumeError>;
+pub type AtomicWriterVolumeEventResult =
+    Result<Vec<AtomicWriterVolumeEvent>, AtomicWriterVolumeError>;
 
-// NOTE: Each instance watches exactly one projected volume mount. This 1:1 relationship
+// NOTE: Each instance watches exactly one atomic-writer volume mount. This 1:1 relationship
 // is intentional. Unlike notify_debouncer_full, which is stateless with respect to watched
 // paths, this debouncer holds per-volume state (SHA-256 snapshots, swap detection) that
 // couples it to a single root. Sharing a debouncer across volumes would force lifecycle
@@ -118,11 +120,11 @@ pub type ProjectedVolumeEventResult = Result<Vec<ProjectedVolumeEvent>, Projecte
 // policy with no obviously correct answer. For a unified event stream across multiple
 // volumes, fan in separate debouncers via a channel instead.
 
-/// A debouncer for Kubernetes projected volume mounts.
+/// A debouncer for Kubernetes atomic-writer volume mounts.
 ///
-/// Monitors a projected volume directory and produces clean, synthetic filesystem events
+/// Monitors a atomic-writer volume directory and produces clean, synthetic filesystem events
 /// when Kubernetes performs an atomic symlink swap to update the volume contents.
-pub struct ProjectedVolumeDebouncer {
+pub struct AtomicWriterVolumeDebouncer {
     // NOTE: Dropping this struct signals the background thread to stop but does not join
     // it, so the event handler may still fire briefly after drop returns. If a hard
     // guarantee of "no callbacks after drop" is ever needed, expose a `stop()` method
@@ -130,16 +132,16 @@ pub struct ProjectedVolumeDebouncer {
     _debouncer: Debouncer<RecommendedWatcher, RecommendedCache>,
 }
 
-impl ProjectedVolumeDebouncer {
-    /// Creates a new [`ProjectedVolumeDebouncer`].
+impl AtomicWriterVolumeDebouncer {
+    /// Creates a new [`AtomicWriterVolumeDebouncer`].
     ///
     /// Immediately snapshots all user-visible files under `root` as the baseline.
     /// The `event_handler` closure will be called on a background thread whenever a
-    /// projected volume update is detected.
+    /// atomic-writer volume update is detected.
     ///
     /// # Arguments
     ///
-    /// * `root` - Path to the projected volume mount directory.
+    /// * `root` - Path to the atomic-writer volume mount directory.
     /// * `event_handler` - Closure invoked with the result of change detection. Runs on a
     ///   background OS thread.
     ///
@@ -147,11 +149,12 @@ impl ProjectedVolumeDebouncer {
     ///
     /// Returns an error if the initial directory snapshot fails or the filesystem watcher
     /// cannot be created.
-    pub fn new<F>(root: PathBuf, mut event_handler: F) -> Result<Self, ProjectedVolumeError>
+    pub fn new<F>(root: PathBuf, mut event_handler: F) -> Result<Self, AtomicWriterVolumeError>
     where
-        F: FnMut(ProjectedVolumeEventResult) + Send + 'static,
+        F: FnMut(AtomicWriterVolumeEventResult) + Send + 'static,
     {
-        let initial_snapshot = snapshot_directory(&root).map_err(ProjectedVolumeError::Snapshot)?;
+        let initial_snapshot =
+            snapshot_directory(&root).map_err(AtomicWriterVolumeError::Snapshot)?;
         let state = Mutex::new(initial_snapshot);
         let root_for_closure = root.clone();
 
@@ -178,7 +181,7 @@ impl ProjectedVolumeDebouncer {
                             }
                         }
                         Err(e) => {
-                            event_handler(Err(ProjectedVolumeError::Snapshot(e)));
+                            event_handler(Err(AtomicWriterVolumeError::Snapshot(e)));
                         }
                     }
                 }
@@ -189,7 +192,7 @@ impl ProjectedVolumeDebouncer {
                     // so multiple concurrent errors are not expected. Taking only the
                     // first is sufficient.
                     if let Some(e) = errors.into_iter().next() {
-                        event_handler(Err(ProjectedVolumeError::Notify(e)));
+                        event_handler(Err(AtomicWriterVolumeError::Notify(e)));
                     }
                 }
             },
@@ -206,7 +209,7 @@ impl ProjectedVolumeDebouncer {
 /// Returns the timestamp of the symlink swap event, if one is present in the batch.
 ///
 /// The swap is identified by any event whose path ends with `..data` or `..data_tmp`,
-/// which are the symlinks Kubernetes uses during projected volume updates.
+/// which are the symlinks Kubernetes uses during atomic-writer volume updates.
 fn symlink_swap_time(events: &[DebouncedEvent]) -> Option<Instant> {
     events
         .iter()
@@ -222,7 +225,7 @@ fn symlink_swap_time(events: &[DebouncedEvent]) -> Option<Instant> {
 /// SHA-256 hash type for file content snapshots.
 type FileHash = [u8; 32];
 
-/// An entry in a projected volume snapshot.
+/// An entry in a atomic-writer volume snapshot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum SnapshotEntry {
     /// A regular file, identified by the SHA-256 hash of its contents.
@@ -234,7 +237,7 @@ enum SnapshotEntry {
 /// A directory snapshot mapping relative paths to their entries.
 type Snapshot = HashMap<PathBuf, SnapshotEntry>;
 
-/// Walks the projected volume directory and builds a map of relative paths to snapshot entries.
+/// Walks the atomic-writer volume directory and builds a map of relative paths to snapshot entries.
 ///
 /// Filters out all entries starting with `..` (Kubernetes internal plumbing) and follows
 /// symlinks to reach actual file content. Both files and directories are recorded.
@@ -288,15 +291,15 @@ fn diff_snapshots(
     old: &Snapshot,
     new: &Snapshot,
     time: Instant,
-) -> Vec<ProjectedVolumeEvent> {
+) -> Vec<AtomicWriterVolumeEvent> {
     let mut events = Vec::new();
 
     for (path, new_entry) in new {
         match old.get(path) {
             Some(old_entry) if old_entry == new_entry => {}
             Some(SnapshotEntry::File(_)) if matches!(new_entry, SnapshotEntry::File(_)) => {
-                events.push(ProjectedVolumeEvent {
-                    kind: ProjectedVolumeEventKind::FileModified,
+                events.push(AtomicWriterVolumeEvent {
+                    kind: AtomicWriterVolumeEventKind::FileModified,
                     path: root.join(path),
                     time,
                 });
@@ -304,20 +307,20 @@ fn diff_snapshots(
             Some(old_entry) => {
                 // Type changed (file <-> dir): report remove + create
                 let remove_kind = match old_entry {
-                    SnapshotEntry::File(_) => ProjectedVolumeEventKind::FileRemoved,
-                    SnapshotEntry::Directory => ProjectedVolumeEventKind::DirRemoved,
+                    SnapshotEntry::File(_) => AtomicWriterVolumeEventKind::FileRemoved,
+                    SnapshotEntry::Directory => AtomicWriterVolumeEventKind::DirRemoved,
                 };
                 let create_kind = match new_entry {
-                    SnapshotEntry::File(_) => ProjectedVolumeEventKind::FileCreated,
-                    SnapshotEntry::Directory => ProjectedVolumeEventKind::DirCreated,
+                    SnapshotEntry::File(_) => AtomicWriterVolumeEventKind::FileCreated,
+                    SnapshotEntry::Directory => AtomicWriterVolumeEventKind::DirCreated,
                 };
                 let abs = root.join(path);
-                events.push(ProjectedVolumeEvent {
+                events.push(AtomicWriterVolumeEvent {
                     kind: remove_kind,
                     path: abs.clone(),
                     time,
                 });
-                events.push(ProjectedVolumeEvent {
+                events.push(AtomicWriterVolumeEvent {
                     kind: create_kind,
                     path: abs,
                     time,
@@ -325,10 +328,10 @@ fn diff_snapshots(
             }
             None => {
                 let kind = match new_entry {
-                    SnapshotEntry::File(_) => ProjectedVolumeEventKind::FileCreated,
-                    SnapshotEntry::Directory => ProjectedVolumeEventKind::DirCreated,
+                    SnapshotEntry::File(_) => AtomicWriterVolumeEventKind::FileCreated,
+                    SnapshotEntry::Directory => AtomicWriterVolumeEventKind::DirCreated,
                 };
-                events.push(ProjectedVolumeEvent {
+                events.push(AtomicWriterVolumeEvent {
                     kind,
                     path: root.join(path),
                     time,
@@ -340,10 +343,10 @@ fn diff_snapshots(
     for (path, old_entry) in old {
         if !new.contains_key(path) {
             let kind = match old_entry {
-                SnapshotEntry::File(_) => ProjectedVolumeEventKind::FileRemoved,
-                SnapshotEntry::Directory => ProjectedVolumeEventKind::DirRemoved,
+                SnapshotEntry::File(_) => AtomicWriterVolumeEventKind::FileRemoved,
+                SnapshotEntry::Directory => AtomicWriterVolumeEventKind::DirRemoved,
             };
-            events.push(ProjectedVolumeEvent {
+            events.push(AtomicWriterVolumeEvent {
                 kind,
                 path: root.join(path),
                 time,
@@ -357,14 +360,14 @@ fn diff_snapshots(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deployment_artifacts::test_utils::TempProjectedVolume;
+    use crate::deployment_artifacts::test_utils::TempAtomicWriterVolume;
 
     mod snapshot {
         use super::*;
 
         #[test]
         fn captures_files_and_dirs() {
-            let vol = TempProjectedVolume::new("snapshot_captures");
+            let vol = TempAtomicWriterVolume::new("snapshot_captures");
             vol.stage_dir_create(Path::new("dir1"));
             vol.stage_file_create(Path::new("dir1/file1"), "value1");
             vol.stage_file_create(Path::new("dir1/file2"), "value2");
@@ -423,7 +426,7 @@ mod tests {
 
         #[test]
         fn skips_dotdot_entries() {
-            let vol = TempProjectedVolume::new("snapshot_dotdot");
+            let vol = TempAtomicWriterVolume::new("snapshot_dotdot");
             vol.stage_dir_create(Path::new("dir"));
             vol.stage_file_create(Path::new("dir/file1"), "value1");
             vol.execute_update();
@@ -439,7 +442,7 @@ mod tests {
 
         #[test]
         fn hashes_are_deterministic() {
-            let vol = TempProjectedVolume::new("snapshot_deterministic");
+            let vol = TempAtomicWriterVolume::new("snapshot_deterministic");
             vol.stage_dir_create(Path::new("dir"));
             vol.stage_file_create(Path::new("dir/file1"), "value1");
             vol.execute_update();
@@ -463,7 +466,7 @@ mod tests {
 
             let events = diff_snapshots(Path::new(ROOT), &old, &new, Instant::now());
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].kind, ProjectedVolumeEventKind::FileCreated);
+            assert_eq!(events[0].kind, AtomicWriterVolumeEventKind::FileCreated);
             assert_eq!(events[0].path, Path::new("/mnt/projected/dir1/file1"));
         }
 
@@ -475,7 +478,7 @@ mod tests {
 
             let events = diff_snapshots(Path::new(ROOT), &old, &new, Instant::now());
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].kind, ProjectedVolumeEventKind::DirCreated);
+            assert_eq!(events[0].kind, AtomicWriterVolumeEventKind::DirCreated);
             assert_eq!(events[0].path, Path::new(ROOT).join(Path::new("dir1")));
         }
 
@@ -488,7 +491,7 @@ mod tests {
 
             let events = diff_snapshots(Path::new(ROOT), &old, &new, Instant::now());
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].kind, ProjectedVolumeEventKind::FileModified);
+            assert_eq!(events[0].kind, AtomicWriterVolumeEventKind::FileModified);
             assert_eq!(
                 events[0].path,
                 Path::new(ROOT).join(Path::new("dir1/file1"))
@@ -503,7 +506,7 @@ mod tests {
 
             let events = diff_snapshots(Path::new(ROOT), &old, &new, Instant::now());
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].kind, ProjectedVolumeEventKind::FileRemoved);
+            assert_eq!(events[0].kind, AtomicWriterVolumeEventKind::FileRemoved);
             assert_eq!(
                 events[0].path,
                 Path::new(ROOT).join(Path::new("dir1/file1"))
@@ -518,7 +521,7 @@ mod tests {
 
             let events = diff_snapshots(Path::new(ROOT), &old, &new, Instant::now());
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].kind, ProjectedVolumeEventKind::DirRemoved);
+            assert_eq!(events[0].kind, AtomicWriterVolumeEventKind::DirRemoved);
             assert_eq!(events[0].path, Path::new(ROOT).join(Path::new("dir1")));
         }
 
@@ -572,19 +575,19 @@ mod tests {
 
             let root = Path::new(ROOT);
             let has_create_file = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileCreated && e.path == root.join("file4")
+                e.kind == AtomicWriterVolumeEventKind::FileCreated && e.path == root.join("file4")
             });
             let has_create_dir = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::DirCreated && e.path == root.join("dir3")
+                e.kind == AtomicWriterVolumeEventKind::DirCreated && e.path == root.join("dir3")
             });
             let has_modify = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileModified && e.path == root.join("file2")
+                e.kind == AtomicWriterVolumeEventKind::FileModified && e.path == root.join("file2")
             });
             let has_remove_file = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileRemoved && e.path == root.join("file3")
+                e.kind == AtomicWriterVolumeEventKind::FileRemoved && e.path == root.join("file3")
             });
             let has_remove_dir = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::DirRemoved && e.path == root.join("dir2")
+                e.kind == AtomicWriterVolumeEventKind::DirRemoved && e.path == root.join("dir2")
             });
 
             assert!(has_create_file, "should detect created file");
@@ -656,7 +659,7 @@ mod tests {
         /// Collector for debouncer events, using a condvar to allow tests to wait
         /// for results with a timeout.
         struct EventCollector {
-            inner: Arc<(Mutex<Vec<ProjectedVolumeEventResult>>, Condvar)>,
+            inner: Arc<(Mutex<Vec<AtomicWriterVolumeEventResult>>, Condvar)>,
         }
 
         impl EventCollector {
@@ -666,8 +669,8 @@ mod tests {
                 }
             }
 
-            /// Returns a closure suitable for passing to [`ProjectedVolumeDebouncer::new`].
-            fn handler(&self) -> impl FnMut(ProjectedVolumeEventResult) + Send + 'static {
+            /// Returns a closure suitable for passing to [`AtomicWriterVolumeDebouncer::new`].
+            fn handler(&self) -> impl FnMut(AtomicWriterVolumeEventResult) + Send + 'static {
                 let inner = Arc::clone(&self.inner);
                 move |result| {
                     let (lock, cvar) = &*inner;
@@ -676,10 +679,10 @@ mod tests {
                 }
             }
 
-            /// Wait for the latest [`ProjectedVolumeEventResult`] to arrive.
+            /// Wait for the latest [`AtomicWriterVolumeEventResult`] to arrive.
             ///
             /// Panics if no event arrives within [`EVENT_TIMEOUT`].
-            fn events_batch(&self) -> ProjectedVolumeEventResult {
+            fn events_batch(&self) -> AtomicWriterVolumeEventResult {
                 let (lock, cvar) = &*self.inner;
                 let (mut guard, wait_result) = cvar
                     .wait_timeout_while(lock.lock().unwrap(), EVENT_TIMEOUT, |events| {
@@ -711,7 +714,7 @@ mod tests {
 
         #[test]
         fn detects_file_modification() {
-            let vol = TempProjectedVolume::new("debouncer_modify");
+            let vol = TempAtomicWriterVolume::new("debouncer_modify");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.stage_dir_create(Path::new("subdir"));
             vol.stage_file_create(Path::new("subdir/file2"), "value2");
@@ -719,7 +722,7 @@ mod tests {
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_file_modify(Path::new("file1"), "value1-updated");
@@ -729,11 +732,11 @@ mod tests {
             let events = collector.events_batch().unwrap();
             assert_eq!(events.len(), 2);
             let has_root = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileModified
+                e.kind == AtomicWriterVolumeEventKind::FileModified
                     && e.path == vol.path().join("file1")
             });
             let has_nested = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileModified
+                e.kind == AtomicWriterVolumeEventKind::FileModified
                     && e.path == vol.path().join("subdir/file2")
             });
             assert!(has_root, "should detect root file modification");
@@ -742,14 +745,14 @@ mod tests {
 
         #[test]
         fn detects_file_addition() {
-            let vol = TempProjectedVolume::new("debouncer_add");
+            let vol = TempAtomicWriterVolume::new("debouncer_add");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.stage_dir_create(Path::new("subdir"));
             vol.execute_update();
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_file_create(Path::new("file2"), "value2");
@@ -759,11 +762,11 @@ mod tests {
             let events = collector.events_batch().unwrap();
             assert_eq!(events.len(), 2);
             let has_root = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileCreated
+                e.kind == AtomicWriterVolumeEventKind::FileCreated
                     && e.path == vol.path().join("file2")
             });
             let has_nested = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileCreated
+                e.kind == AtomicWriterVolumeEventKind::FileCreated
                     && e.path == vol.path().join("subdir/file3")
             });
             assert!(has_root, "should detect root file addition");
@@ -772,7 +775,7 @@ mod tests {
 
         #[test]
         fn detects_file_removal() {
-            let vol = TempProjectedVolume::new("debouncer_remove");
+            let vol = TempAtomicWriterVolume::new("debouncer_remove");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.stage_dir_create(Path::new("subdir"));
             vol.stage_file_create(Path::new("subdir/file2"), "value2");
@@ -780,7 +783,7 @@ mod tests {
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_file_remove(Path::new("file1"));
@@ -790,11 +793,11 @@ mod tests {
             let events = collector.events_batch().unwrap();
             assert_eq!(events.len(), 2);
             let has_root = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileRemoved
+                e.kind == AtomicWriterVolumeEventKind::FileRemoved
                     && e.path == vol.path().join("file1")
             });
             let has_nested = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileRemoved
+                e.kind == AtomicWriterVolumeEventKind::FileRemoved
                     && e.path == vol.path().join("subdir/file2")
             });
             assert!(has_root, "should detect root file removal");
@@ -803,13 +806,13 @@ mod tests {
 
         #[test]
         fn detects_dir_creation() {
-            let vol = TempProjectedVolume::new("debouncer_dir_create");
+            let vol = TempAtomicWriterVolume::new("debouncer_dir_create");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.execute_update();
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_dir_create(Path::new("newdir1"));
@@ -818,11 +821,11 @@ mod tests {
 
             let events = collector.events_batch().unwrap();
             let has_dir_create = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::DirCreated
+                e.kind == AtomicWriterVolumeEventKind::DirCreated
                     && e.path == vol.path().join("newdir1")
             });
             let has_file_create = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileCreated
+                e.kind == AtomicWriterVolumeEventKind::FileCreated
                     && e.path == vol.path().join("newdir1/file1")
             });
             assert!(has_dir_create, "should detect directory creation");
@@ -831,7 +834,7 @@ mod tests {
 
         #[test]
         fn detects_dir_removal() {
-            let vol = TempProjectedVolume::new("debouncer_dir_remove");
+            let vol = TempAtomicWriterVolume::new("debouncer_dir_remove");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.stage_dir_create(Path::new("ephemeral"));
             vol.stage_file_create(Path::new("ephemeral/file1"), "temp");
@@ -839,7 +842,7 @@ mod tests {
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_file_remove(Path::new("ephemeral/file1"));
@@ -848,11 +851,11 @@ mod tests {
 
             let events = collector.events_batch().unwrap();
             let has_dir_remove = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::DirRemoved
+                e.kind == AtomicWriterVolumeEventKind::DirRemoved
                     && e.path == vol.path().join("ephemeral")
             });
             let has_file_remove = events.iter().any(|e| {
-                e.kind == ProjectedVolumeEventKind::FileRemoved
+                e.kind == AtomicWriterVolumeEventKind::FileRemoved
                     && e.path == vol.path().join("ephemeral/file1")
             });
             assert!(has_dir_remove, "should detect directory removal");
@@ -864,7 +867,7 @@ mod tests {
 
         #[test]
         fn detects_no_change() {
-            let vol = TempProjectedVolume::new("debouncer_nochange");
+            let vol = TempAtomicWriterVolume::new("debouncer_nochange");
             vol.stage_file_create(Path::new("file1"), "value1");
             vol.stage_dir_create(Path::new("subdir"));
             vol.stage_file_create(Path::new("subdir/file2"), "value2");
@@ -872,7 +875,7 @@ mod tests {
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             // Re-stage identical content (modify with same values)
@@ -885,7 +888,7 @@ mod tests {
 
         #[test]
         fn detects_mixed_changes() {
-            let vol = TempProjectedVolume::new("debouncer_mixed");
+            let vol = TempAtomicWriterVolume::new("debouncer_mixed");
             vol.stage_file_create(Path::new("unchanged"), "keep");
             vol.stage_file_create(Path::new("modified"), "old");
             vol.stage_file_create(Path::new("removed"), "gone");
@@ -899,7 +902,7 @@ mod tests {
 
             let collector = EventCollector::new();
             let _debouncer =
-                ProjectedVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
+                AtomicWriterVolumeDebouncer::new(vol.path().to_path_buf(), collector.handler())
                     .unwrap();
 
             vol.stage_file_modify(Path::new("modified"), "new");
@@ -918,53 +921,59 @@ mod tests {
             assert_eq!(events.len(), 10);
 
             // Root-level events
-            let has = |kind: ProjectedVolumeEventKind, path: &str| {
+            let has = |kind: AtomicWriterVolumeEventKind, path: &str| {
                 events
                     .iter()
                     .any(|e| e.kind == kind && e.path == vol.path().join(path))
             };
             assert!(
-                has(ProjectedVolumeEventKind::FileModified, "modified"),
+                has(AtomicWriterVolumeEventKind::FileModified, "modified"),
                 "should detect root file modification"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileRemoved, "removed"),
+                has(AtomicWriterVolumeEventKind::FileRemoved, "removed"),
                 "should detect root file removal"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileCreated, "created"),
+                has(AtomicWriterVolumeEventKind::FileCreated, "created"),
                 "should detect root file creation"
             );
 
             // Subdirectory events
             assert!(
-                has(ProjectedVolumeEventKind::FileModified, "subdir/modified"),
+                has(AtomicWriterVolumeEventKind::FileModified, "subdir/modified"),
                 "should detect nested file modification"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileRemoved, "subdir/removed"),
+                has(AtomicWriterVolumeEventKind::FileRemoved, "subdir/removed"),
                 "should detect nested file removal"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileCreated, "subdir/created"),
+                has(AtomicWriterVolumeEventKind::FileCreated, "subdir/created"),
                 "should detect nested file creation"
             );
 
             // Directory-level events
             assert!(
-                has(ProjectedVolumeEventKind::DirRemoved, "removed_dir"),
+                has(AtomicWriterVolumeEventKind::DirRemoved, "removed_dir"),
                 "should detect directory removal"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileRemoved, "removed_dir/file1"),
+                has(
+                    AtomicWriterVolumeEventKind::FileRemoved,
+                    "removed_dir/file1"
+                ),
                 "should detect file removal from removed dir"
             );
             assert!(
-                has(ProjectedVolumeEventKind::DirCreated, "created_dir"),
+                has(AtomicWriterVolumeEventKind::DirCreated, "created_dir"),
                 "should detect directory creation"
             );
             assert!(
-                has(ProjectedVolumeEventKind::FileCreated, "created_dir/file1"),
+                has(
+                    AtomicWriterVolumeEventKind::FileCreated,
+                    "created_dir/file1"
+                ),
                 "should detect file creation in new dir"
             );
         }

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -5,17 +5,19 @@
 
 use std::env::VarError;
 use std::ffi::OsString;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use azure_iot_operations_mqtt as aio_mqtt;
-use serde::Deserialize;
 use serde_json;
 use thiserror::Error;
 
 use crate::deployment_artifacts::{FileMount, Secrets};
+
+pub use super::connector_configuration::{
+    ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls,
+    TlsMode,
+};
 
 const AGGREGATION_WINDOW: Duration = Duration::from_secs(10);
 
@@ -26,7 +28,7 @@ pub struct DeploymentArtifactError(#[from] DeploymentArtifactErrorRepr);
 
 /// Represents the type of error encountered while parsing artifacts in an Akri deployment
 #[derive(Error, Debug)]
-enum DeploymentArtifactErrorRepr {
+pub(crate) enum DeploymentArtifactErrorRepr {
     /// A required environment variable was not found
     #[error("Required environment variable missing: {0}")]
     EnvVarMissing(String),
@@ -69,15 +71,15 @@ pub struct ConnectorArtifacts {
     /// The secrets deployed for the connector
     pub connector_secrets: Option<Secrets>,
     /// Path to directory containing trust list certificates for the connector
-    pub connector_trust_settings_mount: Option<FileMount>,
+    pub connector_trust_settings_mount: Option<FileMount>,                          // TODO: dir (projected)
     /// Path to directory containing trust bundle for the broker
-    pub broker_trust_bundle_mount: Option<FileMount>,
+    pub broker_trust_bundle_mount: Option<FileMount>,                               // TODO: dir (projected)
     /// Path to file containing service account token for authentication with the broker
-    pub broker_sat_mount: Option<FileMount>,
+    pub broker_sat_mount: Option<FileMount>,                                        // TODO: dir (projected)
     /// Path to directory containing trust bundle for device inbound endpoints
-    pub device_endpoint_trust_bundle_mount: Option<FileMount>,
+    pub device_endpoint_trust_bundle_mount: Option<FileMount>,                      // TODO: dir (unknown)
     /// Path to directory containing credentials for device inbound endpoints
-    pub device_endpoint_credentials_mount: Option<FileMount>,
+    pub device_endpoint_credentials_mount: Option<FileMount>,                       // TODO: dir (unknown)
 
     // TODO: The following are stopgap variables - these will change in the future
     /// OTEL grpc/grpcs metric endpoint.
@@ -87,9 +89,9 @@ pub struct ConnectorArtifacts {
     /// OTEL grpc/grpcs trace endpoint.
     pub grpc_trace_endpoint: Option<String>,
     /// Path to the directory containing trust bundle for 1P grpc metric collector.
-    pub grpc_metric_collector_1p_ca_mount: Option<FileMount>,
+    pub grpc_metric_collector_1p_ca_mount: Option<FileMount>,                          // TODO: file
     /// Path to the directory containing trust bundle for 1P grpc log collector.
-    pub grpc_log_collector_1p_ca_mount: Option<FileMount>,
+    pub grpc_log_collector_1p_ca_mount: Option<FileMount>,                              // TODO: file
     /// OTEL http/https metric endpoint.
     pub http_metric_endpoint: Option<String>,
     /// OTEL http/https log endpoint.
@@ -122,6 +124,7 @@ impl ConnectorArtifacts {
         )?;
 
         // Connector Configuration
+        // TODO: bring env var extraction logic back into this module
         let connector_configuration = ConnectorConfiguration::new_from_mount_path(
             string_from_environment("CONNECTOR_CONFIGURATION_MOUNT_PATH")?
                 .map(valid_filemount_from)
@@ -323,181 +326,6 @@ impl ConnectorArtifacts {
             .map_err(|e| format!("{e}"))?;
         Ok(c)
     }
-}
-
-/// The Connector Configuration extracted from the Akri deployment
-#[derive(Debug, Clone, PartialEq)]
-pub struct ConnectorConfiguration {
-    /// MQTT connection details
-    pub mqtt_connection_configuration: MqttConnectionConfiguration,
-    /// Diagnostics
-    pub diagnostics: Option<Diagnostics>,
-    /// Persistent Volume Mount Path
-    pub persistent_volumes: Vec<PathBuf>,
-    /// Additional connector configuration as a JSON string
-    pub additional_configuration: Option<String>,
-}
-
-impl ConnectorConfiguration {
-    /// Create a `ConnectorConfiguration` from the files in the specified mount path
-    fn new_from_mount_path(mount_path: &Path) -> Result<Self, DeploymentArtifactError> {
-        // NOTE: Handling errors here does end up requiring unnecessary allocations in the
-        // FilePathMissing errors returned on optional files, but this is not (yet) code that will
-        // be run often, and it keeps things simpler and easier to pivot as the spec evolves.
-        // When finalized, consider optimizing so the individual helpers have logic to handle
-        // optional files.
-
-        let mqtt_connection_configuration =
-            Self::extract_mqtt_connection_configuration(mount_path)?;
-        let diagnostics = match Self::extract_diagnostics(mount_path) {
-            Ok(d) => Some(d),
-            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => None,
-            Err(e) => Err(e)?,
-        };
-        let persistent_volumes = match Self::extract_persistent_volumes(mount_path) {
-            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => vec![],
-            res => res?,
-        };
-        let additional_configuration = match Self::extract_additional_configuration(mount_path) {
-            Ok(ac) => Some(ac),
-            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => None,
-            Err(e) => Err(e)?,
-        };
-
-        Ok(Self {
-            mqtt_connection_configuration,
-            diagnostics,
-            persistent_volumes,
-            additional_configuration,
-        })
-    }
-
-    /// Extract an `MqttConnectionConfiguration` from the specified mount path
-    fn extract_mqtt_connection_configuration(
-        mount_path: &Path,
-    ) -> Result<MqttConnectionConfiguration, DeploymentArtifactErrorRepr> {
-        let mqtt_conn_config_pathbuf = mount_path.join("MQTT_CONNECTION_CONFIGURATION");
-        if !mqtt_conn_config_pathbuf.exists() {
-            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
-                mqtt_conn_config_pathbuf.into(),
-            ))?;
-        }
-        // NOTE: Manual file read to memory is more efficient than using serde_json::from_reader()
-        let m: MqttConnectionConfiguration =
-            serde_json::from_str(&std::fs::read_to_string(&mqtt_conn_config_pathbuf)?)?;
-        Ok(m)
-    }
-
-    /// Extract a `Diagnostics` struct from the specified mount path
-    fn extract_diagnostics(mount_path: &Path) -> Result<Diagnostics, DeploymentArtifactErrorRepr> {
-        let diagnostics_pathbuf = mount_path.join("DIAGNOSTICS");
-        if !diagnostics_pathbuf.exists() {
-            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
-                diagnostics_pathbuf.into(),
-            ))?;
-        }
-        // NOTE: Manual file read to memory is more efficient than using serde_json::from_reader()
-        let d: Diagnostics = serde_json::from_str(&std::fs::read_to_string(&diagnostics_pathbuf)?)?;
-        Ok(d)
-    }
-
-    /// Extract a list of persistent volumes paths from the specified mount path
-    fn extract_persistent_volumes(
-        mount_path: &Path,
-    ) -> Result<Vec<PathBuf>, DeploymentArtifactErrorRepr> {
-        let persistent_volumes_pathbuf = mount_path.join("PERSISTENT_VOLUME_MOUNT_PATH");
-        if !persistent_volumes_pathbuf.exists() {
-            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
-                persistent_volumes_pathbuf.into(),
-            ))?;
-        }
-        // NOTE: Use a BufReader to reduce allocations
-        let persistent_volumes = BufReader::new(File::open(&persistent_volumes_pathbuf)?)
-            .lines()
-            .map_while(Result::ok)
-            .map(PathBuf::from)
-            .try_fold(vec![], |mut acc, pv_pathbuf| {
-                if !pv_pathbuf.exists() {
-                    return Err(DeploymentArtifactErrorRepr::MountPathMissing(
-                        pv_pathbuf.into_os_string(),
-                    ));
-                }
-                acc.push(pv_pathbuf);
-                Ok(acc)
-            })?;
-        Ok(persistent_volumes)
-    }
-
-    /// Extract additional configuration JSON string from the specified mount path
-    fn extract_additional_configuration(
-        mount_path: &Path,
-    ) -> Result<String, DeploymentArtifactErrorRepr> {
-        let additional_config_pathbuf = mount_path.join("ADDITIONAL_CONNECTOR_CONFIGURATION");
-        if !additional_config_pathbuf.exists() {
-            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
-                additional_config_pathbuf.into_os_string(),
-            ))?;
-        }
-        let additional_config = std::fs::read_to_string(&additional_config_pathbuf)?;
-        Ok(additional_config)
-    }
-}
-
-/// Configuration details related to an MQTT connection
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct MqttConnectionConfiguration {
-    /// Broker host in the format `<hostname>:<port>`
-    pub host: String,
-    /// Number of seconds to keep a connection to the broker alive for
-    pub keep_alive_seconds: u16,
-    /// Maximum number of messages that can be assigned a packet ID
-    pub max_inflight_messages: u16,
-    /// The type of MQTT connection being used
-    pub protocol: Protocol,
-    /// Number of seconds to keep a session with the broker alive for
-    pub session_expiry_seconds: u32,
-    /// TLS configuration
-    pub tls: Tls,
-}
-
-/// Enum representing the type of MQTT connection
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub enum Protocol {
-    /// Regular MQTT
-    #[serde(alias = "mqtt")]
-    Mqtt,
-}
-
-/// TLS configuration information
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct Tls {
-    /// Indicates if TLS is enabled or not
-    pub mode: TlsMode,
-}
-
-/// Enum representing whether TLS is enabled or disabled
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub enum TlsMode {
-    /// TLS is enabled
-    Enabled,
-    /// TLS is disabled
-    Disabled,
-}
-
-/// Diagnostic information
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct Diagnostics {
-    /// Log information
-    pub logs: Logs,
-}
-
-/// Logging information
-#[derive(Debug, Deserialize, Clone, PartialEq)]
-pub struct Logs {
-    /// The log level. Examples - 'debug', 'info', 'warn', 'error', 'trace'.
-    pub level: String,
 }
 
 /// Helper function to get an environment variable as a string.

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 use crate::deployment_artifacts::{FileMount, Secrets};
 // TODO: not sure if all this needs exposing here, revisit.
-// These should probably be exporeted in the root of `deployment_artifacts` instead,
+// These should probably be exported in the root of `deployment_artifacts` instead,
 // but that should be done at the end of the `deployment_artifacts` feature changes.
 pub use super::connector_configuration::{
     ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls, TlsMode,

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector.rs
@@ -13,10 +13,11 @@ use serde_json;
 use thiserror::Error;
 
 use crate::deployment_artifacts::{FileMount, Secrets};
-
+// TODO: not sure if all this needs exposing here, revisit.
+// These should probably be exporeted in the root of `deployment_artifacts` instead,
+// but that should be done at the end of the `deployment_artifacts` feature changes.
 pub use super::connector_configuration::{
-    ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls,
-    TlsMode,
+    ConnectorConfiguration, Diagnostics, Logs, MqttConnectionConfiguration, Protocol, Tls, TlsMode,
 };
 
 const AGGREGATION_WINDOW: Duration = Duration::from_secs(10);
@@ -71,15 +72,15 @@ pub struct ConnectorArtifacts {
     /// The secrets deployed for the connector
     pub connector_secrets: Option<Secrets>,
     /// Path to directory containing trust list certificates for the connector
-    pub connector_trust_settings_mount: Option<FileMount>,                          // TODO: dir (projected)
+    pub connector_trust_settings_mount: Option<FileMount>, // TODO: dir (projected)
     /// Path to directory containing trust bundle for the broker
-    pub broker_trust_bundle_mount: Option<FileMount>,                               // TODO: dir (projected)
+    pub broker_trust_bundle_mount: Option<FileMount>, // TODO: dir (projected)
     /// Path to file containing service account token for authentication with the broker
-    pub broker_sat_mount: Option<FileMount>,                                        // TODO: dir (projected)
+    pub broker_sat_mount: Option<FileMount>, // TODO: dir (projected)
     /// Path to directory containing trust bundle for device inbound endpoints
-    pub device_endpoint_trust_bundle_mount: Option<FileMount>,                      // TODO: dir (unknown)
+    pub device_endpoint_trust_bundle_mount: Option<FileMount>, // TODO: dir (unknown)
     /// Path to directory containing credentials for device inbound endpoints
-    pub device_endpoint_credentials_mount: Option<FileMount>,                       // TODO: dir (unknown)
+    pub device_endpoint_credentials_mount: Option<FileMount>, // TODO: dir (unknown)
 
     // TODO: The following are stopgap variables - these will change in the future
     /// OTEL grpc/grpcs metric endpoint.
@@ -89,9 +90,9 @@ pub struct ConnectorArtifacts {
     /// OTEL grpc/grpcs trace endpoint.
     pub grpc_trace_endpoint: Option<String>,
     /// Path to the directory containing trust bundle for 1P grpc metric collector.
-    pub grpc_metric_collector_1p_ca_mount: Option<FileMount>,                          // TODO: file
+    pub grpc_metric_collector_1p_ca_mount: Option<FileMount>, // TODO: file
     /// Path to the directory containing trust bundle for 1P grpc log collector.
-    pub grpc_log_collector_1p_ca_mount: Option<FileMount>,                              // TODO: file
+    pub grpc_log_collector_1p_ca_mount: Option<FileMount>, // TODO: file
     /// OTEL http/https metric endpoint.
     pub http_metric_endpoint: Option<String>,
     /// OTEL http/https log endpoint.

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/connector_configuration.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/connector_configuration.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Types for extracting Connector Configuration from a ConfigMap volume mount in an Akri
+//! deployment.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use super::connector::DeploymentArtifactErrorRepr;
+
+/// The Connector Configuration extracted from the Akri deployment
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConnectorConfiguration {
+    /// MQTT connection details
+    pub mqtt_connection_configuration: MqttConnectionConfiguration,
+    /// Diagnostics
+    pub diagnostics: Option<Diagnostics>,
+    /// Persistent Volume Mount Path
+    pub persistent_volumes: Vec<PathBuf>,
+    /// Additional connector configuration as a JSON string
+    pub additional_configuration: Option<String>,
+}
+
+impl ConnectorConfiguration {
+    /// Create a `ConnectorConfiguration` from the files in the specified mount path
+    pub(crate) fn new_from_mount_path(
+        mount_path: &Path,
+    ) -> Result<Self, DeploymentArtifactErrorRepr> {
+        // NOTE: Handling errors here does end up requiring unnecessary allocations in the
+        // FilePathMissing errors returned on optional files, but this is not (yet) code that will
+        // be run often, and it keeps things simpler and easier to pivot as the spec evolves.
+        // When finalized, consider optimizing so the individual helpers have logic to handle
+        // optional files.
+
+        let mqtt_connection_configuration =
+            Self::extract_mqtt_connection_configuration(mount_path)?;
+        let diagnostics = match Self::extract_diagnostics(mount_path) {
+            Ok(d) => Some(d),
+            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => None,
+            Err(e) => Err(e)?,
+        };
+        let persistent_volumes = match Self::extract_persistent_volumes(mount_path) {
+            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => vec![],
+            res => res?,
+        };
+        let additional_configuration = match Self::extract_additional_configuration(mount_path) {
+            Ok(ac) => Some(ac),
+            Err(DeploymentArtifactErrorRepr::FilePathMissing(_)) => None,
+            Err(e) => Err(e)?,
+        };
+
+        Ok(Self {
+            mqtt_connection_configuration,
+            diagnostics,
+            persistent_volumes,
+            additional_configuration,
+        })
+    }
+
+    /// Extract an `MqttConnectionConfiguration` from the specified mount path
+    fn extract_mqtt_connection_configuration(
+        mount_path: &Path,
+    ) -> Result<MqttConnectionConfiguration, DeploymentArtifactErrorRepr> {
+        let mqtt_conn_config_pathbuf = mount_path.join("MQTT_CONNECTION_CONFIGURATION");
+        if !mqtt_conn_config_pathbuf.exists() {
+            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
+                mqtt_conn_config_pathbuf.into(),
+            ))?;
+        }
+        // NOTE: Manual file read to memory is more efficient than using serde_json::from_reader()
+        let m: MqttConnectionConfiguration =
+            serde_json::from_str(&std::fs::read_to_string(&mqtt_conn_config_pathbuf)?)?;
+        Ok(m)
+    }
+
+    /// Extract a `Diagnostics` struct from the specified mount path
+    fn extract_diagnostics(mount_path: &Path) -> Result<Diagnostics, DeploymentArtifactErrorRepr> {
+        let diagnostics_pathbuf = mount_path.join("DIAGNOSTICS");
+        if !diagnostics_pathbuf.exists() {
+            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
+                diagnostics_pathbuf.into(),
+            ))?;
+        }
+        // NOTE: Manual file read to memory is more efficient than using serde_json::from_reader()
+        let d: Diagnostics = serde_json::from_str(&std::fs::read_to_string(&diagnostics_pathbuf)?)?;
+        Ok(d)
+    }
+
+    /// Extract a list of persistent volumes paths from the specified mount path
+    fn extract_persistent_volumes(
+        mount_path: &Path,
+    ) -> Result<Vec<PathBuf>, DeploymentArtifactErrorRepr> {
+        let persistent_volumes_pathbuf = mount_path.join("PERSISTENT_VOLUME_MOUNT_PATH");
+        if !persistent_volumes_pathbuf.exists() {
+            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
+                persistent_volumes_pathbuf.into(),
+            ))?;
+        }
+        // NOTE: Use a BufReader to reduce allocations
+        let persistent_volumes = BufReader::new(File::open(&persistent_volumes_pathbuf)?)
+            .lines()
+            .map_while(Result::ok)
+            .map(PathBuf::from)
+            .try_fold(vec![], |mut acc, pv_pathbuf| {
+                if !pv_pathbuf.exists() {
+                    return Err(DeploymentArtifactErrorRepr::MountPathMissing(
+                        pv_pathbuf.into_os_string(),
+                    ));
+                }
+                acc.push(pv_pathbuf);
+                Ok(acc)
+            })?;
+        Ok(persistent_volumes)
+    }
+
+    /// Extract additional configuration JSON string from the specified mount path
+    fn extract_additional_configuration(
+        mount_path: &Path,
+    ) -> Result<String, DeploymentArtifactErrorRepr> {
+        let additional_config_pathbuf = mount_path.join("ADDITIONAL_CONNECTOR_CONFIGURATION");
+        if !additional_config_pathbuf.exists() {
+            return Err(DeploymentArtifactErrorRepr::FilePathMissing(
+                additional_config_pathbuf.into_os_string(),
+            ))?;
+        }
+        let additional_config = std::fs::read_to_string(&additional_config_pathbuf)?;
+        Ok(additional_config)
+    }
+}
+
+/// Configuration details related to an MQTT connection
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MqttConnectionConfiguration {
+    /// Broker host in the format `<hostname>:<port>`
+    pub host: String,
+    /// Number of seconds to keep a connection to the broker alive for
+    pub keep_alive_seconds: u16,
+    /// Maximum number of messages that can be assigned a packet ID
+    pub max_inflight_messages: u16,
+    /// The type of MQTT connection being used
+    pub protocol: Protocol,
+    /// Number of seconds to keep a session with the broker alive for
+    pub session_expiry_seconds: u32,
+    /// TLS configuration
+    pub tls: Tls,
+}
+
+/// Enum representing the type of MQTT connection
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub enum Protocol {
+    /// Regular MQTT
+    #[serde(alias = "mqtt")]
+    Mqtt,
+}
+
+/// TLS configuration information
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Tls {
+    /// Indicates if TLS is enabled or not
+    pub mode: TlsMode,
+}
+
+/// Enum representing whether TLS is enabled or disabled
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub enum TlsMode {
+    /// TLS is enabled
+    Enabled,
+    /// TLS is disabled
+    Disabled,
+}
+
+/// Diagnostic information
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Diagnostics {
+    /// Log information
+    pub logs: Logs,
+}
+
+/// Logging information
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Logs {
+    /// The log level. Examples - 'debug', 'info', 'warn', 'error', 'trace'.
+    pub level: String,
+}

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/projected_volume_debouncer.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/projected_volume_debouncer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! A debouncer for Kubernetes projected volume mounts.
+//! A debouncer for Kubernetes projected volume and config map mounts.
 //!
 //! Wraps [`notify_debouncer_full`] and detects changes via the atomic `..data` symlink
 //! swap that Kubernetes performs when updating projected volumes.

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/secrets.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/secrets.rs
@@ -16,9 +16,9 @@ use std::{
 
 use tokio::sync::watch;
 
-use crate::deployment_artifacts::projected_volume_debouncer::{
-    ProjectedVolumeDebouncer, ProjectedVolumeError, ProjectedVolumeEventKind,
-    ProjectedVolumeEventResult, TICK_RATE as PVDB_TICK_RATE,
+use crate::deployment_artifacts::atomic_writer_volume_debouncer::{
+    AtomicWriterVolumeDebouncer, AtomicWriterVolumeError, AtomicWriterVolumeEventKind,
+    AtomicWriterVolumeEventResult, TICK_RATE as AWVDB_TICK_RATE,
 };
 
 /// Error for secret
@@ -29,7 +29,7 @@ pub struct Error(#[from] InnerError);
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 enum InnerError {
-    ProjectedVolumeError(#[from] ProjectedVolumeError),
+    AtomicWriterVolumeError(#[from] AtomicWriterVolumeError),
     IoError(#[from] std::io::Error),
     #[error("Invalid secret configuration")]
     Invalid,
@@ -41,17 +41,17 @@ enum InnerError {
 /// Set to 2x the debouncer tick rate to guarantee both debouncer callbacks
 /// are absorbed into a single notification.
 const _: () = assert!(
-    PVDB_TICK_RATE.as_millis() * 2 <= u64::MAX as u128,
+    AWVDB_TICK_RATE.as_millis() * 2 <= u64::MAX as u128,
     "COALESCE_WINDOW computation would truncate",
 );
 #[allow(clippy::cast_possible_truncation)] // Safety: const assertion above proves no truncation
-const COALESCE_WINDOW: Duration = Duration::from_millis(PVDB_TICK_RATE.as_millis() as u64 * 2);
+const COALESCE_WINDOW: Duration = Duration::from_millis(AWVDB_TICK_RATE.as_millis() as u64 * 2);
 
 /// Holds the file watchers (debouncers) that must remain alive as long as any
 /// `Secrets` or `Secret` handle exists.
 struct Watchers {
-    _metadata_debouncer: ProjectedVolumeDebouncer,
-    _data_debouncer: ProjectedVolumeDebouncer,
+    _metadata_debouncer: AtomicWriterVolumeDebouncer,
+    _data_debouncer: AtomicWriterVolumeDebouncer,
 }
 
 /// Manager for Secrets deployed in the connector application
@@ -64,8 +64,8 @@ pub struct Secrets {
 
 impl Secrets {
     /// # Arguments
-    /// - `metadata_path`: path the Secret Metadata mount is located at
-    /// - `data_path`: path the Secret Data mount is located at
+    /// - `metadata_path`: path the Secret Metadata configMap mount is located at
+    /// - `data_path`: path the Secret Data projected volume mount is located at
     ///
     /// Fails if paths are invalid
     pub(crate) fn new(metadata_path: PathBuf, data_path: PathBuf) -> Result<Self, Error> {
@@ -78,17 +78,20 @@ impl Secrets {
         let secret_tracker_c2 = secret_tracker.clone();
         let data_path_c1 = data_path.clone();
 
+        // NOTE: Both configMap volumes and projected volumes can use the AtomicWriterVolumeDebouncer
+        // as they have the same atomic symlink swap behavior.
+
         // Set up the Secret Metadata mount debouncer.
-        let metadata_debouncer = ProjectedVolumeDebouncer::new(
+        let metadata_debouncer = AtomicWriterVolumeDebouncer::new(
             metadata_path,
-            move |res: ProjectedVolumeEventResult| {
+            move |res: AtomicWriterVolumeEventResult| {
                 match res {
                     Ok(events) => {
                         for event in &events {
                             match event.kind {
                                 // Handle updates to existing aliases
                                 // (i.e. secret alias now points to a different secret)
-                                ProjectedVolumeEventKind::FileModified => {
+                                AtomicWriterVolumeEventKind::FileModified => {
                                     log::trace!("Secret metadata change detected: {event:?}");
                                     // Alias is the filename.
                                     let Some(file_name) = event.path.file_name() else {
@@ -150,27 +153,28 @@ impl Secrets {
         )?;
 
         // Set up the Secret Data mount debouncer.
-        let data_debouncer =
-            ProjectedVolumeDebouncer::new(data_path, move |res: ProjectedVolumeEventResult| {
+        let data_debouncer = AtomicWriterVolumeDebouncer::new(
+            data_path,
+            move |res: AtomicWriterVolumeEventResult| {
                 match res {
                     Ok(events) => {
                         for event in &events {
                             match event.kind {
                                 // Handle updates to existing secret data.
-                                ProjectedVolumeEventKind::FileModified => {
+                                AtomicWriterVolumeEventKind::FileModified => {
                                     log::trace!("Secret data change detected: {event:?}");
                                     secret_tracker_c2.report_secret_change(&event.path);
                                 }
                                 // Secret files can be created, but we don't need to do anything
                                 // with them until an alias points at them, so log and report.
-                                ProjectedVolumeEventKind::FileCreated => {
+                                AtomicWriterVolumeEventKind::FileCreated => {
                                     log::trace!("Secret data creation detected: {event:?}");
                                     secret_tracker_c2.report_secret_change(&event.path);
                                 }
                                 // Secret files can be deleted, but there's no need for anything
                                 // to be done in response, since the Secret interface will handle
                                 // the file no longer existing. Log only.
-                                ProjectedVolumeEventKind::FileRemoved => {
+                                AtomicWriterVolumeEventKind::FileRemoved => {
                                     log::trace!("Secret data removal detected: {event:?}");
                                 }
                                 // Directory events can be ignored
@@ -182,7 +186,8 @@ impl Secrets {
                         log::error!("Error processing Secret data event: {e:?}");
                     }
                 }
-            })?;
+            },
+        )?;
 
         Ok(Self {
             file_watchers: Arc::new(Watchers {
@@ -373,7 +378,7 @@ impl SecretTrackerState {
             let entry = entry?;
 
             // NOTE: Must use entry.path().is_file() instead of entry.file_type()?.is_file()
-            // In Kubernetes projected volumes, all files are also symlinks, and entry.file_type()
+            // In Kubernetes atomic-writer volumes, all files are also symlinks, and entry.file_type()
             // only returns a mutually-exclusive single type, which is always symlink.
             if entry.path().is_file() {
                 let secret_alias = entry
@@ -561,8 +566,8 @@ impl Drop for CoalesceThread {
 #[cfg(test)]
 mod tests {
     use super::{COALESCE_WINDOW, Secret, Secrets};
-    use crate::deployment_artifacts::projected_volume_debouncer::{DEBOUNCE_WINDOW, TICK_RATE};
-    use crate::deployment_artifacts::test_utils::TempProjectedVolume;
+    use crate::deployment_artifacts::atomic_writer_volume_debouncer::{DEBOUNCE_WINDOW, TICK_RATE};
+    use crate::deployment_artifacts::test_utils::TempAtomicWriterVolume;
     use futures_util::FutureExt;
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet};
@@ -633,8 +638,8 @@ mod tests {
 
     #[derive(Clone)]
     struct StandardSecretMountManager {
-        metadata_mount: Arc<TempProjectedVolume>,
-        data_mount: Arc<TempProjectedVolume>,
+        metadata_mount: Arc<TempAtomicWriterVolume>,
+        data_mount: Arc<TempAtomicWriterVolume>,
         /// Tracks which `secret_ref` directories have been created in the data mount.
         data_dirs: Arc<RefCell<HashSet<String>>>,
     }
@@ -643,8 +648,8 @@ mod tests {
         #[allow(clippy::arc_with_non_send_sync)]
         fn new() -> Self {
             Self {
-                metadata_mount: Arc::new(TempProjectedVolume::new("metadata")),
-                data_mount: Arc::new(TempProjectedVolume::new("data")),
+                metadata_mount: Arc::new(TempAtomicWriterVolume::new("metadata")),
+                data_mount: Arc::new(TempAtomicWriterVolume::new("data")),
                 data_dirs: Arc::new(RefCell::new(HashSet::new())),
             }
         }
@@ -717,16 +722,16 @@ mod tests {
 
     #[derive(Clone)]
     struct SecretSyncMountManager {
-        metadata_mount: Arc<TempProjectedVolume>,
-        data_mount: Arc<TempProjectedVolume>,
+        metadata_mount: Arc<TempAtomicWriterVolume>,
+        data_mount: Arc<TempAtomicWriterVolume>,
     }
 
     impl SecretSyncMountManager {
         #[allow(clippy::arc_with_non_send_sync)]
         fn new() -> Self {
             Self {
-                metadata_mount: Arc::new(TempProjectedVolume::new("metadata")),
-                data_mount: Arc::new(TempProjectedVolume::new("data")),
+                metadata_mount: Arc::new(TempAtomicWriterVolume::new("metadata")),
+                data_mount: Arc::new(TempAtomicWriterVolume::new("data")),
             }
         }
     }

--- a/rust/azure_iot_operations_connector/src/deployment_artifacts/test_utils.rs
+++ b/rust/azure_iot_operations_connector/src/deployment_artifacts/test_utils.rs
@@ -90,7 +90,7 @@ impl TempPersistentVolumeManager {
     }
 }
 
-/// Staged operation for a projected volume update.
+/// Staged operation for a atomic-writer volume update.
 enum StagedOp {
     FileCreate { path: PathBuf, contents: String },
     FileModify { path: PathBuf, contents: String },
@@ -99,16 +99,16 @@ enum StagedOp {
     DirRemove { path: PathBuf },
 }
 
-/// Simulates a Kubernetes projected volume using temporary directories for testing purposes.
+/// Simulates a Kubernetes atomic-writer volume using temporary directories for testing purposes.
 /// This creates real data on the filesystem in a temporary directory, but when dropped, all data
 /// will be removed from the filesystem.
 ///
 /// Updates are performed using the same atomic symlink swap mechanism that the kubelet uses:
 /// staged changes are written to a new timestamped directory, then `..data` is atomically
 /// swapped to point to it. Top-level entries are relative symlinks through `..data`.
-pub struct TempProjectedVolume {
+pub struct TempAtomicWriterVolume {
     dir: TempDir,
-    /// Current files in the projected volume (relative path to contents).
+    /// Current files in the atomic-writer volume (relative path to contents).
     files: RefCell<HashMap<PathBuf, String>>,
     /// Explicitly created directories (that may be empty).
     dirs: RefCell<HashSet<PathBuf>>,
@@ -120,8 +120,8 @@ pub struct TempProjectedVolume {
     counter: Cell<u64>,
 }
 
-impl TempProjectedVolume {
-    /// Create a new `TempProjectedVolume` with the given directory name.
+impl TempAtomicWriterVolume {
+    /// Create a new `TempAtomicWriterVolume` with the given directory name.
     pub fn new(dir_name: &str) -> Self {
         let dir = tempfile::TempDir::with_prefix(dir_name).unwrap();
         Self {
@@ -134,29 +134,29 @@ impl TempProjectedVolume {
         }
     }
 
-    /// Return the path of the projected volume mount.
+    /// Return the path of the atomic-writer volume mount.
     pub fn path(&self) -> &Path {
         self.dir.path()
     }
 
-    /// Validate that a path is safe to use inside the projected volume.
+    /// Validate that a path is safe to use inside the atomic-writer volume.
     ///
     /// Panics if the path is absolute or contains any `..`, root, or Windows
     /// prefix components, which could cause operations to escape the temp dir.
     fn validate_path(path: &Path) {
         assert!(
             path.is_relative(),
-            "projected volume path must be relative: {path:?}"
+            "atomic-writer volume path must be relative: {path:?}"
         );
         for component in path.components() {
             assert!(
                 matches!(component, Component::Normal(_)),
-                "projected volume path must not contain '..' or root components: {path:?}"
+                "atomic-writer volume path must not contain '..' or root components: {path:?}"
             );
         }
     }
 
-    /// Stage a file creation in the projected volume.
+    /// Stage a file creation in the atomic-writer volume.
     /// If the relative path includes subdirectories, they must already exist.
     pub fn stage_file_create(&self, file_path: &Path, contents: &str) {
         Self::validate_path(file_path);
@@ -166,7 +166,7 @@ impl TempProjectedVolume {
         });
     }
 
-    /// Stage a file modification in the projected volume. The file must already exist.
+    /// Stage a file modification in the atomic-writer volume. The file must already exist.
     pub fn stage_file_modify(&self, file_path: &Path, contents: &str) {
         Self::validate_path(file_path);
         self.staged_ops.borrow_mut().push(StagedOp::FileModify {
@@ -175,7 +175,7 @@ impl TempProjectedVolume {
         });
     }
 
-    /// Stage a file removal in the projected volume. The file must already exist.
+    /// Stage a file removal in the atomic-writer volume. The file must already exist.
     pub fn stage_file_remove(&self, file_path: &Path) {
         Self::validate_path(file_path);
         self.staged_ops.borrow_mut().push(StagedOp::FileRemove {
@@ -183,7 +183,7 @@ impl TempProjectedVolume {
         });
     }
 
-    /// Stage a directory creation in the projected volume. The directory must not already exist.
+    /// Stage a directory creation in the atomic-writer volume. The directory must not already exist.
     pub fn stage_dir_create(&self, dir_path: &Path) {
         Self::validate_path(dir_path);
         self.staged_ops.borrow_mut().push(StagedOp::DirCreate {
@@ -191,7 +191,7 @@ impl TempProjectedVolume {
         });
     }
 
-    /// Stage a directory removal in the projected volume. The directory must already exist and be empty.
+    /// Stage a directory removal in the atomic-writer volume. The directory must already exist and be empty.
     pub fn stage_dir_remove(&self, dir_path: &Path) {
         Self::validate_path(dir_path);
         self.staged_ops.borrow_mut().push(StagedOp::DirRemove {
@@ -199,7 +199,7 @@ impl TempProjectedVolume {
         });
     }
 
-    /// Trigger an update of all staged changes to the projected volume.
+    /// Trigger an update of all staged changes to the atomic-writer volume.
     ///
     /// This simulates the kubelet's atomic symlink swap:
     /// 1. Applies staged operations to the in-memory file state.
@@ -355,7 +355,7 @@ mod tests {
 
     // TODO: Write tests for other mounts.
 
-    mod projected_volume {
+    mod atomic_writer_volume {
         use super::*;
         use std::sync::atomic::{AtomicU64, Ordering};
         use test_case::test_case;
@@ -369,17 +369,17 @@ mod tests {
         }
 
         /// Helper: read a file via the canonical symlink path (i.e. through `..data`).
-        fn read_via_data_link(vol: &TempProjectedVolume, rel: &str) -> String {
+        fn read_via_data_link(vol: &TempAtomicWriterVolume, rel: &str) -> String {
             std::fs::read_to_string(vol.path().join("..data").join(rel)).unwrap()
         }
 
         /// Helper: read a file via the top-level symlink (e.g. `<mount>/my_dir/file`).
-        fn read_via_top_level(vol: &TempProjectedVolume, rel: &str) -> String {
+        fn read_via_top_level(vol: &TempAtomicWriterVolume, rel: &str) -> String {
             std::fs::read_to_string(vol.path().join(rel)).unwrap()
         }
 
         /// Helper: stage the parent directory for a file path if needed.
-        fn stage_parent_dirs(vol: &TempProjectedVolume, path: &Path) {
+        fn stage_parent_dirs(vol: &TempAtomicWriterVolume, path: &Path) {
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
             {
@@ -394,7 +394,7 @@ mod tests {
         // after. Depending on which happens, different events may be or not be reported.
         //
         // This does mean that the tests are of slightly lesser value than we might like, and thus we should make
-        // sure to update the TempProjectedVolume implementation if we notice any discrepencies between it and
+        // sure to update the TempAtomicWriterVolume implementation if we notice any discrepencies between it and
         // actual K8S behavior in production.
 
         // -- basic operations --
@@ -402,7 +402,7 @@ mod tests {
         #[test_case(Path::new("key"); "root")]
         #[test_case(Path::new("sub/key"); "subdirectory")]
         fn create_file(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "value");
             vol.execute_update();
@@ -415,7 +415,7 @@ mod tests {
         #[test_case(Path::new("key"); "root")]
         #[test_case(Path::new("sub/key"); "subdirectory")]
         fn modify_file(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "old");
             vol.execute_update();
@@ -431,7 +431,7 @@ mod tests {
         #[test_case(Path::new("key"); "root")]
         #[test_case(Path::new("sub/key"); "subdirectory")]
         fn remove_file(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "value");
             vol.execute_update();
@@ -445,7 +445,7 @@ mod tests {
 
         #[test]
         fn create_and_remove_directory() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_dir_create(Path::new("mydir"));
             vol.execute_update();
 
@@ -464,7 +464,7 @@ mod tests {
         #[test_case(Path::new("f"); "root")]
         #[test_case(Path::new("sub/f"); "subdirectory")]
         fn data_symlink_points_to_timestamped_dir(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "x");
             vol.execute_update();
@@ -482,7 +482,7 @@ mod tests {
 
         #[test]
         fn top_level_symlinks_point_through_data() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_dir_create(Path::new("secrets"));
             vol.stage_file_create(Path::new("secrets/key"), "val");
             vol.execute_update();
@@ -498,7 +498,7 @@ mod tests {
         #[test_case(Path::new("f"); "root")]
         #[test_case(Path::new("sub/f"); "subdirectory")]
         fn old_timestamped_dir_removed_after_swap(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "v1");
             vol.execute_update();
@@ -519,7 +519,7 @@ mod tests {
         #[test_case(Path::new("f"); "root")]
         #[test_case(Path::new("sub/f"); "subdirectory")]
         fn multiple_updates_produce_unique_timestamped_dirs(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
 
             vol.stage_file_create(file_path, "v1");
@@ -541,7 +541,7 @@ mod tests {
 
         #[test]
         fn stale_top_level_symlinks_removed() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_file_create(Path::new("a"), "1");
             vol.stage_file_create(Path::new("b"), "2");
             vol.execute_update();
@@ -578,7 +578,7 @@ mod tests {
 
         #[test]
         fn realistic_secret_mount() {
-            let vol = TempProjectedVolume::new(&unique_name("connector_secrets"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("connector_secrets"));
 
             // Initial mount: dir with two keys
             vol.stage_dir_create(Path::new("fake-ss"));
@@ -613,7 +613,7 @@ mod tests {
         #[test_case(Path::new("sub/f"); "subdirectory")]
         #[should_panic(expected = "file already exists")]
         fn create_duplicate_file_panics(file_path: &Path) {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             stage_parent_dirs(&vol, file_path);
             vol.stage_file_create(file_path, "v1");
             vol.execute_update();
@@ -625,7 +625,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "file does not exist")]
         fn modify_nonexistent_file_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_file_modify(Path::new("nope"), "val");
             vol.execute_update();
         }
@@ -633,7 +633,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "file does not exist")]
         fn remove_nonexistent_file_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_file_remove(Path::new("nope"));
             vol.execute_update();
         }
@@ -641,7 +641,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "directory already exists")]
         fn create_duplicate_dir_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_dir_create(Path::new("d"));
             vol.execute_update();
 
@@ -652,7 +652,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "directory does not exist")]
         fn remove_nonexistent_dir_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_dir_remove(Path::new("nope"));
             vol.execute_update();
         }
@@ -660,7 +660,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "directory contains files")]
         fn remove_nonempty_dir_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_dir_create(Path::new("d"));
             vol.stage_file_create(Path::new("d/f"), "val");
             vol.execute_update();
@@ -672,7 +672,7 @@ mod tests {
         #[test]
         #[should_panic(expected = "parent directory does not exist")]
         fn create_file_without_parent_dir_panics() {
-            let vol = TempProjectedVolume::new(&unique_name("test"));
+            let vol = TempAtomicWriterVolume::new(&unique_name("test"));
             vol.stage_file_create(Path::new("nonexistent_dir/file"), "val");
             vol.execute_update();
         }

--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-doc-valid-idents = ["IoT", "QoS", "PUBLISHes", ".."]
+doc-valid-idents = ["IoT", "QoS", "PUBLISHes", "ConfigMap", ".."]


### PR DESCRIPTION
- Renamed `ProjectedVolumeDebouncer` to `AtomicWriterVolumeDebouncer` as it also supports other volume types
- Moved `ConnectorConfiguration` and related structs to their own module to facilitate future work
- Updated documentation as necessary