### PR TITLE
[Rust][Connector] Version bump for 04-20-2026 release

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.0.1-rc1"
+version = "2.0.1"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"


### PR DESCRIPTION
`connector`: `2.0.1-rc1` -> `2.0.1`