### PR TITLE
[Cherry-pick][Rust] Defined MSRV at 1.88 (#1279)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,9 @@ exclude = [
 
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.88"
+
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
 

--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -5,6 +5,7 @@
 name = "azure_iot_operations_connector"
 version = "2.0.1-rc1"
 edition = "2024"
+rust-version.workspace = true
 license = "MIT"
 description = "Azure IoT Operations Connector"
 repository = "https://github.com/Azure/iot-operations-sdks"

--- a/rust/azure_iot_operations_mqtt/Cargo.toml
+++ b/rust/azure_iot_operations_mqtt/Cargo.toml
@@ -5,6 +5,7 @@
 name = "azure_iot_operations_mqtt"
 version = "1.0.1"
 edition = "2024"
+rust-version.workspace = true
 license = "MIT"
 description = "MQTT version 5.0 client library providing flexibility for decoupled asynchronous applications"
 repository = "https://github.com/Azure/iot-operations-sdks"

--- a/rust/azure_iot_operations_protocol/Cargo.toml
+++ b/rust/azure_iot_operations_protocol/Cargo.toml
@@ -5,6 +5,7 @@
 name = "azure_iot_operations_protocol"
 version = "1.0.0"
 edition = "2024"
+rust-version.workspace = true
 license = "MIT"
 description = "Utilities for using the Azure IoT Operations Protocol over MQTT"
 repository = "https://github.com/Azure/iot-operations-sdks"

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -5,6 +5,7 @@
 name = "azure_iot_operations_services"
 version = "1.2.0"
 edition = "2024"
+rust-version.workspace = true
 license = "MIT"
 description = "Azure IoT Operations Services"
 repository = "https://github.com/Azure/iot-operations-sdks"

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # Licensed under the MIT License.
 
 [toolchain]
-channel = "stable" # Needs to be in "stable" otherwise won't compile with new mqtt client.
+channel = "1.88"    # This is the version that we will use for local dev to ensure we are on the same clippy and rustfmt.
 components = ["clippy", "llvm-tools-preview", "rustfmt"]


### PR DESCRIPTION
- Updated all crates to indicate MSRV (Minimum Supported Rust Version) is 1.88.
- Note that this is just a formalization of what we've been using by convention up until now - it's possible we could loosen this restriction further in the future, but would require investigation.
- Can be set in the workspace for most crates, but the connector scaffolding needs to be independently defined due to not being part of the workspace (and being a scaffold for customer applications that will not use our workspace)
- CI that runs both MSRV and latest stable will be a follow up