### PR TITLE
[Rust][MQTT] Fixed flaky K8S SAT file test

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
@@ -36,7 +36,7 @@ pub trait EnhancedAuthPolicy: Send + Sync {
 // NOTE: The K8S SAT file monitoring implementation probably shouldn't be in this crate as it is specific to
 // the use of K8S in a connector environment. However, because we support SAT directly in the API of the
 // MqttConnectionSettings, we're forced to have it in this crate. This is unfortunate, because it means
-// we can't benefit from the Atomic Writer infrastructure from teh `azure_iot_operations_connector` crate,
+// we can't benefit from the Atomic Writer infrastructure from the `azure_iot_operations_connector` crate,
 // and so this implementation and testing is nowhere near as robust (or accurate) as it should be.
 // However, for the narrow scope of what it needs to do, this implementation does work.
 // If we ever revise the relationship between crates, this ideally would be excised from this crate,

--- a/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
@@ -32,6 +32,16 @@ pub trait EnhancedAuthPolicy: Send + Sync {
     async fn reauth_notified(&self) -> Option<Bytes>;
 }
 
+
+// NOTE: The K8S SAT file monitoring implementation probably shouldn't be in this crate as it is specific to
+// the use of K8S in a connector environment. However, because we support SAT directly in the API of the
+// MqttConnectionSettings, we're forced to have it in this crate. This is unfortunate, because it means
+// we can't benefit from the Atomic Writer infrastructure from teh `azure_iot_operations_connector` crate,
+// and so this implementation and testing is nowhere near as robust (or accurate) as it should be.
+// However, for the narrow scope of what it needs to do, this implementation does work.
+// If we ever revise the relationship between crates, this ideally would be excised from this crate,
+// and reimplemented elsewhere.
+
 // TODO: Wrap error from this module.
 #[derive(Debug, Error)]
 /// Error configuring [`K8sSatFileMonitor`] file monitoring authentication policy.
@@ -220,6 +230,14 @@ mod tests {
             K8sSatFileMonitor::new(mock_sat_file.path().to_path_buf(), aggregation_window).unwrap();
 
         let contents_t1 = fs::read(mock_sat_file.path()).unwrap();
+
+        // Drain any file events queued during setup (e.g. `Access(Open)` events from the reads
+        // above) by waiting for the aggregation window to elapse. The debouncer emits its first
+        // batch when the *oldest* queued event's deadline expires, so without this sleep the
+        // notification below would fire relative to the setup events rather than the upcoming
+        // `update_contents()` call, causing flaky timing assertions. These setup events do not
+        // trigger a reauth notification because no waiter is registered yet.
+        tokio::time::sleep(aggregation_window + Duration::from_millis(500)).await;
 
         // Create future to await reauth notification
         let mut reauth_notified_f = tokio_test::task::spawn(file_monitor.reauth_notified());

--- a/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/enhanced_auth_policy.rs
@@ -32,7 +32,6 @@ pub trait EnhancedAuthPolicy: Send + Sync {
     async fn reauth_notified(&self) -> Option<Bytes>;
 }
 
-
 // NOTE: The K8S SAT file monitoring implementation probably shouldn't be in this crate as it is specific to
 // the use of K8S in a connector environment. However, because we support SAT directly in the API of the
 // MqttConnectionSettings, we're forced to have it in this crate. This is unfortunate, because it means


### PR DESCRIPTION
Test was flaky due to a misunderstanding of aggregation window behavior. This suggests deeper issues with how the `K8sSatFileMonitor` is implemented (and really should not be in this crate), but changing that is not viable now, and the implementation itself does work, there just is a bit of unintuitive behavior at the margins.