### PR TITLE
Fix linkspector issues

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -7,6 +7,14 @@ excludedFiles:
 ignorePatterns:
   # There are some dummy links, ignore these
   - pattern: "^http://link_to_"
+httpHeaders:
+  # w3.org returns 403 to default linkspector/got user agent, which causes
+  # fragment validation on /TR/ specs to falsely fail. Send a browser-like UA.
+  - url:
+      - https://www.w3.org/
+    headers:
+      User-Agent: "Mozilla/5.0 (compatible; linkspector; +https://github.com/Azure/iot-operations-sdks)"
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 aliveStatusCodes:
   - 200
   - 201

--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -9,7 +9,7 @@ ignorePatterns:
   - pattern: "^http://link_to_"
 httpHeaders:
   # w3.org returns 403 to default linkspector/got user agent, which causes
-  # fragment validation on /TR/ specs to falsely fail. Send a browser-like UA.
+  # fragment validation on various specs to falsely fail. Send a browser-like UA.
   - url:
       - https://www.w3.org/
     headers:

--- a/doc/dev/packaging.md
+++ b/doc/dev/packaging.md
@@ -43,69 +43,16 @@ To refresh the dependencies, execute the following:
     dotnet restore --no-cache
     ```
 
-## Rust
+## Rust SDK
 
-To pull the required dependencies from upstream crates.io into Azure IoT Operations SDKs feed, execute the following:
+To issue a release for the Rust SDK:
 
-1. Create a [personal access token](https://dev.azure.com/azure-iot-sdks/_usersSettings/tokens) with with `Packaging | Read & write` permissions.
+1. Bump the version appropriate, and create the tag for the commit hash according to the pattern:
+```rust/{mqtt|protocol|services|connector}/v{major}.{minor}.{patch}```
 
-1. Authenticate using the PAT:
+1. Use the [Rust SDK release pipeline](https://dev.azure.com/msazure/One/_build?definitionId=442088) using the parameters:
+    - default `main` pipeline branch for the pipeline version
+    - the tag you created in the previous step for the "tag to release from" parameter
+    - do not check "Dry run" (unless you want to test it without releasing)
 
-    ```bash
-    cd rust
-    export PAT=<PAT_TOKEN>
-    echo -n Basic $(echo -n PAT:$PAT | base64) | cargo login --registry aio-sdks
-    ```
-
-1. Publish the crates:
-
-    ```bash
-    cargo publish --manifest-path azure_iot_operations_mqtt/Cargo.toml --registry aio-sdks
-    cargo publish --manifest-path azure_iot_operations_protocol/Cargo.toml --registry aio-sdks
-    cargo publish --manifest-path azure_iot_operations_services/Cargo.toml --registry aio-sdks
-    cargo publish --manifest-path azure_iot_operations_connector/Cargo.toml --registry aio-sdks
-    ```
-
-1. **[Optional]** Publish rumqttc:
-
-    Rumqttc is published from [this fork](https://github.com/ryanwinterms/rumqtt/tree/all_test) which contains a number of changes that have been proposed upstream.
-
-    ```bash
-    cargo publish --manifest-path rumqttc/Cargo.toml --registry aio-sdks --features use-native-tls --no-default-features
-    ```
-
-### Rust dependencies
-
-The Rust dependencies aren't automatically populated into the feed. To do this, you need to use a special URL to force authentication.
-
-1. Update the `rust/.cargo/config.toml` with the following:
-
-    ```yaml
-    [registry]
-    global-credential-providers = ["cargo:token"]
-
-    [registries]
-    aio-sdks-auth = { index = "sparse+https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview~force-auth/Cargo/index/" }
-
-    [source.crates-io]
-    replace-with = "aio-sdks-auth"
-    ```
-
-1. Create a [personal access token](https://dev.azure.com/azure-iot-sdks/_usersSettings/tokens) with with `Packaging | Read & write` permissions.
-
-1. Authenticate using the PAT:
-
-    ```bash
-    cd rust
-    export PAT=<PAT_TOKEN>
-    echo -n Basic $(echo -n PAT:$PAT | base64) | cargo login --registry aio-sdks-auth
-    ```
-
-1. Build the crates:
-
-    ```bash
-    cargo build --manifest-path azure_iot_operations_mqtt/Cargo.toml
-    cargo build --manifest-path azure_iot_operations_protocol/Cargo.toml
-    cargo build --manifest-path azure_iot_operations_services/Cargo.toml
-    cargo build --manifest-path azure_iot_operations_connector/Cargo.toml
-    ```
+1. During the run of the pipeline you will require someone other than yourself with a SAW to approve the release using the link provided from the `ApprovalService` in the final stage of the pipeline.

--- a/doc/dev/packaging.md
+++ b/doc/dev/packaging.md
@@ -49,8 +49,7 @@ To issue a release for the Rust SDK:
 
 1. Bump the version as appropriate and merge the changes into main
 
-1. Create the tag for the commit hash according to the pattern:
-```rust/{mqtt|protocol|services|connector}/v{major}.{minor}.{patch}```
+1. Create the tag for the commit hash according to the pattern: `rust/{mqtt|protocol|services|connector}/v{major}.{minor}.{patch}`
 
 1. Use the [Rust SDK release pipeline](https://dev.azure.com/msazure/One/_build?definitionId=442088) using the parameters:
     - default `main` pipeline branch for the pipeline version

--- a/doc/dev/packaging.md
+++ b/doc/dev/packaging.md
@@ -47,7 +47,9 @@ To refresh the dependencies, execute the following:
 
 To issue a release for the Rust SDK:
 
-1. Bump the version appropriate, and create the tag for the commit hash according to the pattern:
+1. Bump the version as appropriate and merge the changes into main
+
+1. Create the tag for the commit hash according to the pattern:
 ```rust/{mqtt|protocol|services|connector}/v{major}.{minor}.{patch}```
 
 1. Use the [Rust SDK release pipeline](https://dev.azure.com/msazure/One/_build?definitionId=442088) using the parameters:

--- a/dotnet/samples/Connectors/SqlConnector/README.md
+++ b/dotnet/samples/Connectors/SqlConnector/README.md
@@ -19,7 +19,7 @@ For instructions on how to install the project template, see [the installation i
 1. Run the following [script](./deploy-connector-and-device.sh) to deploy the connector and the simulated thermostat client to the cluster:
 
     ```bash
-    ./deploy-connector-and-asset.sh
+    ./deploy-connector-and-device.sh
     ```
 
 1. Subscribe to the following MQTT topic to observe the connector output:

--- a/dotnet/samples/Connectors/SqlConnector/README.md
+++ b/dotnet/samples/Connectors/SqlConnector/README.md
@@ -16,7 +16,7 @@ For instructions on how to install the project template, see [the installation i
 
 ## Run the sample
 
-1. Run the following [script](./deploy-connector-and-asset.sh) to deploy the connector and the simulated thermostat client to the cluster:
+1. Run the following [script](./deploy-connector-and-device.sh) to deploy the connector and the simulated thermostat client to the cluster:
 
     ```bash
     ./deploy-connector-and-asset.sh

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -47,11 +47,10 @@ This directory contains a variety of samples demonstrating how to use the .NET p
 
 ### Telemetry and RPC
 
-1. [Cloud events](./Protocol/CloudEvents/) - Send telemetry with cloud events referencing the payload schema
-1. [Read cloud events](./Protocol/ReadCloudEvents/) - Receive telemetry with cloud events and fetch schema from the schema registry
+1. [Cloud events](./Protocol/Telemetry/SendCloudEvents/) - Send telemetry with cloud events referencing the payload schema
+1. [Read cloud events](./Protocol/Telemetry/ReadCloudEvents/) - Receive telemetry with cloud events and fetch schema from the schema registry
 1. [Envoys](./Protocol/TestEnvoys/) - Client library and server stub library for various schema definitions
-1. Counter [client / server](./Protocol/Counter) - Client and server for the counter definition
-1. Additional [clients / servers](./Protocol/Codegen/) - Client and server for different DTDL definitions
+1. Counter [client](./Protocol/RPC/CounterClient/) / [server](./Protocol/RPC/CounterServer/) - Client and server for the counter definition
 
 ### Connectors
 


### PR DESCRIPTION
- Updated Rust SDK release instructions
- Fixed (or removed) broken .NET sample links in README
- Added User-Agent workaround for some URLs that were returning 403 to linkspector