### PR TITLE
[.NET] Bump versions for 4/27/2026 release

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Connector/Azure.Iot.Operations.Connector.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/Azure.Iot.Operations.Mqtt.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/Azure.Iot.Operations.Mqtt.csproj
@@ -7,7 +7,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/Session/SessionClosedException.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/Session/SessionClosedException.cs
@@ -3,6 +3,10 @@
 
 namespace Azure.Iot.Operations.Mqtt.Session.Exceptions
 {
+    /// <summary>
+    /// This exception is thrown by a <see cref="MqttSessionClient"/> if and only if the <see cref="MqttSessionClientOptions"/> flag for <see cref="MqttSessionClientOptions.ThrowIfUsedWhenSessionInactive"/>
+    /// is set and that session client attempts to publish/subscribe/unsubscribe while the session client's MQTT connection is closed and the session client is not attempting to reconnect.
+    /// </summary>
     public class SessionClosedException : Exception
     {
         public SessionClosedException(string message) : base(message) { }

--- a/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Protocol/Azure.Iot.Operations.Protocol.csproj
@@ -7,7 +7,7 @@
     <LicenseUrl>https://github.com/Azure/iot-operations-sdks/blob/main/LICENSE</LicenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Nullable>enable</Nullable>
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -6,7 +6,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.2.0-rc3</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Mqtt

 - Add new "ThrowIfUsedWhenSessionInactive" flag to session client options and new "SessionClosedException" that will be thrown if this flag is set and a session client attempts to publish/subscribe/unsubscribe while the session is closed (#1297)
 - Fix bug where disposing session client while it is reconnecting could cause unobserved ObjectDisposeException (#1289)

## Protocol

- Change StopAsync/DisposeAsync pattern (#1297)
  - **This change now requires users to call ```StopAsync``` on CommandInvoker, CommandExecutor, and TelemetryReceiver in order to unsubscribe from any MQTT topics that they were subscribed to. Previously, simply disposing these clients would unsubscribe from these topics, but now it does not.**
  - 
## Services

- Change StopAsync/DisposeAsync pattern (#1297)
  - **This change now requires users to call ```StopAsync``` on SchemaRegistryClient, StateStoreClient, LeasedLockClient, LeaderElectionClient, and AzureDeviceRegistryClient in order to unsubscribe from any MQTT topics that they were subscribed to. Previously, simply disposing these clients would unsubscribe from these topics, but now it does not.**
- Add support for reporting health status of endpoints, management actions, streams, etc. (#1290)

## Connector

- Adopt new pattern of calling StopAsync and DisposeAsync on clients such as SchemaRegistryClient (#1297)
- Add support for reporting health status of endpoints, management actions, streams, etc. (#1290)
  - Minor note: DeviceEndpointClient and AssetClient now implement IAsyncDisposable rather than IDisposable, but this disposal was already being done for the user in the base connector