### PR TITLE
[.NET] Bump package versions referenced in connector templates + samples

### DIFF
--- a/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/EventDrivenTcpThermostatConnector.csproj
+++ b/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/EventDrivenTcpThermostatConnector.csproj
@@ -12,7 +12,15 @@
 
   </ItemGroup>
 
-  <ItemGroup>
+  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+  </ItemGroup>
+
+  <!--Use local sources if built from inside the source repo-->
+  <ItemGroup Condition="Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Mqtt\Azure.Iot.Operations.Mqtt.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Services\Azure.Iot.Operations.Services.csproj" />

--- a/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/EventDrivenTcpThermostatConnector.csproj
+++ b/dotnet/samples/Connectors/EventDrivenTcpThermostatConnector/EventDrivenTcpThermostatConnector.csproj
@@ -12,11 +12,11 @@
 
   </ItemGroup>
 
-  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <!--Use latest packages from Nuget.org if built from outside the source repo-->
   <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*" />
   </ItemGroup>
 
   <!--Use local sources if built from inside the source repo-->

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/PollingRestThermostatConnector.csproj
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/PollingRestThermostatConnector.csproj
@@ -11,11 +11,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 
-  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <!--Use latest packages from Nuget.org if built from outside the source repo-->
   <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*" />
   </ItemGroup>
 
   <!--Use local sources if built from inside the source repo-->

--- a/dotnet/samples/Connectors/PollingRestThermostatConnector/PollingRestThermostatConnector.csproj
+++ b/dotnet/samples/Connectors/PollingRestThermostatConnector/PollingRestThermostatConnector.csproj
@@ -11,7 +11,15 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+  </ItemGroup>
+
+  <!--Use local sources if built from inside the source repo-->
+  <ItemGroup Condition="Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Mqtt\Azure.Iot.Operations.Mqtt.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Services\Azure.Iot.Operations.Services.csproj" />

--- a/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerConnector.csproj
+++ b/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerConnector.csproj
@@ -14,11 +14,11 @@
 
   </ItemGroup>
 
-  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <!--Use latest packages from Nuget.org if built from outside the source repo-->
   <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
-    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*" />
   </ItemGroup>
 
   <!--Use local sources if built from inside the source repo-->

--- a/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerConnector.csproj
+++ b/dotnet/samples/Connectors/SqlConnector/SqlQualityAnalyzerConnector.csproj
@@ -14,7 +14,15 @@
 
   </ItemGroup>
 
-  <ItemGroup>
+  <!--Use packages from Nuget.org if built from outside the source repo-->
+  <ItemGroup Condition="!Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.*.*" />
+    <PackageReference Include="Azure.Iot.Operations.Services" Version="1.*.*" />
+  </ItemGroup>
+
+  <!--Use local sources if built from inside the source repo-->
+  <ItemGroup Condition="Exists('..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj')">
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Connector\Azure.Iot.Operations.Connector.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Mqtt\Azure.Iot.Operations.Mqtt.csproj" />
     <ProjectReference Include="..\..\..\src\Azure.Iot.Operations.Services\Azure.Iot.Operations.Services.csproj" />

--- a/dotnet/samples/Protocol/RPC/SampleRpcClient/SampleRpcClient/SimpleRpcClient.csproj
+++ b/dotnet/samples/Protocol/RPC/SampleRpcClient/SampleRpcClient/SimpleRpcClient.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.11.0" />
-    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="0.12.1" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.1.0" />
+    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/Protocol/RPC/SampleRpcServer/SampleRpcServer/SimpleRpcServer.csproj
+++ b/dotnet/samples/Protocol/RPC/SampleRpcServer/SampleRpcServer/SimpleRpcServer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.11.0" />
-    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="0.12.1" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.1.0" />
+    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/Protocol/Telemetry/SimpleTelemetryReceiver/SimpleTelemetryReceiver.csproj
+++ b/dotnet/samples/Protocol/Telemetry/SimpleTelemetryReceiver/SimpleTelemetryReceiver.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.11.0" />
-    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="0.12.1" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.1.0" />
+    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/Protocol/Telemetry/SimpleTelemetrySender/SimpleTelemetrySender.csproj
+++ b/dotnet/samples/Protocol/Telemetry/SimpleTelemetrySender/SimpleTelemetrySender.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="0.11.0" />
-    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="0.12.1" />
+    <PackageReference Include="Azure.Iot.Operations.Mqtt" Version="1.1.0" />
+    <PackageReference Include="Azure.Iot.Operations.Protocol" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/templates/EventDrivenTelemetryConnector/EventDrivenTelemetryConnector.csproj
+++ b/dotnet/templates/EventDrivenTelemetryConnector/EventDrivenTelemetryConnector.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.0.1" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/templates/PollingTelemetryConnector/PollingTelemetryConnectorTemplate.csproj
+++ b/dotnet/templates/PollingTelemetryConnector/PollingTelemetryConnectorTemplate.csproj
@@ -9,6 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.0.1" />
+    <PackageReference Include="Azure.Iot.Operations.Connector" Version="1.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Also allow connector samples specifically to source our packages from Nuget.org if they are being built from outside this repo. This is useful for some DevX template work