### PR TITLE
[Codegen] Use strong name signing when building codegen packages (release pipeline compatibility)

### DIFF
--- a/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/Azure.Iot.Operations.CodeGeneration.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/Azure.Iot.Operations.CodeGeneration.csproj
@@ -9,4 +9,11 @@
     <ProjectReference Include="..\Azure.Iot.Operations.TDParser\Azure.Iot.Operations.TDParser.csproj" />
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/Azure.Iot.Operations.EnvoyGenerator.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/Azure.Iot.Operations.EnvoyGenerator.csproj
@@ -304,4 +304,11 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/Azure.Iot.Operations.ProtocolCompiler.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/Azure.Iot.Operations.ProtocolCompiler.csproj
@@ -26,4 +26,12 @@
     <ProjectReference Include="..\Azure.Iot.Operations.ProtocolCompilerLib\Azure.Iot.Operations.ProtocolCompilerLib.csproj" />
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/Azure.Iot.Operations.ProtocolCompilerLib.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/Azure.Iot.Operations.ProtocolCompilerLib.csproj
@@ -13,4 +13,11 @@
     <ProjectReference Include="..\Azure.Iot.Operations.TypeGenerator\Azure.Iot.Operations.TypeGenerator.csproj" />
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.SchemaGenerator/Azure.Iot.Operations.SchemaGenerator.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.SchemaGenerator/Azure.Iot.Operations.SchemaGenerator.csproj
@@ -64,4 +64,11 @@
     </Compile>
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.TDParser/Azure.Iot.Operations.TDParser.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.TDParser/Azure.Iot.Operations.TDParser.csproj
@@ -4,5 +4,12 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
+  
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/Azure.Iot.Operations.TypeGenerator/Azure.Iot.Operations.TypeGenerator.csproj
+++ b/wot-codegen/src/Azure.Iot.Operations.TypeGenerator/Azure.Iot.Operations.TypeGenerator.csproj
@@ -84,4 +84,11 @@
     </Compile>
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>

--- a/wot-codegen/src/TDParse/TDParse.csproj
+++ b/wot-codegen/src/TDParse/TDParse.csproj
@@ -10,4 +10,11 @@
     <ProjectReference Include="..\Azure.Iot.Operations.TDParser\Azure.Iot.Operations.TDParser.csproj" />
   </ItemGroup>
 
+  <!-- Add strong name signing properties for release pipeline compatibility -->
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\..\dotnet\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
We do this already in the other Nuget packages in this repo that we publish