### PR TITLE
[Rust] [Stub Service] Revert stub service codegen update

### DIFF
--- a/tools/azure_iot_operations_stub_services/gen.sh
+++ b/tools/azure_iot_operations_stub_services/gen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 ../../codegen/src/Azure.Iot.Operations.ProtocolCompiler/bin/Debug/net9.0/Azure.Iot.Operations.ProtocolCompiler \
- --serverOnly --modelFile ../../eng/dtdl/SchemaRegistry-1.json --sdkPath ../../rust --lang=rust --noProj \
+ --serverOnly --modelFile ../../eng/dtdl/SchemaRegistry-1.json --lang=rust --noProj \
  --outDir src/schema_registry/schema_registry_gen
  
 cargo fmt

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_request_schema_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_request_schema_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for GetRequestSchema {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !GetRequestSchema::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !GetRequestSchema::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_response_payload_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_response_payload_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for GetResponsePayload {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !GetResponsePayload::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !GetResponsePayload::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_response_schema_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/get_response_schema_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for GetResponseSchema {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !GetResponseSchema::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !GetResponseSchema::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_command_executor.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_command_executor.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use azure_iot_operations_mqtt::session::SessionManagedClient;
+use azure_iot_operations_mqtt::interface::ManagedClient;
 use azure_iot_operations_protocol::application::ApplicationContext;
 use azure_iot_operations_protocol::common::aio_protocol_error::AIOProtocolError;
 use azure_iot_operations_protocol::common::payload_serialize::PayloadSerialize;
@@ -31,15 +31,6 @@ impl PutResponseBuilder {
     /// Custom user data to set on the response
     pub fn custom_user_data(&mut self, custom_user_data: Vec<(String, String)>) -> &mut Self {
         self.inner_builder.custom_user_data(custom_user_data);
-        self
-    }
-
-    /// Cloud event for the response
-    pub fn cloud_event(
-        &mut self,
-        cloud_event: Option<rpc_command::executor::ResponseCloudEvent>,
-    ) -> &mut Self {
-        self.inner_builder.cloud_event(cloud_event);
         self
     }
 
@@ -74,16 +65,23 @@ impl PutResponseBuilder {
 }
 
 /// Command Executor for `put`
-pub struct PutCommandExecutor(rpc_command::Executor<PutRequestSchema, PutResponseSchema>);
+pub struct PutCommandExecutor<C>(rpc_command::Executor<PutRequestSchema, PutResponseSchema, C>)
+where
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static;
 
-impl PutCommandExecutor {
+impl<C> PutCommandExecutor<C>
+where
+    C: ManagedClient + Clone + Send + Sync + 'static,
+    C::PubReceiver: Send + Sync + 'static,
+{
     /// Creates a new [`PutCommandExecutor`]
     ///
     /// # Panics
     /// If the DTDL that generated this code was invalid
     pub fn new(
         application_context: ApplicationContext,
-        client: SessionManagedClient,
+        client: C,
         options: &CommandExecutorOptions,
     ) -> Self {
         let mut executor_options_builder = rpc_command::executor::OptionsBuilder::default();

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_request_schema_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_request_schema_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for PutRequestSchema {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !PutRequestSchema::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !PutRequestSchema::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_response_payload_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_response_payload_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for PutResponsePayload {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !PutResponsePayload::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !PutResponsePayload::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_response_schema_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/put_response_schema_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for PutResponseSchema {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !PutResponseSchema::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !PutResponseSchema::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/schema_registry_error_serialization.rs
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/schema_registry/schema_registry_error_serialization.rs
@@ -38,12 +38,12 @@ impl PayloadSerialize for SchemaRegistryError {
         content_type: Option<&String>,
         _format_indicator: &FormatIndicator,
     ) -> Result<Self, DeserializationError<Self::Error>> {
-        if let Some(content_type) = content_type
-            && !SchemaRegistryError::is_content_type(content_type)
-        {
-            return Err(DeserializationError::UnsupportedContentType(format!(
-                "Invalid content type: '{content_type}'. Must be 'application/json'"
-            )));
+        if let Some(content_type) = content_type {
+            if !SchemaRegistryError::is_content_type(content_type) {
+                return Err(DeserializationError::UnsupportedContentType(format!(
+                    "Invalid content type: '{content_type}'. Must be 'application/json'"
+                )));
+            }
         }
         serde_json::from_slice(payload).map_err(DeserializationError::InvalidPayload)
     }


### PR DESCRIPTION
Stub service codegen was updated to the GA SDKs, but the non codegen code hasn't been updated to the GA SDKs yet. This PR is reverting the codegen changes to get this compiling again and back to its stable state. I also updated the gen.sh to put the actual SDK version in the dependencies.md to make it clearer when the SDK versions need to be updated in the Cargo.toml since we have the versions specified there instead of a relative path