### PR TITLE
[Codegen + .NET] Fix issue where wot codegen'd telemetry sender did not wrap non-custom topic tokens with "ex:..."

### DIFF
--- a/dotnet/samples/Protocol/TestThing/Counter/EventCollectionSender.g.cs
+++ b/dotnet/samples/Protocol/TestThing/Counter/EventCollectionSender.g.cs
@@ -24,6 +24,15 @@ namespace TestThing.Counter
             public EventCollectionSender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/AssetUpdateEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/AssetUpdateEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public AssetUpdateEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DatasetRuntimeHealthEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DatasetRuntimeHealthEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public DatasetRuntimeHealthEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DeviceEndpointRuntimeHealthEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DeviceEndpointRuntimeHealthEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public DeviceEndpointRuntimeHealthEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DeviceUpdateEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/DeviceUpdateEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public DeviceUpdateEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/EventRuntimeHealthEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/EventRuntimeHealthEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public EventRuntimeHealthEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/ManagementActionRuntimeHealthEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/ManagementActionRuntimeHealthEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public ManagementActionRuntimeHealthEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/StreamRuntimeHealthEventTelemetrySender.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/Generated/AdrBaseService/StreamRuntimeHealthEventTelemetrySender.g.cs
@@ -24,6 +24,15 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBase
             public StreamRuntimeHealthEventTelemetrySender(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new Utf8JsonSerializer())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+                
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["senderId"] = mqttClient.ClientId;

--- a/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/dependencies.md
+++ b/tools/azure_iot_operations_stub_services/src/schema_registry/schema_registry_gen/dependencies.md
@@ -15,6 +15,6 @@ bigdecimal = "0.4.5"
 time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
 derive_builder = "0.20"
-azure_iot_operations_mqtt = { path = "../../../../../rust/azure_iot_operations_mqtt" }
-azure_iot_operations_protocol = { path = "../../../../../rust/azure_iot_operations_protocol" }
+azure_iot_operations_mqtt = { version = "1.0" }
+azure_iot_operations_protocol = { version = "1.0" }
 ```

--- a/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Events/t4/DotNetTelemetrySender.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Events/t4/DotNetTelemetrySender.cs
@@ -54,8 +54,17 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             this.Write("(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)\r\n          " +
                     "      : base(applicationContext, mqttClient, new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.serializerClassName));
-            this.Write("())\r\n            {\r\n                if (mqttClient.ClientId != null)\r\n           " +
-                    "     {\r\n                    TopicTokenMap[\"");
+            this.Write("())\r\n            {");
+            this.Write("\r\n                Dictionary<string, string> TopicTokenMapWithExPrefix = new();");
+            this.Write("\r\n                foreach (string key in TopicTokenMap.Keys)");
+            this.Write("\r\n                {");
+            this.Write("\r\n                    string keyWithPrefix = $\"ex:{{key}}\";");
+            this.Write("\r\n                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];");
+            this.Write("\r\n                }");
+            this.Write("\r\n                ");
+            this.Write("\r\n                TopicTokenMap = TopicTokenMapWithExPrefix;");
+            this.Write("\r\n");            
+            this.Write("\r\n                if (mqttClient.ClientId != null)\r\n                {\r\n                    TopicTokenMap[\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(MqttTopicTokens.EventSenderId));
             this.Write("\"] = mqttClient.ClientId;\r\n                }\r\n            }\r\n        }\r\n    }\r\n}\r" +
                     "\n");

--- a/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Events/t4/DotNetTelemetrySender.tt
+++ b/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/dotnet/Events/t4/DotNetTelemetrySender.tt
@@ -28,6 +28,16 @@ namespace <#=this.projectName#>.<#=this.genNamespace.GetNamespaceName(TargetLang
             public <#=this.componentName.GetTypeName(TargetLanguage.CSharp)#>(ApplicationContext applicationContext, IMqttPubSubClient mqttClient)
                 : base(applicationContext, mqttClient, new <#=this.serializerClassName#>())
             {
+                Dictionary<string, string> TopicTokenMapWithExPrefix = new();
+
+                foreach (string key in TopicTokenMap.Keys)
+                {
+                    string keyWithPrefix = $"ex:{{key}}";
+                    TopicTokenMapWithExPrefix[keyWithPrefix] = TopicTokenMap[key];
+                }
+
+                TopicTokenMap = TopicTokenMapWithExPrefix;
+
                 if (mqttClient.ClientId != null)
                 {
                     TopicTokenMap["<#=MqttTopicTokens.EventSenderId#>"] = mqttClient.ClientId;


### PR DESCRIPTION
Rust [does this](https://github.com/Azure/iot-operations-sdks/blob/8993ab15004cbd13d164e5290d57949b78a0406c/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/rust/Events/t4/RustTelemetrySender.tt#L51), but .NET did not

As a consequence, telemetry sender APIs in codegen'd services like ADR didn't actually work correctly because the telemetry sender base class expected to see a topic token key like "ex:connectorClientId" but the codegen layer would pass down a topic token key like "connectorClientId"