### PR TITLE
[.NET][Services] Fix how ADR client uses telemetry codegen layer

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AzureDeviceRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/AzureDeviceRegistryClient.cs
@@ -631,14 +631,15 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
 
             try
             {
-                await _adrBaseServiceService.DeviceEndpointRuntimeHealthEventTelemetrySender.SendTelemetryAsync(
-                    new()
+                await _adrBaseServiceService.SendTelemetryAsync(
+                    new DeviceEndpointRuntimeHealthEventTelemetry()
                     {
                         DeviceEndpointRuntimeHealthEvent = new()
                         {
                             RuntimeHealth = deviceEndpointRuntimeHealth.ToProtocol(),
                         },
                     },
+                    new(),
                     additionalTopicTokenMap,
                     MqttQualityOfServiceLevel.AtLeastOnce,
                     telemetryTimeout ?? _defaultTimeout,
@@ -686,8 +687,8 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
             {
                 var protocolDatasetsRuntimeHealth = datasetsRuntimeHealth?.Select(x => x.ToProtocol());
 
-                await _adrBaseServiceService.DatasetRuntimeHealthEventTelemetrySender.SendTelemetryAsync(
-                    new()
+                await _adrBaseServiceService.SendTelemetryAsync(
+                    new DatasetRuntimeHealthEventTelemetry()
                     {
                         DatasetRuntimeHealthEvent = new()
                         {
@@ -695,6 +696,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
                             Datasets = protocolDatasetsRuntimeHealth != null ? protocolDatasetsRuntimeHealth.ToList() : new(),
                         }
                     },
+                    new(),
                     additionalTopicTokenMap,
                     MqttQualityOfServiceLevel.AtLeastOnce,
                     telemetryTimeout ?? _defaultTimeout,
@@ -742,8 +744,8 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
             {
                 var protocolEventsRuntimeHealth = eventsRuntimeHealth?.Select(x => x.ToProtocol());
 
-                await _adrBaseServiceService.EventRuntimeHealthEventTelemetrySender.SendTelemetryAsync(
-                    new()
+                await _adrBaseServiceService.SendTelemetryAsync(
+                    new EventRuntimeHealthEventTelemetry()
                     {
                         EventRuntimeHealthEvent = new()
                         {
@@ -751,6 +753,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
                             Events = protocolEventsRuntimeHealth != null ? protocolEventsRuntimeHealth.ToList() : new(),
                         }
                     },
+                    new(),
                     additionalTopicTokenMap,
                     MqttQualityOfServiceLevel.AtLeastOnce,
                     telemetryTimeout ?? _defaultTimeout,
@@ -798,7 +801,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
             {
                 var protocolStreamsRuntimeHealth = streamsRuntimeHealth?.Select(x => x.ToProtocol());
 
-                await _adrBaseServiceService.StreamRuntimeHealthEventTelemetrySender.SendTelemetryAsync(
+                await _adrBaseServiceService.SendTelemetryAsync(
                     new StreamRuntimeHealthEventTelemetry()
                     {
                         StreamRuntimeHealthEvent = new()
@@ -807,6 +810,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
                             Streams = protocolStreamsRuntimeHealth != null ? protocolStreamsRuntimeHealth.ToList() : new(),
                         }
                     },
+                    new(),
                     additionalTopicTokenMap,
                     MqttQualityOfServiceLevel.AtLeastOnce,
                     telemetryTimeout ?? _defaultTimeout,
@@ -854,7 +858,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
             {
                 var protocolManagementActionsRuntimeHealth = managementActionsRuntimeHealth?.Select(x => x.ToProtocol());
 
-                await _adrBaseServiceService.ManagementActionRuntimeHealthEventTelemetrySender.SendTelemetryAsync(
+                await _adrBaseServiceService.SendTelemetryAsync(
                     new ManagementActionRuntimeHealthEventTelemetry()
                     {
                         ManagementActionRuntimeHealthEvent = new ManagementActionRuntimeHealthEventSchema()
@@ -863,6 +867,7 @@ public class AzureDeviceRegistryClient : IAzureDeviceRegistryClient
                             ManagementActions = protocolManagementActionsRuntimeHealth != null ? protocolManagementActionsRuntimeHealth.ToList() : new(),
                         }
                     },
+                    new(),
                     additionalTopicTokenMap,
                     MqttQualityOfServiceLevel.AtLeastOnce,
                     telemetryTimeout ?? _defaultTimeout,

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrBaseServiceServiceStub.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrBaseServiceServiceStub.cs
@@ -25,7 +25,7 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry
 
         Task SendTelemetryAsync(DeviceEndpointRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
 
-        Task SendTelemetryAsync(DatasetRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default)
+        Task SendTelemetryAsync(DatasetRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
 
         Task SendTelemetryAsync(EventRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
 

--- a/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrBaseServiceServiceStub.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/AssetAndDeviceRegistry/IAdrBaseServiceServiceStub.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Iot.Operations.Protocol.Models;
+using Azure.Iot.Operations.Protocol.Telemetry;
+using Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService;
 using static Azure.Iot.Operations.Services.AssetAndDeviceRegistry.Generated.AdrBaseService.AdrBaseService;
 
 namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry
@@ -19,6 +22,20 @@ namespace Azure.Iot.Operations.Services.AssetAndDeviceRegistry
         StreamRuntimeHealthEventTelemetrySender StreamRuntimeHealthEventTelemetrySender { get; }
 
         Task StopAsync(CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(DeviceEndpointRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(DatasetRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default)
+
+        Task SendTelemetryAsync(EventRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(ManagementActionRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(StreamRuntimeHealthEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(DeviceUpdateEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
+
+        Task SendTelemetryAsync(AssetUpdateEventTelemetry telemetry, OutgoingTelemetryMetadata metadata, Dictionary<string, string>? additionalTopicTokenMap = null, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtLeastOnce, TimeSpan? telemetryTimeout = null, CancellationToken cancellationToken = default);
 
         ValueTask DisposeAsync(bool disposing, CancellationToken cancellationToken);
 


### PR DESCRIPTION
The handwritten layer of the ADR service client was inadvertently skipping one layer of the codegen'd ADR client when using telemetry specifically. As a result, topic tokens were not being processed correctly.

Users who attempted to use these telemetry APIs (like health status reporting) would see failures around topic tokens.