### PR TITLE
[Rust][MQTT] Version bump for 5-14-2026 release

### DIFF
--- a/rust/azure_iot_operations_mqtt/Cargo.toml
+++ b/rust/azure_iot_operations_mqtt/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_mqtt"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"


### PR DESCRIPTION
mqtt: 1.0.1 -> 1.0.2
to release this fix: https://github.com/Azure/iot-operations-sdks/pull/1333