### PR TITLE
modify Opc2Wot typeRef to use reverse DNS name not expanded Node ID

### DIFF
--- a/wot-codegen/opc-output-integrated/ADI.TM.json
+++ b/wot-codegen/opc-output-integrated/ADI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -88,7 +88,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserDeviceStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserDeviceStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -204,7 +204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -406,7 +406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannel_OperatingModeSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannel_OperatingModeSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -864,7 +864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannel_OperatingModeExecuteSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannel_OperatingModeExecuteSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1238,7 +1238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelOperatingExecuteStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=8964",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelOperatingExecuteStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1264,7 +1264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelOperatingStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelOperatingStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1290,7 +1290,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelLocalStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelLocalStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1316,7 +1316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelMaintenanceStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelMaintenanceStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1342,7 +1342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_StreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.StreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1422,7 +1422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessorySlotType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessorySlotType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1493,7 +1493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessorySlotStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessorySlotStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1627,7 +1627,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1704,7 +1704,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1767,7 +1767,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MassSpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MassSpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1794,7 +1794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ParticleSizeMonitorDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ParticleSizeMonitorDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1833,7 +1833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AcousticSpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AcousticSpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1860,7 +1860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ChromatographDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ChromatographDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1887,7 +1887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MNRDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MNRDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1914,7 +1914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1953,7 +1953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ParticleSizeMonitorDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ParticleSizeMonitorDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1980,7 +1980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ChromatographDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ChromatographDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2007,7 +2007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MassSpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MassSpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2034,7 +2034,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AcousticSpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AcousticSpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2061,7 +2061,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_NMRDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.NMRDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2088,7 +2088,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_DetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9350",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.DetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2115,7 +2115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SmartSamplingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9359",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SmartSamplingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2142,7 +2142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9368",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SourceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2169,7 +2169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_GcOvenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.GcOvenType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2196,7 +2196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2243,7 +2243,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -2305,7 +2305,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2458,7 +2458,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2482,7 +2482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2685,7 +2685,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2741,7 +2741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2812,7 +2812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2834,7 +2834,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -2856,7 +2856,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -2878,7 +2878,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -2888,7 +2888,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -2910,7 +2910,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -3003,7 +3003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3048,7 +3048,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3074,7 +3074,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3119,7 +3119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfigurableObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfigurableObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3158,7 +3158,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3179,7 +3179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3205,7 +3205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3347,7 +3347,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3432,7 +3432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3458,7 +3458,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3504,7 +3504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/AMB.TM.json
+++ b/wot-codegen/opc-output-integrated/AMB.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_CalibrationDueConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.CalibrationDueConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ExternalCheckConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ExternalCheckConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_FlashUpdateInProgressConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.FlashUpdateInProgressConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ImprovementConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ImprovementConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_InspectionConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.InspectionConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_RepairConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.RepairConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ServicingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ServicingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_BadConfigurationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.BadConfigurationConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ConnectionFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ConnectionFailureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_FlashUpdateFailedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.FlashUpdateFailedConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -268,7 +268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OutOfResourcesConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OutOfResourcesConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -294,7 +294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OutOfMemoryConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OutOfMemoryConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -320,7 +320,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OverTemperatureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OverTemperatureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -346,7 +346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_SelfTestFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.SelfTestFailureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -372,7 +372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_IMaintenanceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.IMaintenanceEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -389,7 +389,7 @@
     "schemaDefinitions": {
       "MaintenanceMethodEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceMethodEnum",
         "const": {
           "Local": 0,
           "Remote": 1
@@ -462,7 +462,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AMB/",
         "title": "MaintenanceMethodEnum",
         "description": "Information about the planned or used maintenance method. The content may change during the different MaintenanceStates. By accessing the history of Events a Client can distinguish between the planned and actual used maintenance method during the maintenance activity.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceMethodEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -485,7 +485,7 @@
         "title": "NameNodeIdDataType",
         "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
         "required": [ "Name", "NodeId" ],
         "properties": {
           "Name": {
@@ -519,7 +519,7 @@
           "title": "NameNodeIdDataType",
           "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
           "required": [ "Name", "NodeId" ],
           "properties": {
             "Name": {
@@ -554,7 +554,7 @@
           "title": "NameNodeIdDataType",
           "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
           "required": [ "Name", "NodeId" ],
           "properties": {
             "Name": {
@@ -605,7 +605,7 @@
         "title": "NameNodeIdDataType",
         "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
         "required": [ "Name", "NodeId" ],
         "properties": {
           "Name": {
@@ -644,7 +644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_MaintenanceEventStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceEventStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -706,7 +706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_IRootCauseIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.IRootCauseIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -739,7 +739,7 @@
           "title": "RootCauseDataType",
           "description": "Root cause of an alarm",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.RootCauseDataType",
           "required": [ "RootCauseId", "RootCause" ],
           "properties": {
             "RootCauseId": {
@@ -779,7 +779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_DocumentationLinksType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.DocumentationLinksType",
     "dov:isComposite": true,
     "links": [
       {
@@ -813,7 +813,7 @@
         "description": "Method to add an end-user specific link that is stored persistently in the server.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LinkToExternalSource", "BrowseName", "DisplayName", "Description" ],
           "properties": {
             "LinkToExternalSource": {
@@ -836,7 +836,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LinkVariable" ],
           "properties": {
             "LinkVariable": {
@@ -858,7 +858,7 @@
         "description": "Method to remove an end-user specific link that is managed in the server.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariableToBeDeleted" ],
           "properties": {
             "VariableToBeDeleted": {
@@ -940,7 +940,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_MaintenanceConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11165",
+    "dov:typeRef": "org.opcfoundation.UA.MaintenanceConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -966,7 +966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -992,7 +992,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1013,7 +1013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11166",
+    "dov:typeRef": "org.opcfoundation.UA.SystemConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1039,7 +1039,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1207,7 +1207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1292,7 +1292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1338,7 +1338,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1384,7 +1384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/AMLBaseTypes.TM.json
+++ b/wot-codegen/opc-output-integrated/AMLBaseTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXBasicObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXBasicObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -54,7 +54,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -105,7 +105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -151,7 +151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -178,7 +178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseRole",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseRole",
     "dov:isComposite": true,
     "links": [
       {
@@ -205,7 +205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseSystemUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseSystemUnit",
     "dov:isComposite": true,
     "links": [
       {
@@ -232,7 +232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -253,7 +253,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/AMLLibs.TM.json
+++ b/wot-codegen/opc-output-integrated/AMLLibs.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AutomationMLBaseInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.AutomationMLBaseInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Order",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=25",
+    "dov:typeRef": "org.opcfoundation.UA.Order",
     "dov:isComposite": true,
     "links": [
       {
@@ -154,7 +154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PortConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.PortConnector",
     "links": [
       {
         "rel": "tm:extends",
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_InterlockingConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.InterlockingConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -269,7 +269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PPRConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.PPRConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -327,7 +327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ExternalDataConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.ExternalDataConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -415,7 +415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Communication_1",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.Communication",
     "dov:isComposite": true,
     "links": [
       {
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AttachmentInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.AttachmentInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_COLLADAInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.COLLADAInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -589,7 +589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLCopenXMLInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.PLCopenXMLInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -647,7 +647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_LogicInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.LogicInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -705,7 +705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_VariableInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.VariableInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -763,7 +763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_InterlockingVariableInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=64",
+    "dov:typeRef": "org.opcfoundation.UA.InterlockingVariableInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -851,7 +851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_SignalInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=71",
+    "dov:typeRef": "org.opcfoundation.UA.SignalInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -909,7 +909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AutomationMLBaseRole",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=74",
+    "dov:typeRef": "org.opcfoundation.UA.AutomationMLBaseRole",
     "dov:isComposite": true,
     "links": [
       {
@@ -967,7 +967,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Group",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=77",
+    "dov:typeRef": "org.opcfoundation.UA.Group",
     "dov:isComposite": true,
     "links": [
       {
@@ -1055,7 +1055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Facet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=80",
+    "dov:typeRef": "org.opcfoundation.UA.Facet",
     "dov:isComposite": true,
     "links": [
       {
@@ -1113,7 +1113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Port",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=83",
+    "dov:typeRef": "org.opcfoundation.UA.Port",
     "dov:isComposite": true,
     "links": [
       {
@@ -1321,7 +1321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Resource",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=86",
+    "dov:typeRef": "org.opcfoundation.UA.Resource",
     "dov:isComposite": true,
     "links": [
       {
@@ -1379,7 +1379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Product",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=89",
+    "dov:typeRef": "org.opcfoundation.UA.Product",
     "dov:isComposite": true,
     "links": [
       {
@@ -1437,7 +1437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Process",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=92",
+    "dov:typeRef": "org.opcfoundation.UA.Process",
     "dov:isComposite": true,
     "links": [
       {
@@ -1495,7 +1495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Structure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=95",
+    "dov:typeRef": "org.opcfoundation.UA.Structure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1553,7 +1553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PropertySet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=98",
+    "dov:typeRef": "org.opcfoundation.UA.PropertySet",
     "dov:isComposite": true,
     "links": [
       {
@@ -1611,7 +1611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Frame",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=101",
+    "dov:typeRef": "org.opcfoundation.UA.Frame",
     "dov:isComposite": true,
     "links": [
       {
@@ -1669,7 +1669,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_SignalGroup",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=107",
+    "dov:typeRef": "org.opcfoundation.UA.SignalGroup",
     "dov:isComposite": true,
     "links": [
       {
@@ -1727,7 +1727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ComponentGroup",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=110",
+    "dov:typeRef": "org.opcfoundation.UA.ComponentGroup",
     "dov:isComposite": true,
     "links": [
       {
@@ -1785,7 +1785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=131",
+    "dov:typeRef": "org.opcfoundation.UA.ProductStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1843,7 +1843,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=134",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1901,7 +1901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ResourceStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=137",
+    "dov:typeRef": "org.opcfoundation.UA.ResourceStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1959,7 +1959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BatchManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=140",
+    "dov:typeRef": "org.opcfoundation.UA.BatchManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2017,7 +2017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ContManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=143",
+    "dov:typeRef": "org.opcfoundation.UA.ContManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2075,7 +2075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_DiscManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=146",
+    "dov:typeRef": "org.opcfoundation.UA.DiscManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2133,7 +2133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Transport",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=149",
+    "dov:typeRef": "org.opcfoundation.UA.Transport",
     "dov:isComposite": true,
     "links": [
       {
@@ -2191,7 +2191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Storage",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=152",
+    "dov:typeRef": "org.opcfoundation.UA.Storage",
     "dov:isComposite": true,
     "links": [
       {
@@ -2249,7 +2249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Fixture",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=155",
+    "dov:typeRef": "org.opcfoundation.UA.Fixture",
     "dov:isComposite": true,
     "links": [
       {
@@ -2307,7 +2307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Gate",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=158",
+    "dov:typeRef": "org.opcfoundation.UA.Gate",
     "dov:isComposite": true,
     "links": [
       {
@@ -2365,7 +2365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Robot",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=161",
+    "dov:typeRef": "org.opcfoundation.UA.Robot",
     "dov:isComposite": true,
     "links": [
       {
@@ -2423,7 +2423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Tool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=164",
+    "dov:typeRef": "org.opcfoundation.UA.Tool",
     "dov:isComposite": true,
     "links": [
       {
@@ -2481,7 +2481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Carrier",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=167",
+    "dov:typeRef": "org.opcfoundation.UA.Carrier",
     "dov:isComposite": true,
     "links": [
       {
@@ -2539,7 +2539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Machine",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=170",
+    "dov:typeRef": "org.opcfoundation.UA.Machine",
     "dov:isComposite": true,
     "links": [
       {
@@ -2597,7 +2597,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StaticObject",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=173",
+    "dov:typeRef": "org.opcfoundation.UA.StaticObject",
     "dov:isComposite": true,
     "links": [
       {
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=176",
+    "dov:typeRef": "org.opcfoundation.UA.ControlEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2713,7 +2713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Communication_2",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=179",
+    "dov:typeRef": "org.opcfoundation.UA.Communication",
     "dov:isComposite": true,
     "links": [
       {
@@ -2771,7 +2771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlHardware",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=182",
+    "dov:typeRef": "org.opcfoundation.UA.ControlHardware",
     "dov:isComposite": true,
     "links": [
       {
@@ -2829,7 +2829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Sensor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=185",
+    "dov:typeRef": "org.opcfoundation.UA.Sensor",
     "dov:isComposite": true,
     "links": [
       {
@@ -2887,7 +2887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Actuator",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=188",
+    "dov:typeRef": "org.opcfoundation.UA.Actuator",
     "dov:isComposite": true,
     "links": [
       {
@@ -2945,7 +2945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Controller",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=191",
+    "dov:typeRef": "org.opcfoundation.UA.Controller",
     "dov:isComposite": true,
     "links": [
       {
@@ -3003,7 +3003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=194",
+    "dov:typeRef": "org.opcfoundation.UA.PC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3061,7 +3061,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_IPC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=197",
+    "dov:typeRef": "org.opcfoundation.UA.IPC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3119,7 +3119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_EmbeddedDevice",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=200",
+    "dov:typeRef": "org.opcfoundation.UA.EmbeddedDevice",
     "dov:isComposite": true,
     "links": [
       {
@@ -3177,7 +3177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Handheld",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=203",
+    "dov:typeRef": "org.opcfoundation.UA.Handheld",
     "dov:isComposite": true,
     "links": [
       {
@@ -3235,7 +3235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=206",
+    "dov:typeRef": "org.opcfoundation.UA.PLC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3293,7 +3293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_NC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=209",
+    "dov:typeRef": "org.opcfoundation.UA.NC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3351,7 +3351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_RC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=212",
+    "dov:typeRef": "org.opcfoundation.UA.RC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3409,7 +3409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PAC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=215",
+    "dov:typeRef": "org.opcfoundation.UA.PAC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3467,7 +3467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLCFacet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=218",
+    "dov:typeRef": "org.opcfoundation.UA.PLCFacet",
     "dov:isComposite": true,
     "links": [
       {
@@ -3525,7 +3525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_HMIFacet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=221",
+    "dov:typeRef": "org.opcfoundation.UA.HMIFacet",
     "dov:isComposite": true,
     "links": [
       {
@@ -3583,7 +3583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Enterprise",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=224",
+    "dov:typeRef": "org.opcfoundation.UA.Enterprise",
     "dov:isComposite": true,
     "links": [
       {
@@ -3641,7 +3641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Site",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=227",
+    "dov:typeRef": "org.opcfoundation.UA.Site",
     "dov:isComposite": true,
     "links": [
       {
@@ -3699,7 +3699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Area",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=230",
+    "dov:typeRef": "org.opcfoundation.UA.Area",
     "dov:isComposite": true,
     "links": [
       {
@@ -3757,7 +3757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductionLine",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=233",
+    "dov:typeRef": "org.opcfoundation.UA.ProductionLine",
     "dov:isComposite": true,
     "links": [
       {
@@ -3815,7 +3815,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_WorkCell",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=236",
+    "dov:typeRef": "org.opcfoundation.UA.WorkCell",
     "dov:isComposite": true,
     "links": [
       {
@@ -3873,7 +3873,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessCell",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=239",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessCell",
     "dov:isComposite": true,
     "links": [
       {
@@ -3931,7 +3931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Unit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=242",
+    "dov:typeRef": "org.opcfoundation.UA.Unit",
     "dov:isComposite": true,
     "links": [
       {
@@ -3989,7 +3989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductionUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=245",
+    "dov:typeRef": "org.opcfoundation.UA.ProductionUnit",
     "dov:isComposite": true,
     "links": [
       {
@@ -4047,7 +4047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StorageZone",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=248",
+    "dov:typeRef": "org.opcfoundation.UA.StorageZone",
     "dov:isComposite": true,
     "links": [
       {
@@ -4105,7 +4105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StorageUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=251",
+    "dov:typeRef": "org.opcfoundation.UA.StorageUnit",
     "dov:isComposite": true,
     "links": [
       {
@@ -4163,7 +4163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Turntable",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=254",
+    "dov:typeRef": "org.opcfoundation.UA.Turntable",
     "dov:isComposite": true,
     "links": [
       {
@@ -4221,7 +4221,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Conveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=257",
+    "dov:typeRef": "org.opcfoundation.UA.Conveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -4279,7 +4279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_LiftingTable",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=260",
+    "dov:typeRef": "org.opcfoundation.UA.LiftingTable",
     "dov:isComposite": true,
     "links": [
       {
@@ -4337,7 +4337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AGV",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=263",
+    "dov:typeRef": "org.opcfoundation.UA.AGV",
     "dov:isComposite": true,
     "links": [
       {
@@ -4395,7 +4395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Transposer",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=266",
+    "dov:typeRef": "org.opcfoundation.UA.Transposer",
     "dov:isComposite": true,
     "links": [
       {
@@ -4453,7 +4453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_CarrierHandlingSystem",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=269",
+    "dov:typeRef": "org.opcfoundation.UA.CarrierHandlingSystem",
     "dov:isComposite": true,
     "links": [
       {
@@ -4511,7 +4511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BodyStore",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=272",
+    "dov:typeRef": "org.opcfoundation.UA.BodyStore",
     "dov:isComposite": true,
     "links": [
       {
@@ -4569,7 +4569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Lift",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=275",
+    "dov:typeRef": "org.opcfoundation.UA.Lift",
     "dov:isComposite": true,
     "links": [
       {
@@ -4627,7 +4627,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Rollerbed",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=278",
+    "dov:typeRef": "org.opcfoundation.UA.Rollerbed",
     "dov:isComposite": true,
     "links": [
       {
@@ -4685,7 +4685,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StationaryTool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=281",
+    "dov:typeRef": "org.opcfoundation.UA.StationaryTool",
     "dov:isComposite": true,
     "links": [
       {
@@ -4743,7 +4743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MovableTool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=284",
+    "dov:typeRef": "org.opcfoundation.UA.MovableTool",
     "dov:isComposite": true,
     "links": [
       {
@@ -4801,7 +4801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlCabinet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=287",
+    "dov:typeRef": "org.opcfoundation.UA.ControlCabinet",
     "dov:isComposite": true,
     "links": [
       {
@@ -4859,7 +4859,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_IODevice",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=290",
+    "dov:typeRef": "org.opcfoundation.UA.IODevice",
     "dov:isComposite": true,
     "links": [
       {
@@ -4917,7 +4917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_HMI",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=293",
+    "dov:typeRef": "org.opcfoundation.UA.HMI",
     "dov:isComposite": true,
     "links": [
       {
@@ -4975,7 +4975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ActuatingDrive",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=296",
+    "dov:typeRef": "org.opcfoundation.UA.ActuatingDrive",
     "dov:isComposite": true,
     "links": [
       {
@@ -5033,7 +5033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MotionController",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=299",
+    "dov:typeRef": "org.opcfoundation.UA.MotionController",
     "dov:isComposite": true,
     "links": [
       {
@@ -5091,7 +5091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Panel",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=302",
+    "dov:typeRef": "org.opcfoundation.UA.Panel",
     "dov:isComposite": true,
     "links": [
       {
@@ -5149,7 +5149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MeasuringEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=305",
+    "dov:typeRef": "org.opcfoundation.UA.MeasuringEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -5207,7 +5207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Clamp",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=308",
+    "dov:typeRef": "org.opcfoundation.UA.Clamp",
     "dov:isComposite": true,
     "links": [
       {
@@ -5265,7 +5265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessController",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=311",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessController",
     "dov:isComposite": true,
     "links": [
       {
@@ -5323,7 +5323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Loader",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=314",
+    "dov:typeRef": "org.opcfoundation.UA.Loader",
     "dov:isComposite": true,
     "links": [
       {
@@ -5381,7 +5381,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Unloader",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=317",
+    "dov:typeRef": "org.opcfoundation.UA.Unloader",
     "dov:isComposite": true,
     "links": [
       {
@@ -5439,7 +5439,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BeltConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=320",
+    "dov:typeRef": "org.opcfoundation.UA.BeltConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5497,7 +5497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_RollConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=323",
+    "dov:typeRef": "org.opcfoundation.UA.RollConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5555,7 +5555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ChainConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=326",
+    "dov:typeRef": "org.opcfoundation.UA.ChainConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5613,7 +5613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PalletConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=329",
+    "dov:typeRef": "org.opcfoundation.UA.PalletConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5671,7 +5671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_OverheadConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=332",
+    "dov:typeRef": "org.opcfoundation.UA.OverheadConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5729,7 +5729,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_WarningEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=335",
+    "dov:typeRef": "org.opcfoundation.UA.WarningEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -5787,7 +5787,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5833,7 +5833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXBasicObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXBasicObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5879,7 +5879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/AdditiveManufacturing.TM.json
+++ b/wot-codegen/opc-output-integrated/AdditiveManufacturing.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_EquipmentAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.EquipmentAMType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,7 +40,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_FeedstockListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -90,7 +90,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_FeedstockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockType",
     "links": [
       {
         "rel": "tm:extends",
@@ -101,7 +101,7 @@
     "schemaDefinitions": {
       "FeedstockFunction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
         "const": {
           "Undefined": 0,
           "Main": 1,
@@ -188,7 +188,7 @@
       "Function": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "FeedstockFunction",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -312,7 +312,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "data": {
           "title": "FeedstockFunction",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+          "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_MachineIdentificationAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.MachineIdentificationAMType",
     "links": [
       {
         "rel": "tm:extends",
@@ -417,7 +417,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_AdditiveManufacturingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.AdditiveManufacturingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -462,7 +462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_ProcessValueAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.ProcessValueAMType",
     "dov:isComposite": true,
     "links": [
       {
@@ -474,7 +474,7 @@
     "schemaDefinitions": {
       "SensorCategory": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorCategory",
         "const": {
           "MachineHealth": 0,
           "MaintenanceTracking": 1,
@@ -498,7 +498,7 @@
       },
       "SensorSeverity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorSeverity",
         "const": {
           "Info": 0,
           "Critical": 1
@@ -534,7 +534,7 @@
       "Category": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "SensorCategory",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorCategory",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -555,7 +555,7 @@
       "Severity": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "SensorSeverity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorSeverity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -586,7 +586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -618,7 +618,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -668,7 +668,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -731,7 +731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -763,7 +763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -826,7 +826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -870,7 +870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -915,7 +915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -932,7 +932,7 @@
     "schemaDefinitions": {
       "MachineOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "const": {
           "Manual": 0,
           "Automatic": 1,
@@ -1013,7 +1013,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "MachineOperationMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1074,7 +1074,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "MachineOperationMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1113,7 +1113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ObligationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ObligationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1201,7 +1201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1239,7 +1239,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1265,7 +1265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1315,7 +1315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1361,7 +1361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1405,7 +1405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1499,7 +1499,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=59",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1563,7 +1563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1679,7 +1679,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1854,7 +1854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1880,7 +1880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1947,7 +1947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1968,7 +1968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1994,7 +1994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2008,7 +2008,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -2018,7 +2018,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -2037,7 +2037,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -2050,7 +2050,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -2074,7 +2074,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -2093,7 +2093,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -2112,7 +2112,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -2143,7 +2143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2188,7 +2188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2330,7 +2330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2415,7 +2415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2461,7 +2461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2507,7 +2507,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2533,7 +2533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2589,7 +2589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2657,7 +2657,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2899,7 +2899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2938,7 +2938,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -2969,7 +2969,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2997,7 +2997,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3025,7 +3025,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3062,7 +3062,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3090,7 +3090,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3415,7 +3415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3442,7 +3442,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3467,7 +3467,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3573,7 +3573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3600,7 +3600,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3625,7 +3625,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -3647,7 +3647,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -3906,7 +3906,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4002,7 +4002,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4106,7 +4106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4190,7 +4190,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4209,7 +4209,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -4229,7 +4229,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -4261,7 +4261,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4304,7 +4304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4330,7 +4330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4404,7 +4404,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4486,7 +4486,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4738,7 +4738,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4809,7 +4809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4833,7 +4833,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -4880,7 +4880,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4911,7 +4911,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4922,7 +4922,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -4969,7 +4969,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5014,7 +5014,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5054,7 +5054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5081,7 +5081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5475,7 +5475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5571,7 +5571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/AutoID.TM.json
+++ b/wot-codegen/opc-output-integrated/AutoID.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdDiagnosticsEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdDiagnosticsEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -55,7 +55,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdAccessEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdAccessEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -84,7 +84,7 @@
           "title": "AccessResult",
           "description": "Result values of an AutoID Identifier access.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.AccessResult",
           "properties": {
             "CodeType": {
               "description": "Defines the format of Identifier as string.",
@@ -94,7 +94,7 @@
               "title": "ScanData",
               "description": "The AutoID Identifier (e.g. a code or a transponder) which was accessed by a command.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -106,7 +106,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -191,7 +191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidAccessEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidAccessEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -220,7 +220,7 @@
           "title": "RfidAccessResult",
           "description": "Additional result values of an Rfid Transponder access.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidAccessResult",
           "properties": {
             "CodeTypeRWData": {
               "description": "Defines the format of RWData as string.",
@@ -230,7 +230,7 @@
               "title": "ScanData",
               "description": "The user data which was written to / was read from the Rfid Transponder by the command.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -242,7 +242,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -324,7 +324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdLogEntryEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdLogEntryEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -351,7 +351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdPresenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdPresenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -400,7 +400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -439,7 +439,7 @@
         "items": {
           "title": "ScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3001",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanResult",
           "required": [ "CodeType", "ScanData", "Timestamp" ],
           "properties": {
             "CodeType": {
@@ -450,7 +450,7 @@
               "title": "ScanData",
               "description": "Holds the information about the detected objects e.g. the detected transponders.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -462,7 +462,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -501,7 +501,7 @@
               "title": "Location",
               "description": "Returns the location of the object detection.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
               "properties": {
                 "NMEA": {
                   "type": "string"
@@ -509,7 +509,7 @@
                 "Local": {
                   "title": "LocalCoordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                   "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                   "properties": {
                     "X": {
@@ -549,7 +549,7 @@
                 "WGS84": {
                   "title": "WGS84Coordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                   "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                   "properties": {
                     "N/S Hemisphere": {
@@ -623,7 +623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OcrScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -650,7 +650,7 @@
         "items": {
           "title": "OcrScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanResult",
           "required": [ "ImageId", "Quality", "Position" ],
           "properties": {
             "ImageId": {
@@ -667,7 +667,7 @@
               "title": "Position",
               "description": "Returns the position of the text within the image.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
               "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
               "properties": {
                 "PositionX": {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -757,7 +757,7 @@
         "items": {
           "title": "OpticalScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanResult",
           "properties": {
             "Grade": {
               "description": "Returns the quality of the 1D/2D code.",
@@ -769,7 +769,7 @@
               "title": "Position",
               "description": "Returns the position of the text within the image.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
               "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
               "properties": {
                 "PositionX": {
@@ -829,7 +829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalVerifierScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -856,7 +856,7 @@
         "items": {
           "title": "OpticalVerifierScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierScanResult",
           "required": [ "IsoGrade", "RMin", "SymbolContrast", "ECMin", "Modulation", "Defects", "Decodability", "Decode", "PrintGain" ],
           "properties": {
             "IsoGrade": {
@@ -926,7 +926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -953,7 +953,7 @@
         "items": {
           "title": "RfidScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanResult",
           "required": [ "Sighting" ],
           "properties": {
             "Sighting": {
@@ -962,7 +962,7 @@
               "items": {
                 "title": "RfidSighting",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidSighting",
                 "required": [ "Antenna", "Strength", "Timestamp", "CurrentPowerLevel" ],
                 "properties": {
                   "Antenna": {
@@ -1015,7 +1015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RtlsLocationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1042,7 +1042,7 @@
         "items": {
           "title": "RtlsLocationResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
           "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
           "properties": {
             "Speed": {
@@ -1058,7 +1058,7 @@
             "Rotation": {
               "title": "Rotation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
               "required": [ "Yaw", "Pitch", "Roll" ],
               "properties": {
                 "Yaw": {
@@ -1106,7 +1106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1135,7 +1135,7 @@
     "schemaDefinitions": {
       "DeviceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
         "const": {
           "Idle": 0,
           "Error": 1,
@@ -1159,7 +1159,7 @@
       },
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -1183,7 +1183,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -1322,12 +1322,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6130",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LocationType" ],
           "properties": {
             "LocationType": {
               "title": "LocationTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1336,14 +1336,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6129",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Location" ],
           "properties": {
             "Location": {
               "title": "Location",
               "description": "Union of GPS, UTM or Local",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
               "properties": {
                 "NMEA": {
                   "type": "string"
@@ -1351,7 +1351,7 @@
                 "Local": {
                   "title": "LocalCoordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                   "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                   "properties": {
                     "X": {
@@ -1391,7 +1391,7 @@
                 "WGS84": {
                   "title": "WGS84Coordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                   "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                   "properties": {
                     "N/S Hemisphere": {
@@ -1455,13 +1455,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -1478,7 +1478,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1489,7 +1489,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6001",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -1497,7 +1497,7 @@
               "items": {
                 "title": "ScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3001",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanResult",
                 "required": [ "CodeType", "ScanData", "Timestamp" ],
                 "properties": {
                   "CodeType": {
@@ -1508,7 +1508,7 @@
                     "title": "ScanData",
                     "description": "Holds the information about the detected objects e.g. the detected transponders.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
                     "properties": {
                       "ByteString": {
                         "type": "string",
@@ -1520,7 +1520,7 @@
                       "Epc": {
                         "title": "ScanDataEpc",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                         "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                         "properties": {
                           "PC": {
@@ -1559,7 +1559,7 @@
                     "title": "Location",
                     "description": "Returns the location of the object detection.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
                     "properties": {
                       "NMEA": {
                         "type": "string"
@@ -1567,7 +1567,7 @@
                       "Local": {
                         "title": "LocalCoordinate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                         "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                         "properties": {
                           "X": {
@@ -1607,7 +1607,7 @@
                       "WGS84": {
                         "title": "WGS84Coordinate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                         "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                         "properties": {
                           "N/S Hemisphere": {
@@ -1662,7 +1662,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1681,13 +1681,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -1704,7 +1704,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1715,12 +1715,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6208",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1787,7 +1787,7 @@
         "title": "Location",
         "description": "Union of GPS, UTM, Local.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
         "properties": {
           "NMEA": {
             "type": "string"
@@ -1795,7 +1795,7 @@
           "Local": {
             "title": "LocalCoordinate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
             "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
             "properties": {
               "X": {
@@ -1835,7 +1835,7 @@
           "WGS84": {
             "title": "WGS84Coordinate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+            "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
             "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
             "properties": {
               "N/S Hemisphere": {
@@ -1937,7 +1937,7 @@
       "DeviceStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "DeviceStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2013,7 +2013,7 @@
           "title": "Location",
           "description": "Union of GPS, UTM, Local.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
           "properties": {
             "NMEA": {
               "type": "string"
@@ -2021,7 +2021,7 @@
             "Local": {
               "title": "LocalCoordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
               "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
               "properties": {
                 "X": {
@@ -2061,7 +2061,7 @@
             "WGS84": {
               "title": "WGS84Coordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
               "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
               "properties": {
                 "N/S Hemisphere": {
@@ -2123,7 +2123,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "data": {
           "title": "DeviceStatusEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2190,7 +2190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OcrReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2214,7 +2214,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2238,7 +2238,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2360,13 +2360,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6027",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2383,7 +2383,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2394,7 +2394,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6015",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2402,7 +2402,7 @@
               "items": {
                 "title": "OcrScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanResult",
                 "required": [ "ImageId", "Quality", "Position" ],
                 "properties": {
                   "ImageId": {
@@ -2419,7 +2419,7 @@
                     "title": "Position",
                     "description": "Returns the position of the text within the image.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
                     "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
                     "properties": {
                       "PositionX": {
@@ -2463,7 +2463,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2493,7 +2493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2517,7 +2517,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2541,7 +2541,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2663,13 +2663,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2686,7 +2686,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2697,7 +2697,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2705,7 +2705,7 @@
               "items": {
                 "title": "OpticalScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanResult",
                 "properties": {
                   "Grade": {
                     "description": "Returns the quality of the 1D/2D code.",
@@ -2717,7 +2717,7 @@
                     "title": "Position",
                     "description": "Returns the position of the text within the image.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
                     "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
                     "properties": {
                       "PositionX": {
@@ -2758,7 +2758,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2788,7 +2788,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalVerifierDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2800,7 +2800,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2824,7 +2824,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2946,13 +2946,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6031",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2969,7 +2969,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2980,7 +2980,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6076",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2988,7 +2988,7 @@
               "items": {
                 "title": "WGS84Coordinate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                 "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                 "properties": {
                   "N/S Hemisphere": {
@@ -3036,7 +3036,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3066,7 +3066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3090,7 +3090,7 @@
     "schemaDefinitions": {
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -3208,7 +3208,7 @@
       },
       "RfidLockRegionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockRegionEnumeration",
         "const": {
           "Kill": 0,
           "Access": 1,
@@ -3236,7 +3236,7 @@
       },
       "RfidLockOperationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockOperationEnumeration",
         "const": {
           "Lock": 0,
           "Unlock": 1,
@@ -3260,7 +3260,7 @@
       },
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -3284,7 +3284,7 @@
       },
       "RfidPasswordTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidPasswordTypeEnumeration",
         "const": {
           "Access": 0,
           "Kill": 1,
@@ -3329,13 +3329,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "KillPassword" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3347,7 +3347,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3388,12 +3388,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3412,13 +3412,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Password", "Region", "Lock", "Offset", "Length" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3430,7 +3430,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3469,14 +3469,14 @@
             },
             "Region": {
               "title": "RfidLockRegionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockRegionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Lock": {
               "title": "RfidLockOperationEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockOperationEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3495,12 +3495,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3519,13 +3519,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Region", "Offset", "Length", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3537,7 +3537,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3593,7 +3593,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultData", "Status" ],
           "properties": {
             "ResultData": {
@@ -3602,7 +3602,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3621,13 +3621,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Setting" ],
           "properties": {
             "Setting": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -3644,7 +3644,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -3655,7 +3655,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -3663,7 +3663,7 @@
               "items": {
                 "title": "RfidScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3007",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanResult",
                 "required": [ "Sighting" ],
                 "properties": {
                   "Sighting": {
@@ -3672,7 +3672,7 @@
                     "items": {
                       "title": "RfidSighting",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidSighting",
                       "required": [ "Antenna", "Strength", "Timestamp", "CurrentPowerLevel" ],
                       "properties": {
                         "Antenna": {
@@ -3706,7 +3706,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3725,13 +3725,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "PasswordType", "AccessPassword", "NewPassword" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3743,7 +3743,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3778,7 +3778,7 @@
             },
             "PasswordType": {
               "title": "RfidPasswordTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidPasswordTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3795,12 +3795,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3819,13 +3819,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Region", "Offset", "Data", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3837,7 +3837,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3892,12 +3892,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3916,13 +3916,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6137",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "NewUId", "AFI", "Toggle", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3934,7 +3934,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3987,12 +3987,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6140",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4015,7 +4015,7 @@
         "items": {
           "title": "AntennaNameIdPair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.AntennaNameIdPair",
           "required": [ "AntennaId", "AntennaName" ],
           "properties": {
             "AntennaId": {
@@ -4127,7 +4127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RtlsDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4139,7 +4139,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -4163,7 +4163,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -4297,13 +4297,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6224",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "LocationType", "CodeType" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -4315,7 +4315,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -4347,7 +4347,7 @@
             },
             "LocationType": {
               "title": "LocationTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4359,13 +4359,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6225",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Result" ],
           "properties": {
             "Result": {
               "title": "RtlsLocationResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
               "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
               "properties": {
                 "Speed": {
@@ -4381,7 +4381,7 @@
                 "Rotation": {
                   "title": "Rotation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
                   "required": [ "Yaw", "Pitch", "Roll" ],
                   "properties": {
                     "Yaw": {
@@ -4421,14 +4421,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6226",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SupportedLocationTypes" ],
           "properties": {
             "SupportedLocationTypes": {
               "type": "array",
               "items": {
                 "title": "LocationTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4458,13 +4458,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -4481,7 +4481,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -4492,7 +4492,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6219",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -4500,7 +4500,7 @@
               "items": {
                 "title": "RtlsLocationResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
                 "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
                 "properties": {
                   "Speed": {
@@ -4516,7 +4516,7 @@
                   "Rotation": {
                     "title": "Rotation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
                     "required": [ "Yaw", "Pitch", "Roll" ],
                     "properties": {
                       "Yaw": {
@@ -4545,7 +4545,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4566,7 +4566,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4602,7 +4602,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4638,7 +4638,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4674,7 +4674,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4719,7 +4719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4815,7 +4815,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4919,7 +4919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4940,7 +4940,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4966,7 +4966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5013,7 +5013,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -5075,7 +5075,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5228,7 +5228,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5252,7 +5252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5455,7 +5455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5511,7 +5511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5582,7 +5582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5604,7 +5604,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5626,7 +5626,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5648,7 +5648,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5658,7 +5658,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5680,7 +5680,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -5773,7 +5773,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5818,7 +5818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5844,7 +5844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/BACnet_V2.TM.json
+++ b/wot-codegen/opc-output-integrated/BACnet_V2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBackupRestoreType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101020",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupRestoreType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "BACnetBackupState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103016",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupState",
         "const": {
           "Idle": 0,
           "Preparing_For_Backup": 1,
@@ -55,7 +55,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -1611,7 +1611,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -1679,7 +1679,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -1827,7 +1827,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -1904,7 +1904,7 @@
       "Backup_And_Restore_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetBackupState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103016",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1966,7 +1966,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -1976,7 +1976,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2011,12 +2011,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTimeStamp",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
         "properties": {
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -2049,13 +2049,13 @@
           "DateTime": {
             "title": "BACnetDateTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
             "required": [ "Date", "Time" ],
             "properties": {
               "Date": {
                 "title": "BACnetDate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                 "properties": {
                   "Year": {
@@ -2065,21 +2065,21 @@
                   },
                   "Month": {
                     "title": "BACnetMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfMonth": {
                     "title": "BACnetDayOfMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfWeek": {
                     "title": "BACnetDayOfWeek",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2089,7 +2089,7 @@
               "Time": {
                 "title": "BACnetTime",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                 "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                 "properties": {
                   "Hour": {
@@ -2182,7 +2182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateCountType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateCountType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2193,7 +2193,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -2261,7 +2261,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -2409,7 +2409,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -2496,13 +2496,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -2512,21 +2512,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2536,7 +2536,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -2607,7 +2607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDeviceRestartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101022",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceRestartType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2618,7 +2618,7 @@
     "schemaDefinitions": {
       "BACnetRestartReason": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRestartReason",
         "const": {
           "unknown": 0,
           "coldstart": 1,
@@ -2658,7 +2658,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -2726,7 +2726,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -2874,7 +2874,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -2930,7 +2930,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RestartNotificationRecipients" ],
           "properties": {
             "RestartNotificationRecipients": {
@@ -2938,7 +2938,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -2948,7 +2948,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -2971,7 +2971,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6137",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -2993,7 +2993,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6147",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RestartNotificationRecipients" ],
           "properties": {
             "RestartNotificationRecipients": {
@@ -3001,7 +3001,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -3011,7 +3011,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -3034,7 +3034,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -3057,7 +3057,7 @@
       "Last_Restart_Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetRestartReason",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRestartReason",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3081,7 +3081,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -3091,7 +3091,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -3127,12 +3127,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTimeStamp",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
         "properties": {
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -3165,13 +3165,13 @@
           "DateTime": {
             "title": "BACnetDateTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
             "required": [ "Date", "Time" ],
             "properties": {
               "Date": {
                 "title": "BACnetDate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                 "properties": {
                   "Year": {
@@ -3181,21 +3181,21 @@
                   },
                   "Month": {
                     "title": "BACnetMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfMonth": {
                     "title": "BACnetDayOfMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfWeek": {
                     "title": "BACnetDayOfWeek",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3205,7 +3205,7 @@
               "Time": {
                 "title": "BACnetTime",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                 "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                 "properties": {
                   "Hour": {
@@ -3260,7 +3260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetElapsedActiveTimeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetElapsedActiveTimeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3345,7 +3345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3421,7 +3421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBufferReadyAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101005",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBufferReadyAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3497,7 +3497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfBitStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101003",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfBitStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3527,7 +3527,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -3566,7 +3566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfCharacterStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101034",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfCharacterStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3625,7 +3625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfLifeSafetyAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101028",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfLifeSafetyAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3637,7 +3637,7 @@
     "schemaDefinitions": {
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -3765,7 +3765,7 @@
         "type": "array",
         "items": {
           "title": "BACnetLifeSafetyState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3789,7 +3789,7 @@
         "type": "array",
         "items": {
           "title": "BACnetLifeSafetyState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3816,7 +3816,7 @@
           "type": "array",
           "items": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3836,7 +3836,7 @@
           "type": "array",
           "items": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3861,7 +3861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3917,7 +3917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStatusFlagsAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101030",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStatusFlagsAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3929,7 +3929,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -3970,7 +3970,7 @@
       "SelectedFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4001,7 +4001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfValueAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101004",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfValueAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4031,7 +4031,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -4089,7 +4089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCommandFailureAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCommandFailureAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4100,7 +4100,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -5674,7 +5674,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -5684,7 +5684,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5727,7 +5727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDoubleOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101031",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDoubleOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5739,7 +5739,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -5810,7 +5810,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5860,7 +5860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFloatingLimitAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101002",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFloatingLimitAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5871,7 +5871,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -7502,7 +7502,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -7512,7 +7512,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -7555,7 +7555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetOutOfRangeAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7566,7 +7566,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7637,7 +7637,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7687,7 +7687,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSignedOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101032",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSignedOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7699,7 +7699,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7766,7 +7766,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7814,7 +7814,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101033",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7826,7 +7826,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7895,7 +7895,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7944,7 +7944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101029",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8019,7 +8019,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventReportingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventReportingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8036,7 +8036,7 @@
     "schemaDefinitions": {
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -8056,7 +8056,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -9612,7 +9612,7 @@
       },
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -9644,7 +9644,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -9712,7 +9712,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -9860,7 +9860,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -9900,7 +9900,7 @@
       },
       "BACnetNotifyType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "const": {
           "Alarm": 0,
           "Event": 1,
@@ -9937,7 +9937,7 @@
       "Acked_Transitions": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9976,7 +9976,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -9986,7 +9986,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -10036,7 +10036,7 @@
       "Event_Enable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10097,7 +10097,7 @@
       "Event_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10121,12 +10121,12 @@
         "items": {
           "title": "BACnetTimeStamp",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
           "properties": {
             "Time": {
               "title": "BACnetTime",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
               "required": [ "Hour", "Minute", "Second", "Hundredths" ],
               "properties": {
                 "Hour": {
@@ -10159,13 +10159,13 @@
             "DateTime": {
               "title": "BACnetDateTime",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
               "required": [ "Date", "Time" ],
               "properties": {
                 "Date": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -10175,21 +10175,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -10199,7 +10199,7 @@
                 "Time": {
                   "title": "BACnetTime",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                   "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                   "properties": {
                     "Hour": {
@@ -10264,7 +10264,7 @@
       "Notify_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNotifyType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10295,7 +10295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetIntrinsicReportingTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101016",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetIntrinsicReportingTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10353,7 +10353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101025",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10379,7 +10379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultCharacterStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101009",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultCharacterStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10438,7 +10438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultStateAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101011",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultStateAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10497,7 +10497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultStatusFlagsAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101012",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultStatusFlagsAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10524,7 +10524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultEvaluationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultEvaluationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10541,7 +10541,7 @@
     "schemaDefinitions": {
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -10641,7 +10641,7 @@
       "Reliability": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetReliability",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10689,7 +10689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetInternetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetInternetworkType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10707,7 +10707,7 @@
     "schemaDefinitions": {
       "BACnetSegmentation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "const": {
           "segmented_both": 0,
           "segmented_transmit": 1,
@@ -10731,7 +10731,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -12291,7 +12291,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6252",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Address" ],
           "properties": {
             "Address": {
@@ -12311,7 +12311,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6248",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObject" ],
           "properties": {
             "DeviceObject": {
@@ -12331,7 +12331,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6247",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BACnetDeviceIds", "OpcUaObjectIds" ],
           "properties": {
             "BACnetDeviceIds": {
@@ -12362,7 +12362,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6660",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "WaitTimeInSeconds", "ApplyRange", "DeviceRangeLow", "DeviceRangeHigh" ],
           "properties": {
             "WaitTimeInSeconds": {
@@ -12387,7 +12387,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6661",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeviceAddressBindings", "MaxAPDULengthAccepted", "SegmentationSupported", "VendorIdentifier" ],
           "properties": {
             "DeviceAddressBindings": {
@@ -12408,7 +12408,7 @@
               "type": "array",
               "items": {
                 "title": "BACnetSegmentation",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -12436,7 +12436,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6662",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Time" ],
           "properties": {
             "Time": {
@@ -12457,7 +12457,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6245",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "BACnetIds" ],
           "properties": {
             "BACnetIds": {
@@ -12465,7 +12465,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -12475,7 +12475,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -12497,7 +12497,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "OpcUaIds" ],
           "properties": {
             "OpcUaIds": {
@@ -12531,7 +12531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12578,7 +12578,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -14134,7 +14134,7 @@
       },
       "BACnetObjectTypeSupportedBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3063",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeSupportedBits",
         "const": {
           "analog_input": 0,
           "analog_output": 1,
@@ -14362,7 +14362,7 @@
       },
       "BACnetServicesSupportedBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3064",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetServicesSupportedBits",
         "const": {
           "acknowledgeAlarm": 0,
           "confirmedCOVNotification": 1,
@@ -14530,7 +14530,7 @@
       },
       "BACnetSegmentation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "const": {
           "segmented_both": 0,
           "segmented_transmit": 1,
@@ -14554,7 +14554,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -14586,7 +14586,7 @@
       },
       "BACnetDeviceCommunicationEnabled": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceCommunicationEnabled",
         "const": {
           "Enable": 0,
           "Disable": 1,
@@ -14606,7 +14606,7 @@
       },
       "BACnetReinitializedStateofDevice": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3049",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReinitializedStateofDevice",
         "const": {
           "Coldstart": 0,
           "Warmstart": 1,
@@ -14642,7 +14642,7 @@
       },
       "BACnetMessagePriority": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3057",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessagePriority",
         "const": {
           "normal": 0,
           "urgent": 1
@@ -14674,7 +14674,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6271",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddressBindings" ],
           "properties": {
             "AddressBindings": {
@@ -14682,7 +14682,7 @@
               "items": {
                 "title": "BACnetAddressBinding",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
                 "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
                 "properties": {
                   "DeviceObjectIdentifier": {
@@ -14693,7 +14693,7 @@
                   "DeviceAddress": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -14716,7 +14716,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6272",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -14738,7 +14738,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6254",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectSpecifier", "ListOfInitialValues" ],
           "properties": {
             "ObjectSpecifier": {
@@ -14751,7 +14751,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -14778,7 +14778,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6256",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -14801,7 +14801,7 @@
         "description": "ToDo",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6266",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TimeDurationInMinutes", "EnableDisable", "Password" ],
           "properties": {
             "TimeDurationInMinutes": {
@@ -14811,7 +14811,7 @@
             },
             "EnableDisable": {
               "title": "BACnetDeviceCommunicationEnabled",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceCommunicationEnabled",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -14833,12 +14833,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6255",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReinitializedStateofDevice", "Password" ],
           "properties": {
             "ReinitializedStateofDevice": {
               "title": "BACnetReinitializedStateofDevice",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3049",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReinitializedStateofDevice",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -14860,7 +14860,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6273",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddressBindings" ],
           "properties": {
             "AddressBindings": {
@@ -14868,7 +14868,7 @@
               "items": {
                 "title": "BACnetAddressBinding",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
                 "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
                 "properties": {
                   "DeviceObjectIdentifier": {
@@ -14879,7 +14879,7 @@
                   "DeviceAddress": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -14902,7 +14902,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6274",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -14924,7 +14924,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6267",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SendUnconfirmed", "TextMessageSourceDevice", "MessageClass", "MessagePriority", "Message" ],
           "properties": {
             "SendUnconfirmed": {
@@ -14938,7 +14938,7 @@
             "MessageClass": {
               "title": "BACnetMessageClass",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3052",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessageClass",
               "properties": {
                 "Unsigned": {
                   "type": "integer",
@@ -14951,7 +14951,7 @@
             },
             "MessagePriority": {
               "title": "BACnetMessagePriority",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3057",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessagePriority",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -14977,19 +14977,19 @@
         "items": {
           "title": "BACnetCOVSubscription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103017",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCOVSubscription",
           "required": [ "Recipient", "MonitoredPropertyReference", "IssueConfirmedNotifications", "TimeRemaining" ],
           "properties": {
             "Recipient": {
               "title": "BACnetRecipientProcess",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103018",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipientProcess",
               "required": [ "Recipient", "ProcessIdentifier" ],
               "properties": {
                 "Recipient": {
                   "title": "BACnetRecipient",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                   "properties": {
                     "Device": {
                       "type": "integer",
@@ -14999,7 +14999,7 @@
                     "Address": {
                       "title": "BACnetAddress",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                       "required": [ "NetworkNumber", "MacAddress" ],
                       "properties": {
                         "NetworkNumber": {
@@ -15027,7 +15027,7 @@
             "MonitoredPropertyReference": {
               "title": "BACnetDeviceObjectPropertyReference",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
               "required": [ "ObjectIdentifier" ],
               "properties": {
                 "ObjectIdentifier": {
@@ -15037,7 +15037,7 @@
                 },
                 "PropertyIdentifier": {
                   "title": "BACnetPropertyIdentifier",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -15160,7 +15160,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -15171,7 +15171,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -15311,7 +15311,7 @@
       "Protocol_Object_Types_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetObjectTypeSupportedBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3063",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeSupportedBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15350,7 +15350,7 @@
       "Protocol_Services_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetServicesSupportedBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3064",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetServicesSupportedBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15389,7 +15389,7 @@
       "Segmentation_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetSegmentation",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15427,7 +15427,7 @@
       "System_Status": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15494,7 +15494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15568,7 +15568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMstpMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101021",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMstpMasterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15616,7 +15616,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -15627,7 +15627,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -15702,7 +15702,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -15713,7 +15713,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -15775,7 +15775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTimeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101019",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15786,7 +15786,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -15854,7 +15854,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -16002,7 +16002,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -16058,7 +16058,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6346",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Time" ],
           "properties": {
             "Time": {
@@ -16098,7 +16098,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDate",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
         "properties": {
           "Year": {
@@ -16108,21 +16108,21 @@
           },
           "Month": {
             "title": "BACnetMonth",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "DayOfMonth": {
             "title": "BACnetDayOfMonth",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "DayOfWeek": {
             "title": "BACnetDayOfWeek",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -16146,7 +16146,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
         "required": [ "Hour", "Minute", "Second", "Hundredths" ],
         "properties": {
           "Hour": {
@@ -16216,7 +16216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16239,7 +16239,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -16359,7 +16359,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16405,7 +16405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16461,7 +16461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16510,7 +16510,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -16585,7 +16585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16617,7 +16617,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -16692,7 +16692,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16727,7 +16727,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -16807,7 +16807,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16851,7 +16851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16869,7 +16869,7 @@
     "schemaDefinitions": {
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -16919,7 +16919,7 @@
       "Polarity": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPolarity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16950,7 +16950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16968,7 +16968,7 @@
     "schemaDefinitions": {
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -17073,7 +17073,7 @@
       "Polarity": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPolarity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17097,7 +17097,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -17170,7 +17170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17246,7 +17246,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -17319,7 +17319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCalendarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17331,7 +17331,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -17399,7 +17399,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -17547,7 +17547,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -17587,7 +17587,7 @@
       },
       "BACnetDay": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
         "const": {
           "days_numbered_1_7": 1,
           "days_numbered_8_14": 2,
@@ -17644,7 +17644,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -17652,12 +17652,12 @@
               "items": {
                 "title": "BACnetCalendarEntry",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                 "properties": {
                   "Date": {
                     "title": "BACnetDate",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -17667,21 +17667,21 @@
                       },
                       "Month": {
                         "title": "BACnetMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "BACnetDayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17691,13 +17691,13 @@
                   "DateRange": {
                     "title": "BACnetDateRange",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                     "required": [ "StartDate", "EndTime" ],
                     "properties": {
                       "StartDate": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -17707,21 +17707,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -17731,7 +17731,7 @@
                       "EndTime": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -17741,21 +17741,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -17767,13 +17767,13 @@
                   "WeekNDay": {
                     "title": "BACnetWeekNDay",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                     "required": [ "Month", "Day", "DayOfWeek" ],
                     "properties": {
                       "Month": {
                         "title": "BACnetMonth",
                         "description": "January = 1, 0xFF = Any Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17781,7 +17781,7 @@
                       "Day": {
                         "title": "BACnetDay",
                         "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17789,7 +17789,7 @@
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
                         "description": "1 = Monday, 0xFF = Any day of week",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17803,7 +17803,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=106294",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -17826,7 +17826,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6084",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -17834,12 +17834,12 @@
               "items": {
                 "title": "BACnetCalendarEntry",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                 "properties": {
                   "Date": {
                     "title": "BACnetDate",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -17849,21 +17849,21 @@
                       },
                       "Month": {
                         "title": "BACnetMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "BACnetDayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17873,13 +17873,13 @@
                   "DateRange": {
                     "title": "BACnetDateRange",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                     "required": [ "StartDate", "EndTime" ],
                     "properties": {
                       "StartDate": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -17889,21 +17889,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -17913,7 +17913,7 @@
                       "EndTime": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -17923,21 +17923,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -17949,13 +17949,13 @@
                   "WeekNDay": {
                     "title": "BACnetWeekNDay",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                     "required": [ "Month", "Day", "DayOfWeek" ],
                     "properties": {
                       "Month": {
                         "title": "BACnetMonth",
                         "description": "January = 1, 0xFF = Any Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17963,7 +17963,7 @@
                       "Day": {
                         "title": "BACnetDay",
                         "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17971,7 +17971,7 @@
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
                         "description": "1 = Monday, 0xFF = Any day of week",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17985,7 +17985,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=106295",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -18011,12 +18011,12 @@
         "items": {
           "title": "BACnetCalendarEntry",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
           "properties": {
             "Date": {
               "title": "BACnetDate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
               "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
               "properties": {
                 "Year": {
@@ -18026,21 +18026,21 @@
                 },
                 "Month": {
                   "title": "BACnetMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfMonth": {
                   "title": "BACnetDayOfMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfWeek": {
                   "title": "BACnetDayOfWeek",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -18050,13 +18050,13 @@
             "DateRange": {
               "title": "BACnetDateRange",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
               "required": [ "StartDate", "EndTime" ],
               "properties": {
                 "StartDate": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -18066,21 +18066,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -18090,7 +18090,7 @@
                 "EndTime": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -18100,21 +18100,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -18126,13 +18126,13 @@
             "WeekNDay": {
               "title": "BACnetWeekNDay",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
               "required": [ "Month", "Day", "DayOfWeek" ],
               "properties": {
                 "Month": {
                   "title": "BACnetMonth",
                   "description": "January = 1, 0xFF = Any Month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -18140,7 +18140,7 @@
                 "Day": {
                   "title": "BACnetDay",
                   "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -18148,7 +18148,7 @@
                 "DayOfWeek": {
                   "title": "BACnetDayOfWeek",
                   "description": "1 = Monday, 0xFF = Any day of week",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -18214,7 +18214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventEnrollmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101006",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnrollmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18238,7 +18238,7 @@
     "schemaDefinitions": {
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -18270,7 +18270,7 @@
       },
       "BACnetEventType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103054",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventType",
         "const": {
           "change_of_bitstring": 0,
           "change_of_state": 1,
@@ -18342,7 +18342,7 @@
       },
       "BACnetFaultType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultType",
         "const": {
           "none": 0,
           "fault_characterstring": 1,
@@ -18374,7 +18374,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -19930,7 +19930,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -19954,7 +19954,7 @@
       },
       "BACnetBinaryPV": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
         "const": {
           "Inactive": 0,
           "Active": 1
@@ -19970,7 +19970,7 @@
       },
       "BACnetEventEnumType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
         "const": {
           "ChangeOfBitstring": 0,
           "ChangeOfState": 1,
@@ -20018,7 +20018,7 @@
       },
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -20034,7 +20034,7 @@
       },
       "BACnetProgramRequest": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
         "const": {
           "Ready": 0,
           "Load": 1,
@@ -20066,7 +20066,7 @@
       },
       "BACnetProgramStates": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
         "const": {
           "Idle": 0,
           "Loading": 1,
@@ -20098,7 +20098,7 @@
       },
       "BACnetProgramError": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
         "const": {
           "Normal": 0,
           "LoadFailed": 1,
@@ -20126,7 +20126,7 @@
       },
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -20209,7 +20209,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -20241,7 +20241,7 @@
       },
       "BACnetLifeSafetyMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
         "const": {
           "Off": 0,
           "On": 1,
@@ -20309,7 +20309,7 @@
       },
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -20413,7 +20413,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -20481,7 +20481,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -20629,7 +20629,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -20669,7 +20669,7 @@
       },
       "BACnetLifeSafetyOperation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3044",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyOperation",
         "const": {
           "None": 0,
           "Silence": 1,
@@ -20733,18 +20733,18 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventParameters" ],
           "properties": {
             "EventParameters": {
               "title": "BACnetEventParameter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3050",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameter",
               "properties": {
                 "Change-of-bitstring": {
                   "title": "BACnetEventParameterChangeOfBitstring",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103005",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfBitstring",
                   "required": [ "Time-delay", "Bitmask", "List-of-bitstring-values" ],
                   "properties": {
                     "Time-delay": {
@@ -20755,7 +20755,7 @@
                     "Bitmask": {
                       "title": "OptionSet",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                      "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                       "required": [ "Value", "ValidBits" ],
                       "properties": {
                         "Value": {
@@ -20773,7 +20773,7 @@
                       "items": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -20792,7 +20792,7 @@
                 "Change-of-state": {
                   "title": "BACnetEventParameterChangeOfState",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103009",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfState",
                   "required": [ "Time-delay", "List-of-values" ],
                   "properties": {
                     "Time-delay": {
@@ -20805,7 +20805,7 @@
                       "items": {
                         "title": "BACnetPropertyStates",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3028",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyStates",
                         "required": [ "BooleanValue", "BinaryValue", "EventType", "Polarity", "ProgramChange", "ProgramState", "ProgramError", "Reliability", "State", "SystemStatus", "Units", "UnsignedValue", "LifeSafetyMode", "LifeSafetyState" ],
                         "properties": {
                           "BooleanValue": {
@@ -20813,63 +20813,63 @@
                           },
                           "BinaryValue": {
                             "title": "BACnetBinaryPV",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "EventType": {
                             "title": "BACnetEventEnumType",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "Polarity": {
                             "title": "BACnetPolarity",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramChange": {
                             "title": "BACnetProgramRequest",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramState": {
                             "title": "BACnetProgramStates",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramError": {
                             "title": "BACnetProgramError",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "Reliability": {
                             "title": "BACnetReliability",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "State": {
                             "title": "BACnetEventState",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "SystemStatus": {
                             "title": "BACnetDeviceStatus",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -20877,7 +20877,7 @@
                           "Units": {
                             "title": "EUInformation",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -20903,14 +20903,14 @@
                           },
                           "LifeSafetyMode": {
                             "title": "BACnetLifeSafetyMode",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "LifeSafetyState": {
                             "title": "BACnetLifeSafetyState",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -20923,7 +20923,7 @@
                 "Change-of-value": {
                   "title": "BACnetEventParameterChangeOfValue",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103037",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfValue",
                   "required": [ "Time-delay", "Cov-criteria-bitmask", "Cov-criteria-referenced-property-increment" ],
                   "properties": {
                     "Time-delay": {
@@ -20934,7 +20934,7 @@
                     "Cov-criteria-bitmask": {
                       "title": "OptionSet",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                      "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                       "required": [ "Value", "ValidBits" ],
                       "properties": {
                         "Value": {
@@ -20957,7 +20957,7 @@
                 "Command-failure": {
                   "title": "BACnetEventParameterCommandFailure",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103039",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterCommandFailure",
                   "required": [ "Time-delay", "Feedback-property-reference" ],
                   "properties": {
                     "Time-delay": {
@@ -20968,7 +20968,7 @@
                     "Feedback-property-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -20978,7 +20978,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -21000,7 +21000,7 @@
                 "Floating-limit": {
                   "title": "BACnetEventParameterFloatingLimit",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103040",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterFloatingLimit",
                   "required": [ "Time-delay", "Setpoint-reference", "Low-diff-limit", "High-diff-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -21011,7 +21011,7 @@
                     "Setpoint-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -21021,7 +21021,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -21058,7 +21058,7 @@
                 "Out-of-range": {
                   "title": "BACnetEventParameterOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103041",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -21086,7 +21086,7 @@
                 "Extended": {
                   "title": "BACnetEventFaultParameterExtended",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103031",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventFaultParameterExtended",
                   "required": [ "VendorId", "Extended-fault-type", "Parameters" ],
                   "properties": {
                     "VendorId": {
@@ -21103,7 +21103,7 @@
                       "items": {
                         "title": "BACnetEventParameterExtendedParameters",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3068",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterExtendedParameters",
                         "properties": {
                           "Real": {
                             "type": "number",
@@ -21137,7 +21137,7 @@
                           "BitString": {
                             "title": "OptionSet",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                            "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                             "required": [ "Value", "ValidBits" ],
                             "properties": {
                               "Value": {
@@ -21158,7 +21158,7 @@
                           "Date": {
                             "title": "BACnetDate",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -21168,21 +21168,21 @@
                               },
                               "Month": {
                                 "title": "BACnetMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "BACnetDayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "BACnetDayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21192,7 +21192,7 @@
                           "Time": {
                             "title": "BACnetTime",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                             "properties": {
                               "Hour": {
@@ -21225,7 +21225,7 @@
                           "Reference": {
                             "title": "BACnetDeviceObjectPropertyReference",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                             "required": [ "ObjectIdentifier" ],
                             "properties": {
                               "ObjectIdentifier": {
@@ -21235,7 +21235,7 @@
                               },
                               "PropertyIdentifier": {
                                 "title": "BACnetPropertyIdentifier",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21265,7 +21265,7 @@
                 "Buffer-ready": {
                   "title": "BACnetEventParameterBufferReady",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103042",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterBufferReady",
                   "required": [ "Notification-threshold", "Previous-notification-count" ],
                   "properties": {
                     "Notification-threshold": {
@@ -21283,7 +21283,7 @@
                 "Unsigned-range": {
                   "title": "BACnetEventParameterUnsignedRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3067",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterUnsignedRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit" ],
                   "properties": {
                     "Time-delay": {
@@ -21306,7 +21306,7 @@
                 "Double-out-of-range": {
                   "title": "BACnetEventParameterDoubleOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3058",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterDoubleOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -21334,7 +21334,7 @@
                 "Signed-out-of-range": {
                   "title": "BACnetEventParameterSignedOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3059",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterSignedOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -21362,7 +21362,7 @@
                 "Unsigned-out-of-range": {
                   "title": "BACnetEventParameterUnsignedOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103043",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterUnsignedOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -21390,7 +21390,7 @@
                 "Change-of-characterstring": {
                   "title": "BACnetEventParameterChangeOfCharacterString",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3066",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfCharacterString",
                   "required": [ "Time-delay", "AlarmValues" ],
                   "properties": {
                     "Time-delay": {
@@ -21409,26 +21409,26 @@
                 "Change-of-life-safety": {
                   "title": "BACnetEventParameterChangeOfLifeSafety",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfLifeSafety",
                   "required": [ "NewState", "NewMode", "OperationExtended" ],
                   "properties": {
                     "NewState": {
                       "title": "BACnetLifeSafetyState",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "NewMode": {
                       "title": "BACnetLifeSafetyMode",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "OperationExtended": {
                       "title": "BACnetLifeSafetyOperation",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3044",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyOperation",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -21451,18 +21451,18 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6332",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FaultParameters" ],
           "properties": {
             "FaultParameters": {
               "title": "BACnetFaultParameter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3051",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameter",
               "properties": {
                 "Fault-characterstring": {
                   "title": "BACnetFaultParameterFaultCharacterstring",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103030",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultCharacterstring",
                   "required": [ "Fault-characterstring" ],
                   "properties": {
                     "Fault-characterstring": {
@@ -21473,14 +21473,14 @@
                 "Fault-life-safety": {
                   "title": "BACnetFaultParameterFaultLifeSafety",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103032",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultLifeSafety",
                   "required": [ "List-of-fault-values", "Mode-property-reference" ],
                   "properties": {
                     "List-of-fault-values": {
                       "type": "array",
                       "items": {
                         "title": "BACnetLifeSafetyState",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -21489,7 +21489,7 @@
                     "Mode-property-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -21499,7 +21499,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -21521,14 +21521,14 @@
                 "Fault-state": {
                   "title": "BACnetFaultParameterFaultState",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103033",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultState",
                   "required": [ "List-of-fault-values" ],
                   "properties": {
                     "List-of-fault-values": {
                       "type": "array",
                       "items": {
                         "title": "BACnetProgramStates",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -21539,7 +21539,7 @@
                 "Fault-status-flags": {
                   "title": "BACnetFaultParameterFaultStatusFlags",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103034",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultStatusFlags",
                   "required": [ "Status-flags-reference" ],
                   "properties": {
                     "Status-flags-reference": {
@@ -21547,7 +21547,7 @@
                       "items": {
                         "title": "BACnetDeviceObjectPropertyReference",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                         "required": [ "ObjectIdentifier" ],
                         "properties": {
                           "ObjectIdentifier": {
@@ -21557,7 +21557,7 @@
                           },
                           "PropertyIdentifier": {
                             "title": "BACnetPropertyIdentifier",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -21580,7 +21580,7 @@
                 "Fault-extended": {
                   "title": "BACnetEventFaultParameterExtended",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103031",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventFaultParameterExtended",
                   "required": [ "VendorId", "Extended-fault-type", "Parameters" ],
                   "properties": {
                     "VendorId": {
@@ -21597,7 +21597,7 @@
                       "items": {
                         "title": "BACnetEventParameterExtendedParameters",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3068",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterExtendedParameters",
                         "properties": {
                           "Real": {
                             "type": "number",
@@ -21631,7 +21631,7 @@
                           "BitString": {
                             "title": "OptionSet",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                            "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                             "required": [ "Value", "ValidBits" ],
                             "properties": {
                               "Value": {
@@ -21652,7 +21652,7 @@
                           "Date": {
                             "title": "BACnetDate",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -21662,21 +21662,21 @@
                               },
                               "Month": {
                                 "title": "BACnetMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "BACnetDayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "BACnetDayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21686,7 +21686,7 @@
                           "Time": {
                             "title": "BACnetTime",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                             "properties": {
                               "Hour": {
@@ -21719,7 +21719,7 @@
                           "Reference": {
                             "title": "BACnetDeviceObjectPropertyReference",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                             "required": [ "ObjectIdentifier" ],
                             "properties": {
                               "ObjectIdentifier": {
@@ -21729,7 +21729,7 @@
                               },
                               "PropertyIdentifier": {
                                 "title": "BACnetPropertyIdentifier",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21773,7 +21773,7 @@
       "Event_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21794,7 +21794,7 @@
       "Event_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103054",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21815,7 +21815,7 @@
       "Fault_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetFaultType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21837,7 +21837,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -21847,7 +21847,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -21880,7 +21880,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21911,7 +21911,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101014",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21934,7 +21934,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -22002,7 +22002,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -22150,7 +22150,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -22190,7 +22190,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -22301,13 +22301,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -22317,21 +22317,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -22341,7 +22341,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -22384,7 +22384,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22406,13 +22406,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -22422,21 +22422,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -22446,7 +22446,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -22525,7 +22525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101018",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22552,7 +22552,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogBaseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101026",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogBaseType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22563,7 +22563,7 @@
     "schemaDefinitions": {
       "BACnetLoggingType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103048",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoggingType",
         "const": {
           "Polled": 0,
           "COV": 1,
@@ -22653,7 +22653,7 @@
       "Logging_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLoggingType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103048",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoggingType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22701,7 +22701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogMultipleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101027",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogMultipleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22713,7 +22713,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -24315,7 +24315,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -24325,7 +24325,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -24386,7 +24386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101017",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24398,7 +24398,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -25977,7 +25977,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetClientCOV",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetClientCOV",
         "properties": {
           "Real-increment": {
             "type": "number",
@@ -26034,7 +26034,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -26044,7 +26044,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -26101,7 +26101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetClockAlignedTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101015",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetClockAlignedTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26188,7 +26188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLoopType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101001",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoopType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26212,7 +26212,7 @@
     "schemaDefinitions": {
       "BACnetAction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAction",
         "const": {
           "direct": 0,
           "reverse": 1
@@ -26228,7 +26228,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -27784,7 +27784,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -27830,7 +27830,7 @@
       "Action": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetAction",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -27871,7 +27871,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -27881,7 +27881,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -27991,7 +27991,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -28001,7 +28001,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -28128,7 +28128,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -28138,7 +28138,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -28171,7 +28171,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28307,7 +28307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28330,7 +28330,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -28411,7 +28411,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28456,7 +28456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28524,7 +28524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28597,7 +28597,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -28671,7 +28671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28715,7 +28715,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -28789,7 +28789,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28800,7 +28800,7 @@
     "schemaDefinitions": {
       "BACnetDaysOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3060",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDaysOfWeek",
         "const": {
           "monday": 0,
           "tuesday": 1,
@@ -28836,7 +28836,7 @@
       },
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -28874,13 +28874,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDestination",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103020",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDestination",
         "required": [ "ValidDays", "FromTime", "ToTime", "Recipient", "ProcessIdentifier", "IssueConfirmedNotifications", "Transitions" ],
         "properties": {
           "ValidDays": {
             "title": "BACnetDaysOfWeek",
             "description": "BACnetDaysOfWeek BitField",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3060",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDaysOfWeek",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -28888,7 +28888,7 @@
           "FromTime": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -28916,7 +28916,7 @@
           "ToTime": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -28944,7 +28944,7 @@
           "Recipient": {
             "title": "BACnetRecipient",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
             "properties": {
               "Device": {
                 "type": "integer",
@@ -28954,7 +28954,7 @@
               "Address": {
                 "title": "BACnetAddress",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                 "required": [ "NetworkNumber", "MacAddress" ],
                 "properties": {
                   "NetworkNumber": {
@@ -28983,7 +28983,7 @@
           "Transitions": {
             "title": "BACnetEventTransitionBits",
             "description": "BACnetEventTransitionsBits BitField",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -29016,7 +29016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotificationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotificationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -29028,7 +29028,7 @@
     "schemaDefinitions": {
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -29065,7 +29065,7 @@
       "Ack_Required": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -29137,7 +29137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetObjectTypeUnknown",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101024",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeUnknown",
     "dov:isComposite": true,
     "links": [
       {
@@ -29149,7 +29149,7 @@
     "schemaDefinitions": {
       "BACnetObjectTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
         "const": {
           "analog_input": 0,
           "analog_output": 1,
@@ -29399,7 +29399,7 @@
       "Object_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetObjectTypeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -29423,7 +29423,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "data": {
           "title": "BACnetObjectTypeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -29447,7 +29447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetScheduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetScheduleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -29471,7 +29471,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -29539,7 +29539,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -29687,7 +29687,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -29727,7 +29727,7 @@
       },
       "BACnetDay": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
         "const": {
           "days_numbered_1_7": 1,
           "days_numbered_8_14": 2,
@@ -29763,7 +29763,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -31319,7 +31319,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -31364,7 +31364,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObjectPropertyReferences" ],
           "properties": {
             "DeviceObjectPropertyReferences": {
@@ -31372,7 +31372,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -31382,7 +31382,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -31404,7 +31404,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6324",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -31426,7 +31426,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObjectPropertyReferences" ],
           "properties": {
             "DeviceObjectPropertyReferences": {
@@ -31434,7 +31434,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -31444,7 +31444,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -31466,7 +31466,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6326",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -31490,13 +31490,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateRange",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
         "required": [ "StartDate", "EndTime" ],
         "properties": {
           "StartDate": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -31506,21 +31506,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -31530,7 +31530,7 @@
           "EndTime": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -31540,21 +31540,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -31582,23 +31582,23 @@
         "items": {
           "title": "BACnetSpecialEvent",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103003",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSpecialEvent",
           "required": [ "Period", "ListOfTimeValues", "EventPriority" ],
           "properties": {
             "Period": {
               "title": "BACnetSpecialEventPeriod",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3055",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSpecialEventPeriod",
               "properties": {
                 "CalendarEntry": {
                   "title": "BACnetCalendarEntry",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                   "properties": {
                     "Date": {
                       "title": "BACnetDate",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                       "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                       "properties": {
                         "Year": {
@@ -31608,21 +31608,21 @@
                         },
                         "Month": {
                           "title": "BACnetMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfMonth": {
                           "title": "BACnetDayOfMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfWeek": {
                           "title": "BACnetDayOfWeek",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31632,13 +31632,13 @@
                     "DateRange": {
                       "title": "BACnetDateRange",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                       "required": [ "StartDate", "EndTime" ],
                       "properties": {
                         "StartDate": {
                           "title": "BACnetDate",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -31648,21 +31648,21 @@
                             },
                             "Month": {
                               "title": "BACnetMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "BACnetDayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "BACnetDayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -31672,7 +31672,7 @@
                         "EndTime": {
                           "title": "BACnetDate",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -31682,21 +31682,21 @@
                             },
                             "Month": {
                               "title": "BACnetMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "BACnetDayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "BACnetDayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -31708,13 +31708,13 @@
                     "WeekNDay": {
                       "title": "BACnetWeekNDay",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                       "required": [ "Month", "Day", "DayOfWeek" ],
                       "properties": {
                         "Month": {
                           "title": "BACnetMonth",
                           "description": "January = 1, 0xFF = Any Month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31722,7 +31722,7 @@
                         "Day": {
                           "title": "BACnetDay",
                           "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31730,7 +31730,7 @@
                         "DayOfWeek": {
                           "title": "BACnetDayOfWeek",
                           "description": "1 = Monday, 0xFF = Any day of week",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31751,13 +31751,13 @@
               "items": {
                 "title": "BACnetTimeValue",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103004",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValue",
                 "required": [ "Time", "Value" ],
                 "properties": {
                   "Time": {
                     "title": "BACnetTime",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                     "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                     "properties": {
                       "Hour": {
@@ -31785,7 +31785,7 @@
                   "Value": {
                     "title": "BACnetTimeValueValue",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103010",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValueValue",
                     "required": [ "BooleanValue", "UnsignedValue", "SignedValue", "OctedStringValue", "CharStringValue", "ObjectIdentifierValue", "EnumerationValue", "BitStringValue" ],
                     "properties": {
                       "BooleanValue": {
@@ -31818,7 +31818,7 @@
                       "BitStringValue": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -31863,7 +31863,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -31873,7 +31873,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -31979,7 +31979,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32003,7 +32003,7 @@
         "items": {
           "title": "BACnetDailySchedule",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103001",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDailySchedule",
           "required": [ "Day-schedule" ],
           "properties": {
             "Day-schedule": {
@@ -32011,13 +32011,13 @@
               "items": {
                 "title": "BACnetTimeValue",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103004",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValue",
                 "required": [ "Time", "Value" ],
                 "properties": {
                   "Time": {
                     "title": "BACnetTime",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                     "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                     "properties": {
                       "Hour": {
@@ -32045,7 +32045,7 @@
                   "Value": {
                     "title": "BACnetTimeValueValue",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103010",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValueValue",
                     "required": [ "BooleanValue", "UnsignedValue", "SignedValue", "OctedStringValue", "CharStringValue", "ObjectIdentifierValue", "EnumerationValue", "BitStringValue" ],
                     "properties": {
                       "BooleanValue": {
@@ -32078,7 +32078,7 @@
                       "BitStringValue": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -32153,7 +32153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetStructuredViewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStructuredViewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -32176,7 +32176,7 @@
     "schemaDefinitions": {
       "BACnetNodeType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3045",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNodeType",
         "const": {
           "UNKNOWN": 0,
           "SYSTEM": 1,
@@ -32232,7 +32232,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -33822,7 +33822,7 @@
       "Node_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNodeType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3045",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNodeType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33866,7 +33866,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -33876,7 +33876,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33920,7 +33920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAutomaticTimeSynchronizationMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAutomaticTimeSynchronizationMasterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33948,7 +33948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6353",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddToUtcList", "TimeSynchronizationRecipients" ],
           "properties": {
             "AddToUtcList": {
@@ -33959,7 +33959,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -33969,7 +33969,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -33992,7 +33992,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6354",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -34014,7 +34014,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6355",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RemoveFromUtcList", "TimeSynchronizationRecipients" ],
           "properties": {
             "RemoveFromUtcList": {
@@ -34025,7 +34025,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -34035,7 +34035,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -34058,7 +34058,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6356",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -34137,7 +34137,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -34147,7 +34147,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -34185,7 +34185,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -34195,7 +34195,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -34240,7 +34240,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34252,7 +34252,7 @@
     "schemaDefinitions": {
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -34284,7 +34284,7 @@
       },
       "BACnetNotifyType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "const": {
           "Alarm": 0,
           "Event": 1,
@@ -34321,7 +34321,7 @@
       "From_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34361,7 +34361,7 @@
       "Notify_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNotifyType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34382,7 +34382,7 @@
       "To_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34413,7 +34413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34473,7 +34473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBufferReadyNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBufferReadyNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34485,7 +34485,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -36059,7 +36059,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -36069,7 +36069,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -36150,7 +36150,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfBitStringNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfBitStringNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36162,7 +36162,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36223,7 +36223,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36254,7 +36254,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfCharacterStringNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfCharacterStringNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36266,7 +36266,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36341,7 +36341,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36372,7 +36372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfRealValueNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfRealValueNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36384,7 +36384,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36444,7 +36444,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36475,7 +36475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36487,7 +36487,7 @@
     "schemaDefinitions": {
       "BACnetBinaryPV": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
         "const": {
           "Inactive": 0,
           "Active": 1
@@ -36503,7 +36503,7 @@
       },
       "BACnetEventEnumType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
         "const": {
           "ChangeOfBitstring": 0,
           "ChangeOfState": 1,
@@ -36551,7 +36551,7 @@
       },
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -36567,7 +36567,7 @@
       },
       "BACnetProgramRequest": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
         "const": {
           "Ready": 0,
           "Load": 1,
@@ -36599,7 +36599,7 @@
       },
       "BACnetProgramStates": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
         "const": {
           "Idle": 0,
           "Loading": 1,
@@ -36631,7 +36631,7 @@
       },
       "BACnetProgramError": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
         "const": {
           "Normal": 0,
           "LoadFailed": 1,
@@ -36659,7 +36659,7 @@
       },
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -36742,7 +36742,7 @@
       },
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -36774,7 +36774,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -36806,7 +36806,7 @@
       },
       "BACnetLifeSafetyMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
         "const": {
           "Off": 0,
           "On": 1,
@@ -36874,7 +36874,7 @@
       },
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -36978,7 +36978,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37020,7 +37020,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPropertyStates",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyStates",
         "required": [ "BooleanValue", "BinaryValue", "EventType", "Polarity", "ProgramChange", "ProgramState", "ProgramError", "Reliability", "State", "SystemStatus", "Units", "UnsignedValue", "LifeSafetyMode", "LifeSafetyState" ],
         "properties": {
           "BooleanValue": {
@@ -37028,63 +37028,63 @@
           },
           "BinaryValue": {
             "title": "BACnetBinaryPV",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "EventType": {
             "title": "BACnetEventEnumType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "Polarity": {
             "title": "BACnetPolarity",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramChange": {
             "title": "BACnetProgramRequest",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramState": {
             "title": "BACnetProgramStates",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramError": {
             "title": "BACnetProgramError",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "Reliability": {
             "title": "BACnetReliability",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "State": {
             "title": "BACnetEventState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "SystemStatus": {
             "title": "BACnetDeviceStatus",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -37092,7 +37092,7 @@
           "Units": {
             "title": "EUInformation",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -37118,14 +37118,14 @@
           },
           "LifeSafetyMode": {
             "title": "BACnetLifeSafetyMode",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "LifeSafetyState": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -37148,7 +37148,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37179,7 +37179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfValueNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfValueNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37191,7 +37191,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37233,7 +37233,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -37262,7 +37262,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37293,7 +37293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCommandFailureNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCommandFailureNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37305,7 +37305,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37382,7 +37382,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37413,7 +37413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDoubleOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDoubleOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37425,7 +37425,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37523,7 +37523,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37554,7 +37554,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFloatingLimitNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFloatingLimitNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37566,7 +37566,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37664,7 +37664,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37695,7 +37695,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37707,7 +37707,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37805,7 +37805,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37836,7 +37836,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSignedOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSignedOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37848,7 +37848,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37940,7 +37940,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37971,7 +37971,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37983,7 +37983,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38078,7 +38078,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38109,7 +38109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38121,7 +38121,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38198,7 +38198,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38229,7 +38229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38241,7 +38241,7 @@
     "schemaDefinitions": {
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -38324,7 +38324,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38365,7 +38365,7 @@
       "Reliability": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetReliability",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38386,7 +38386,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38417,7 +38417,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfReliabilityNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfReliabilityNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38477,7 +38477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventEnrollmentNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnrollmentNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38504,7 +38504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFeedbackNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFeedbackNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38531,7 +38531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLoopNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoopNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38558,7 +38558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSimpleNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSimpleNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38585,7 +38585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -38606,7 +38606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38645,7 +38645,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -38676,7 +38676,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -38704,7 +38704,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -38732,7 +38732,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -38769,7 +38769,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -38797,7 +38797,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -39122,7 +39122,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -39149,7 +39149,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -39174,7 +39174,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -39280,7 +39280,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -39307,7 +39307,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -39332,7 +39332,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -39354,7 +39354,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -39613,7 +39613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -39709,7 +39709,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -39813,7 +39813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -39897,7 +39897,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -39916,7 +39916,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -39936,7 +39936,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -39968,7 +39968,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -40011,7 +40011,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40153,7 +40153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -40238,7 +40238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40284,7 +40284,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40330,7 +40330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40356,7 +40356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/CAS.TM.json
+++ b/wot-codegen/opc-output-integrated/CAS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AnalysisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AnalysisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -51,7 +51,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASType",
     "dov:isComposite": true,
     "links": [
       {
@@ -102,7 +102,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -163,7 +163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -231,7 +231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FluidQuantitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FluidQuantitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -639,7 +639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ParticleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ParticleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -770,7 +770,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetComponentsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -874,7 +874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -989,7 +989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1015,7 +1015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ElectricalCircuitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ElectricalCircuitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ElectricalQuantitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ElectricalQuantitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1283,7 +1283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1355,7 +1355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1366,7 +1366,7 @@
     "schemaDefinitions": {
       "AirnetHealthStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
         "const": {
           "OK": 0,
           "Warning": 1,
@@ -1394,7 +1394,7 @@
       },
       "AirnetIntegratedStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
         "const": {
           "FullyIntegrated": 0,
           "PartiallyIntegrated": 1,
@@ -1417,7 +1417,7 @@
       },
       "AirnetOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -1543,7 +1543,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetHealthStateEnum",
         "description": "Actual health state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1560,7 +1560,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetIntegratedStateEnum",
         "description": "Actual integrated state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1577,7 +1577,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetOperatingStateEnum",
         "description": "Actual operating state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1737,7 +1737,7 @@
         "data": {
           "title": "AirnetHealthStateEnum",
           "description": "Actual health state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1755,7 +1755,7 @@
         "data": {
           "title": "AirnetIntegratedStateEnum",
           "description": "Actual integrated state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1773,7 +1773,7 @@
         "data": {
           "title": "AirnetOperatingStateEnum",
           "description": "Actual operating state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1861,7 +1861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_OperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.OperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2007,7 +2007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FluidCircuitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FluidCircuitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2042,7 +2042,7 @@
     "schemaDefinitions": {
       "FluidTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
         "const": {
           "Air": 0,
           "Condensate": 1,
@@ -2089,7 +2089,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "FluidTypeEnum",
         "description": "Enumeration of possible fluid types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2109,7 +2109,7 @@
         "data": {
           "title": "FluidTypeEnum",
           "description": "Enumeration of possible fluid types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2133,7 +2133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ComponentsGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ComponentsGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2237,7 +2237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MCSType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MCSType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2305,7 +2305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AnalysesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AnalysesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2349,7 +2349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MCSConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MCSConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2409,7 +2409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CommunicationSettingsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CommunicationSettingsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2420,7 +2420,7 @@
     "schemaDefinitions": {
       "IpVersionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.IpVersionEnum",
         "const": {
           "IPv4": 0,
           "IPv6": 1
@@ -2534,7 +2534,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "IpVersionEnum",
         "description": "Version of the internet protocol used for the MCS.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.IpVersionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2614,7 +2614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_EventsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.EventsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2670,7 +2670,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_StatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.StatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2870,7 +2870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2966,7 +2966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3031,7 +3031,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3042,7 +3042,7 @@
     "schemaDefinitions": {
       "CompressorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
         "const": {
           "Other": 0,
           "AxialTurboCompressor": 1,
@@ -3116,7 +3116,7 @@
       },
       "DisplacementTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
         "const": {
           "PositiveDisplacement": 0,
           "DynamicDisplacement": 1
@@ -3135,7 +3135,7 @@
       },
       "LubricationTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
         "const": {
           "NoLubrication": 0,
           "OilLubricated": 1,
@@ -3177,7 +3177,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "CompressorTypeEnum",
         "description": "Enumeration of possible compressor types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3194,7 +3194,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DisplacementTypeEnum",
         "description": "Enumeration of possible displacement types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3211,7 +3211,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "LubricationTypeEnum",
         "description": "Enumeration of possible lubrication types for the compression process of a compressor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3259,7 +3259,7 @@
         "data": {
           "title": "CompressorTypeEnum",
           "description": "Enumeration of possible compressor types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3277,7 +3277,7 @@
         "data": {
           "title": "DisplacementTypeEnum",
           "description": "Enumeration of possible displacement types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3295,7 +3295,7 @@
         "data": {
           "title": "LubricationTypeEnum",
           "description": "Enumeration of possible lubrication types for the compression process of a compressor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3349,7 +3349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3360,7 +3360,7 @@
     "schemaDefinitions": {
       "ConverterTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
         "const": {
           "Other": 0,
           "CatalyticHCConverter": 1
@@ -3397,7 +3397,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ConverterTypeEnum",
         "description": "Enumeration of possible converter types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3417,7 +3417,7 @@
         "data": {
           "title": "ConverterTypeEnum",
           "description": "Enumeration of possible converter types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3441,7 +3441,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3452,7 +3452,7 @@
     "schemaDefinitions": {
       "DrainTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
         "const": {
           "Other": 0,
           "CapacitiveDrain": 1,
@@ -3499,7 +3499,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DrainTypeEnum",
         "description": "Enumeration of possible condensate drain types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3519,7 +3519,7 @@
         "data": {
           "title": "DrainTypeEnum",
           "description": "Enumeration of possible condensate drain types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3543,7 +3543,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3554,7 +3554,7 @@
     "schemaDefinitions": {
       "DryerTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
         "const": {
           "Other": 0,
           "AbsorptionDryer": 1,
@@ -3606,7 +3606,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DryerTypeEnum",
         "description": "Enumeration of possible dryer types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3641,7 +3641,7 @@
         "data": {
           "title": "DryerTypeEnum",
           "description": "Enumeration of possible dryer types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3681,7 +3681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FilterDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FilterDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3692,7 +3692,7 @@
     "schemaDefinitions": {
       "FilterTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
         "const": {
           "Other": 0,
           "ActivatedCarbonFilter": 1,
@@ -3736,7 +3736,7 @@
       },
       "FilterClassEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
         "const": {
           "S0": 0,
           "S1": 1,
@@ -3818,7 +3818,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "FilterTypeEnum",
         "description": "Enumeration of possible filter types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3836,13 +3836,13 @@
         "title": "FilterClassDataType",
         "description": "information about the used filter class according to ISO 8573-1 of a filter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
             "title": "FilterClassEnum",
             "description": "Class for particles",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3850,7 +3850,7 @@
           "B": {
             "title": "FilterClassEnum",
             "description": "Class for water and humidity",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3858,7 +3858,7 @@
           "C": {
             "title": "FilterClassEnum",
             "description": "Class for oil",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3880,7 +3880,7 @@
         "data": {
           "title": "FilterTypeEnum",
           "description": "Enumeration of possible filter types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3899,13 +3899,13 @@
           "title": "FilterClassDataType",
           "description": "information about the used filter class according to ISO 8573-1 of a filter",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
               "title": "FilterClassEnum",
               "description": "Class for particles",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3913,7 +3913,7 @@
             "B": {
               "title": "FilterClassEnum",
               "description": "Class for water and humidity",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3921,7 +3921,7 @@
             "C": {
               "title": "FilterClassEnum",
               "description": "Class for oil",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3947,7 +3947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ReceiverDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3958,7 +3958,7 @@
     "schemaDefinitions": {
       "ReceiverTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
         "const": {
           "Other": 0,
           "DryReceiver": 1,
@@ -4000,7 +4000,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ReceiverTypeEnum",
         "description": "Enumeration of possible receiver types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4035,7 +4035,7 @@
         "data": {
           "title": "ReceiverTypeEnum",
           "description": "Enumeration of possible receiver types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4075,7 +4075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SensorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SensorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4086,7 +4086,7 @@
     "schemaDefinitions": {
       "SensorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
         "const": {
           "Other": 0,
           "Ammeter": 1,
@@ -4160,7 +4160,7 @@
       },
       "SensorTechnologyOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
         "const": {
           "CapacitiveSensor": 0,
           "ElectronTube": 1,
@@ -4247,7 +4247,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SensorTypeEnum",
         "description": "Enumeration of possible sensor types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4264,7 +4264,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SensorTechnologyOptionSet",
         "description": "Selection of sensor technologies this sensor uses.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4297,7 +4297,7 @@
         "data": {
           "title": "SensorTypeEnum",
           "description": "Enumeration of possible sensor types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4315,7 +4315,7 @@
         "data": {
           "title": "SensorTechnologyOptionSet",
           "description": "Selection of sensor technologies this sensor uses.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4353,7 +4353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SeparatorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4364,7 +4364,7 @@
     "schemaDefinitions": {
       "SeparatorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
         "const": {
           "Other": 0,
           "CentrifugalOilyWaterSeparator": 1,
@@ -4421,7 +4421,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SeparatorTypeEnum",
         "description": "Enumeration of possible condensate separator types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4441,7 +4441,7 @@
         "data": {
           "title": "SeparatorTypeEnum",
           "description": "Enumeration of possible condensate separator types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4465,7 +4465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4476,7 +4476,7 @@
     "schemaDefinitions": {
       "ValveTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
         "const": {
           "Other": 0,
           "CheckValve": 1,
@@ -4533,7 +4533,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ValveTypeEnum",
         "description": "Enumeration of possible valve types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4568,7 +4568,7 @@
         "data": {
           "title": "ValveTypeEnum",
           "description": "Enumeration of possible valve types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4608,7 +4608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4708,7 +4708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4719,7 +4719,7 @@
     "schemaDefinitions": {
       "CompressorOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -4830,7 +4830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "CompressorOperatingStateEnum",
         "description": "Actual operating state of the compressor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4913,7 +4913,7 @@
         "data": {
           "title": "CompressorOperatingStateEnum",
           "description": "Actual operating state of the compressor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4953,7 +4953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5022,7 +5022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5059,7 +5059,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5070,7 +5070,7 @@
     "schemaDefinitions": {
       "DryerOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -5174,7 +5174,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DryerOperatingStateEnum",
         "description": "Actual operating state of the dryer.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5223,7 +5223,7 @@
         "data": {
           "title": "DryerOperatingStateEnum",
           "description": "Actual operating state of the dryer.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5263,7 +5263,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5363,7 +5363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5463,7 +5463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5579,7 +5579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ChargingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ChargingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5606,7 +5606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5657,7 +5657,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5696,7 +5696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CoolingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5723,7 +5723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5768,7 +5768,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5807,7 +5807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5840,7 +5840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_HeatRecoverySystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.HeatRecoverySystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5867,7 +5867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ReceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5900,7 +5900,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5951,7 +5951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5990,7 +5990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6029,7 +6029,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -6050,7 +6050,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6071,7 +6071,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -6092,7 +6092,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -6104,7 +6104,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -6125,7 +6125,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -6137,7 +6137,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -6158,7 +6158,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -6175,7 +6175,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -6195,7 +6195,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -6221,7 +6221,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -6342,7 +6342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6368,7 +6368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6395,7 +6395,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6420,7 +6420,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -6442,7 +6442,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -6701,7 +6701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6797,7 +6797,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -6901,7 +6901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6946,7 +6946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6973,7 +6973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7012,7 +7012,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -7043,7 +7043,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7071,7 +7071,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7099,7 +7099,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7136,7 +7136,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7164,7 +7164,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7489,7 +7489,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7516,7 +7516,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7541,7 +7541,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7647,7 +7647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7731,7 +7731,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7750,7 +7750,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -7770,7 +7770,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -7802,7 +7802,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7845,7 +7845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7987,7 +7987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8072,7 +8072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8118,7 +8118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8164,7 +8164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8190,7 +8190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineComponentsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8252,7 +8252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryComponentIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8321,7 +8321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8573,7 +8573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8655,7 +8655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8711,7 +8711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8782,7 +8782,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8804,7 +8804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -8826,7 +8826,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -8848,7 +8848,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -8858,7 +8858,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -8880,7 +8880,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/CSPPlusForMachine.TM.json
+++ b/wot-codegen/opc-output-integrated/CSPPlusForMachine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CSPPlusForMachine_CsppMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CSPPlusForMachine/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.CSPPlusForMachine.CsppMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -46,7 +46,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -93,7 +93,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -155,7 +155,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -308,7 +308,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -332,7 +332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -535,7 +535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -591,7 +591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -662,7 +662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -684,7 +684,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -706,7 +706,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -728,7 +728,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -738,7 +738,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -760,7 +760,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -853,7 +853,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -898,7 +898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -924,7 +924,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -969,7 +969,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -990,7 +990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/CommercialKitchenEquipment.TM.json
+++ b/wot-codegen/opc-output-integrated/CommercialKitchenEquipment.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_BatchInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BatchInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -54,7 +54,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -128,7 +128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_KitchenDeviceHAConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.KitchenDeviceHAConfigType",
     "dov:isComposite": true,
     "links": [
       {
@@ -203,7 +203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_KitchenDeviceParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.KitchenDeviceParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -343,7 +343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_ChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -354,7 +354,7 @@
     "schemaDefinitions": {
       "ChamberModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
         "const": {
           "NoSpecialMode": 0,
           "Off": 1,
@@ -610,7 +610,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "ChamberModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1130,7 +1130,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "ChamberModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1308,7 +1308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1319,7 +1319,7 @@
     "schemaDefinitions": {
       "CoffeeMachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -1425,7 +1425,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CoffeeMachineModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1608,7 +1608,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CoffeeMachineModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1696,7 +1696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineRecipeParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineRecipeParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1707,7 +1707,7 @@
     "schemaDefinitions": {
       "BeverageSMLEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
         "const": {
           "Inactive": 0,
           "Small": 1,
@@ -1774,7 +1774,7 @@
       "BeverageSML": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "BeverageSMLEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2044,7 +2044,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "BeverageSMLEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2199,7 +2199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CombiSteamerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2210,7 +2210,7 @@
     "schemaDefinitions": {
       "CombiSteamerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
         "const": {
           "Off": 0,
           "On": 1,
@@ -2262,7 +2262,7 @@
       },
       "SpecialCookingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
         "const": {
           "NoSpecialMode": 0,
           "Baking": 1,
@@ -2399,7 +2399,7 @@
       "CombiSteamerMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CombiSteamerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2564,7 +2564,7 @@
       "SpecialCookingMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SpecialCookingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2830,7 +2830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CombiSteamerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3001,7 +3001,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SpecialCookingModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3060,7 +3060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingKettleParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3071,7 +3071,7 @@
     "schemaDefinitions": {
       "CookingKettleModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -3115,7 +3115,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -3198,7 +3198,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CookingKettleModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3262,7 +3262,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3418,7 +3418,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CookingKettleModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3486,7 +3486,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3528,7 +3528,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingZoneParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingZoneParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3539,7 +3539,7 @@
     "schemaDefinitions": {
       "CurrentStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -3638,7 +3638,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CurrentStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3839,7 +3839,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CurrentStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3928,7 +3928,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_DishWashingMachineProgramParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.DishWashingMachineProgramParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3939,7 +3939,7 @@
     "schemaDefinitions": {
       "HygieneModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
         "const": {
           "HygieneOperationOFF": 0,
           "HygieneA0": 1,
@@ -3971,7 +3971,7 @@
       },
       "OperationModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
         "const": {
           "Init": 0,
           "MachineOff": 1,
@@ -4043,7 +4043,7 @@
       },
       "ProgramModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
         "const": {
           "OperationOFF": 0,
           "PreWash": 1,
@@ -4277,7 +4277,7 @@
       "HygieneMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "HygieneModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4338,7 +4338,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "OperationModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4411,7 +4411,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "ProgramModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4737,7 +4737,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "HygieneModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4802,7 +4802,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "OperationModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4852,7 +4852,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "ProgramModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4910,7 +4910,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4921,7 +4921,7 @@
     "schemaDefinitions": {
       "FryerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -4957,7 +4957,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -5022,7 +5022,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "FryerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5070,7 +5070,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5183,7 +5183,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "FryerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5234,7 +5234,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5276,7 +5276,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingAndGrillingParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingAndGrillingParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5287,7 +5287,7 @@
     "schemaDefinitions": {
       "GrillingZoneStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -5311,7 +5311,7 @@
       },
       "PlatenPositionStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
         "const": {
           "Home": 0,
           "Cooking": 1,
@@ -5386,7 +5386,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "GrillingZoneStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5426,7 +5426,7 @@
       "PlatenPositionState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PlatenPositionStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5619,7 +5619,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "GrillingZoneStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5662,7 +5662,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PlatenPositionStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5757,7 +5757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingPanParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5768,7 +5768,7 @@
     "schemaDefinitions": {
       "FryingPanModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -5816,7 +5816,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -5927,7 +5927,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "FryingPanModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5991,7 +5991,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6189,7 +6189,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "FryingPanModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6257,7 +6257,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6299,7 +6299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_IceMachineParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.IceMachineParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6310,7 +6310,7 @@
     "schemaDefinitions": {
       "StatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
         "const": {
           "INIT": 0,
           "WATER_PURGE": 1,
@@ -6443,7 +6443,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "StatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6577,7 +6577,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "StatusEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6637,7 +6637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MicrowaveCombiOvenParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MicrowaveCombiOvenParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6648,7 +6648,7 @@
     "schemaDefinitions": {
       "OperatingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
         "const": {
           "Preheat": 0,
           "CoolDown": 1,
@@ -6793,7 +6793,7 @@
       "OperatingMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "OperatingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7039,7 +7039,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "OperatingModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7132,7 +7132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MultiFunctionPanParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7143,7 +7143,7 @@
     "schemaDefinitions": {
       "MultiFunctionPanModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
         "const": {
           "Off": 0,
           "On": 1,
@@ -7215,7 +7215,7 @@
       },
       "SpecialFunctionModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
         "const": {
           "LidUpDown": 0,
           "PanTilt": 1,
@@ -7421,7 +7421,7 @@
       "MultiFunctionPanMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "MultiFunctionPanModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7518,7 +7518,7 @@
       "SpecialFunctionMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SpecialFunctionModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7878,7 +7878,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "MultiFunctionPanModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7981,7 +7981,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SpecialFunctionModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8040,7 +8040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PastaCookerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8051,7 +8051,7 @@
     "schemaDefinitions": {
       "PastaCookerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -8091,7 +8091,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -8158,7 +8158,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PastaCookerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8206,7 +8206,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8321,7 +8321,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PastaCookerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8372,7 +8372,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8414,7 +8414,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PressureCookingKettleParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8425,7 +8425,7 @@
     "schemaDefinitions": {
       "PressureCookingKettleModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -8469,7 +8469,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -8620,7 +8620,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PressureCookingKettleModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8684,7 +8684,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8937,7 +8937,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PressureCookingKettleModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9005,7 +9005,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9047,7 +9047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_TrayType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9058,7 +9058,7 @@
     "schemaDefinitions": {
       "TrayModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
         "const": {
           "Off": 0,
           "PreHeat": 1,
@@ -9090,7 +9090,7 @@
       },
       "TrayTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
         "const": {
           "Generic": 0,
           "HeaterPlate": 1,
@@ -9225,7 +9225,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TrayModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9267,7 +9267,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TrayTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9385,7 +9385,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "TrayModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9419,7 +9419,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "TrayTypeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9443,7 +9443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CommercialKitchenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CommercialKitchenDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9525,7 +9525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9564,7 +9564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CombiSteamerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9582,7 +9582,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9614,7 +9614,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9688,7 +9688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingKettleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9706,7 +9706,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9738,7 +9738,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9789,7 +9789,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingZoneDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingZoneDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9807,7 +9807,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9844,7 +9844,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9941,7 +9941,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_DishWashingMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.DishWashingMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9974,7 +9974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9992,7 +9992,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10024,7 +10024,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10062,7 +10062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingAndGrillingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingAndGrillingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10080,7 +10080,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10112,7 +10112,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10138,7 +10138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingPanDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10156,7 +10156,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10188,7 +10188,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10226,7 +10226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_IceMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.IceMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10259,7 +10259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MicrowaveCombiOvenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MicrowaveCombiOvenDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10292,7 +10292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MultiFunctionPanDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10310,7 +10310,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10342,7 +10342,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10368,7 +10368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_OvenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OvenDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10401,7 +10401,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PastaCookerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10419,7 +10419,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10451,7 +10451,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10489,7 +10489,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PressureCookingKettleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10507,7 +10507,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10539,7 +10539,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10565,7 +10565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_ServeryCounterDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ServeryCounterDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10598,7 +10598,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -10619,7 +10619,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalDataConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2318",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalDataConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10642,7 +10642,7 @@
     "schemaDefinitions": {
       "ExceptionDeviationFormat": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "const": {
           "AbsoluteValue": 0,
           "PercentOfValue": 1,
@@ -10705,7 +10705,7 @@
       },
       "ExceptionDeviationFormat": {
         "title": "ExceptionDeviationFormat",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10826,7 +10826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AggregateConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11187",
+    "dov:typeRef": "org.opcfoundation.UA.AggregateConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10907,7 +10907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10933,7 +10933,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10980,7 +10980,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -11042,7 +11042,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -11195,7 +11195,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -11219,7 +11219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11422,7 +11422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11478,7 +11478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11549,7 +11549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11571,7 +11571,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -11593,7 +11593,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -11615,7 +11615,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -11625,7 +11625,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -11647,7 +11647,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -11740,7 +11740,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11785,7 +11785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11811,7 +11811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/CranesHoists.TM.json
+++ b/wot-codegen/opc-output-integrated/CranesHoists.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_BrakeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1556",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.BrakeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1369",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -61,7 +61,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1392",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotionDeviceSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=2112",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotionDeviceSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -114,7 +114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1262",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -147,7 +147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_ProtectiveFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1462",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.ProtectiveFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -173,7 +173,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -376,7 +376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -432,7 +432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -503,7 +503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -525,7 +525,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -547,7 +547,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -569,7 +569,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -579,7 +579,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -601,7 +601,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -694,7 +694,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -715,7 +715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -741,7 +741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_AxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16601",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -771,7 +771,7 @@
     "schemaDefinitions": {
       "AxisMotionProfileEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "const": {
           "OTHER": 0,
           "ROTARY": 1,
@@ -829,7 +829,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "AxisMotionProfileEnumeration",
         "description": "The kind of axis motion as defined with the AxisMotionProfileEnumeration.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -855,7 +855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_PowerTrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16794",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.PowerTrainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -926,7 +926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_GearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.GearType",
     "links": [
       {
         "rel": "tm:extends",
@@ -968,7 +968,7 @@
         "title": "RationalNumber",
         "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+        "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
         "required": [ "Numerator", "Denominator" ],
         "properties": {
           "Numerator": {
@@ -1091,7 +1091,7 @@
           "title": "RationalNumber",
           "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+          "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
           "required": [ "Numerator", "Denominator" ],
           "properties": {
             "Numerator": {
@@ -1172,7 +1172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1278,7 +1278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_LoadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.LoadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1308,13 +1308,13 @@
         "title": "ThreeDFrame",
         "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
         "required": [ "CartesianCoordinates", "Orientation" ],
         "properties": {
           "CartesianCoordinates": {
             "title": "ThreeDCartesianCoordinates",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
             "required": [ "X", "Y", "Z" ],
             "properties": {
               "X": {
@@ -1337,7 +1337,7 @@
           "Orientation": {
             "title": "ThreeDOrientation",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
             "required": [ "A", "B", "C" ],
             "properties": {
               "A": {
@@ -1371,7 +1371,7 @@
       "CenterOfMass_CartesianCoordinates": {
         "title": "ThreeDCartesianCoordinates",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -1446,7 +1446,7 @@
       "CenterOfMass_Orientation": {
         "title": "ThreeDOrientation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -1523,7 +1523,7 @@
         "title": "ThreeDVector",
         "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -1617,13 +1617,13 @@
           "title": "ThreeDFrame",
           "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
           "required": [ "CartesianCoordinates", "Orientation" ],
           "properties": {
             "CartesianCoordinates": {
               "title": "ThreeDCartesianCoordinates",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
               "required": [ "X", "Y", "Z" ],
               "properties": {
                 "X": {
@@ -1646,7 +1646,7 @@
             "Orientation": {
               "title": "ThreeDOrientation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
               "required": [ "A", "B", "C" ],
               "properties": {
                 "A": {
@@ -1681,7 +1681,7 @@
         "data": {
           "title": "ThreeDCartesianCoordinates",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -1760,7 +1760,7 @@
         "data": {
           "title": "ThreeDOrientation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1841,7 +1841,7 @@
           "title": "ThreeDVector",
           "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -1942,7 +1942,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1983,7 +1983,7 @@
     "schemaDefinitions": {
       "MotionDeviceCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "ARTICULATED_ROBOT": 1,
@@ -2104,7 +2104,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "MotionDeviceCategoryEnumeration",
         "description": "The variable MotionDeviceCategory provides the kind of motion device defined by MotionDeviceCategoryEnumeration based on ISO 8373.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2179,7 +2179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceSystemType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/CuttingTool.TM.json
+++ b/wot-codegen/opc-output-integrated/CuttingTool.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_CuttingToolFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.CuttingToolFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -38,7 +38,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CuttingTool/",
         "title": "FileFormatDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CuttingTool.FileFormatDataType",
         "required": [ "Name", "FileExtension", "Version" ],
         "properties": {
           "Name": {
@@ -78,7 +78,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_ToolMeasuringMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.ToolMeasuringMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -117,7 +117,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_ToolManufacturingMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.ToolManufacturingMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -156,7 +156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -177,7 +177,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -198,7 +198,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -210,7 +210,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -231,7 +231,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -243,7 +243,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -264,7 +264,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -281,7 +281,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -301,7 +301,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -327,7 +327,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -448,7 +448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -469,7 +469,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -483,7 +483,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -493,7 +493,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -512,7 +512,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -525,7 +525,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -549,7 +549,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -568,7 +568,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -587,7 +587,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -618,7 +618,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -644,7 +644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -689,7 +689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -831,7 +831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -916,7 +916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -962,7 +962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1008,7 +1008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1034,7 +1034,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1062,7 +1062,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1074,7 +1074,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1093,7 +1093,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1103,7 +1103,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1130,7 +1130,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1140,7 +1140,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1188,7 +1188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1307,7 +1307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1364,7 +1364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1408,7 +1408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1446,7 +1446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_LoadingMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.LoadingMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1551,7 +1551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_ToolMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.ToolMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1609,7 +1609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1641,7 +1641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1704,7 +1704,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1736,7 +1736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1786,7 +1786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1849,7 +1849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1893,7 +1893,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1938,7 +1938,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1955,7 +1955,7 @@
     "schemaDefinitions": {
       "MachineOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "const": {
           "Manual": 0,
           "Automatic": 1,
@@ -2036,7 +2036,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "MachineOperationMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2097,7 +2097,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "MachineOperationMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2136,7 +2136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ObligationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ObligationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2224,7 +2224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2262,7 +2262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2288,7 +2288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2338,7 +2338,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2384,7 +2384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2428,7 +2428,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2522,7 +2522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=59",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2586,7 +2586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2702,7 +2702,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2877,7 +2877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2903,7 +2903,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2970,7 +2970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2996,7 +2996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3020,7 +3020,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -3067,7 +3067,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3098,7 +3098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3109,7 +3109,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -3156,7 +3156,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3201,7 +3201,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3241,7 +3241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3267,7 +3267,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3291,7 +3291,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -3320,7 +3320,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -3416,7 +3416,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -3430,7 +3430,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -3462,7 +3462,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -3475,7 +3475,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -3488,14 +3488,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -3561,7 +3561,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -3596,7 +3596,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -3651,7 +3651,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -3668,7 +3668,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -3681,14 +3681,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -3754,7 +3754,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -3789,7 +3789,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -3843,14 +3843,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -3858,12 +3858,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -3885,7 +3885,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -3893,7 +3893,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -3930,7 +3930,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -3966,7 +3966,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -3979,7 +3979,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -4030,7 +4030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4044,14 +4044,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -4064,7 +4064,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {

--- a/wot-codegen/opc-output-integrated/DEXPI.TM.json
+++ b/wot-codegen/opc-output-integrated/DEXPI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DEXPISupplementaryDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DEXPISupplementaryDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BaseDEXPIObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BaseDEXPIObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -156,7 +156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantModelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantModelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MetaDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MetaDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -212,7 +212,7 @@
     "schemaDefinitions": {
       "ConfidentialityClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
         "const": {
           "ConfidentialInformation": 0,
           "NonConfidentialInformation": 1
@@ -434,7 +434,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ConfidentialityClassification",
         "description": "The confidentiality of the drawing.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1069,7 +1069,7 @@
         "data": {
           "title": "ConfidentialityClassification",
           "description": "The confidentiality of the drawing.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1459,7 +1459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantStructureItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1308",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantStructureItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1485,7 +1485,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1547,7 +1547,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ActuatingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1200",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ActuatingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1672,7 +1672,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ControlledActuatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1258",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ControlledActuatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1683,7 +1683,7 @@
     "schemaDefinitions": {
       "FailActionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
         "const": {
           "FailClose": 0,
           "FailOpen": 1,
@@ -1766,7 +1766,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "FailActionClassification",
         "description": "The fail action of the ControlledActuator.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1837,7 +1837,7 @@
         "data": {
           "title": "FailActionClassification",
           "description": "The fail action of the ControlledActuator.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1875,7 +1875,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShutOffValveReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1197",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShutOffValveReferenceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1950,7 +1950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PositionerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1127",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PositionerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2057,7 +2057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InstrumentationLoopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1188",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InstrumentationLoopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2132,7 +2132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1726",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2155,7 +2155,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -2189,7 +2189,7 @@
       },
       "JacketedPipeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "const": {
           "JacketedPipe": 0,
           "UnjacketedPipe": 1
@@ -2208,7 +2208,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -2542,7 +2542,7 @@
       },
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -2620,7 +2620,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipingNetworkSystem.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2698,7 +2698,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "JacketedPipeClassification",
         "description": "A specialization indicating whether the PipingNetworkSystem is jacketed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2812,7 +2812,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNetworkSystem, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2852,7 +2852,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingNetworkSystem is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2941,7 +2941,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipingNetworkSystem.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3003,7 +3003,7 @@
         "data": {
           "title": "JacketedPipeClassification",
           "description": "A specialization indicating whether the PipingNetworkSystem is jacketed.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3093,7 +3093,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNetworkSystem, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3125,7 +3125,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingNetworkSystem is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3177,7 +3177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSegmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1898",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3200,7 +3200,7 @@
     "schemaDefinitions": {
       "PipingNetworkSegmentFlowClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
         "const": {
           "DualFlowPipingNetworkSegment": 0,
           "SingleFlowPipingNetworkSegment": 1
@@ -3219,7 +3219,7 @@
       },
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -3253,7 +3253,7 @@
       },
       "JacketedPipeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "const": {
           "JacketedPipe": 0,
           "UnjacketedPipe": 1
@@ -3272,7 +3272,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -3606,7 +3606,7 @@
       },
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -3625,7 +3625,7 @@
       },
       "PrimarySecondaryPipingNetworkSegmentClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
         "const": {
           "PrimaryPipingNetworkSegment": 0,
           "SecondaryPipingNetworkSegment": 1
@@ -3644,7 +3644,7 @@
       },
       "SiphonClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
         "const": {
           "NoSiphon": 0,
           "Siphon": 1
@@ -3663,7 +3663,7 @@
       },
       "PipingNetworkSegmentSlopeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
         "const": {
           "SlopedPipingNetworkSegment": 0,
           "UnslopedPipingNetworkSegment": 1
@@ -3741,7 +3741,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingNetworkSegmentFlowClassification",
         "description": "A specialization indicating if the PipingNetworkSegment enables dual flow or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3799,7 +3799,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipingNetworkSegment.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3879,7 +3879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "JacketedPipeClassification",
         "description": "A specialization indicating whether the PipingNetworkSegment is jacketed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3957,7 +3957,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNetworkSegment, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3997,7 +3997,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4075,7 +4075,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PrimarySecondaryPipingNetworkSegmentClassification",
         "description": "A specialization indicating whether the PipingNetworkSegment is a primary or secondary PipingNetworkSegment.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4115,7 +4115,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SiphonClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is a siphon or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4137,7 +4137,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingNetworkSegmentSlopeClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is sloped or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4190,7 +4190,7 @@
         "data": {
           "title": "PipingNetworkSegmentFlowClassification",
           "description": "A specialization indicating if the PipingNetworkSegment enables dual flow or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4236,7 +4236,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipingNetworkSegment.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4300,7 +4300,7 @@
         "data": {
           "title": "JacketedPipeClassification",
           "description": "A specialization indicating whether the PipingNetworkSegment is jacketed.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4362,7 +4362,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNetworkSegment, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4394,7 +4394,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4456,7 +4456,7 @@
         "data": {
           "title": "PrimarySecondaryPipingNetworkSegmentClassification",
           "description": "A specialization indicating whether the PipingNetworkSegment is a primary or secondary PipingNetworkSegment.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4488,7 +4488,7 @@
         "data": {
           "title": "SiphonClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is a siphon or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4506,7 +4506,7 @@
         "data": {
           "title": "PipingNetworkSegmentSlopeClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is sloped or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4530,7 +4530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSegmentItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1754",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4556,7 +4556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1989",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4582,7 +4582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PropertyBreakType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1938",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PropertyBreakType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4599,7 +4599,7 @@
     "schemaDefinitions": {
       "CompositionBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
         "const": {
           "CompositionBreak": 0,
           "NoCompositionBreak": 1
@@ -4618,7 +4618,7 @@
       },
       "InsulationBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
         "const": {
           "InsulationBreak": 0,
           "NoInsulationBreak": 1
@@ -4637,7 +4637,7 @@
       },
       "NominalDiameterBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
         "const": {
           "NoNominalDiameterBreak": 0,
           "NominalDiameterBreak": 1
@@ -4656,7 +4656,7 @@
       },
       "PipingClassBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
         "const": {
           "NoPipingClassBreak": 0,
           "PipingClassBreak": 1
@@ -4698,7 +4698,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "CompositionBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4720,7 +4720,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "InsulationBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is an insulation break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4742,7 +4742,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a nominal diameter break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4764,7 +4764,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingClassBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4789,7 +4789,7 @@
         "data": {
           "title": "CompositionBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4807,7 +4807,7 @@
         "data": {
           "title": "InsulationBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is an insulation break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4825,7 +4825,7 @@
         "data": {
           "title": "NominalDiameterBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a nominal diameter break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4843,7 +4843,7 @@
         "data": {
           "title": "PipingClassBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4867,7 +4867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNodeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2008",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNodeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4878,7 +4878,7 @@
     "schemaDefinitions": {
       "NodeFlowClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
         "const": {
           "MainFlowInNode": 0,
           "MainFlowOutNode": 1
@@ -4897,7 +4897,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -5254,7 +5254,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NodeFlowClassification",
         "description": "A classification of the flow direction in the PipingNode with respect to its PipingNodeOwner.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5312,7 +5312,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNode, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5355,7 +5355,7 @@
         "data": {
           "title": "NodeFlowClassification",
           "description": "A classification of the flow direction in the PipingNode with respect to its PipingNodeOwner.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5401,7 +5401,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNode, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5439,7 +5439,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessInstrumentationFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1130",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessInstrumentationFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5468,7 +5468,7 @@
     "schemaDefinitions": {
       "GmpRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "const": {
           "GmpRelevantFunction": 0,
           "NonGmpRelevantFunction": 1
@@ -5487,7 +5487,7 @@
       },
       "GuaranteedSupplyFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "const": {
           "GuaranteedSupplyFunction": 0,
           "NonGuaranteedSupplyFunction": 1
@@ -5506,7 +5506,7 @@
       },
       "LocationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "const": {
           "CentralLocation": 0,
           "ControlPanel": 1,
@@ -5530,7 +5530,7 @@
       },
       "QualityRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "const": {
           "NonQualityRelevantFunction": 0,
           "QualityRelevantFunction": 1
@@ -5590,7 +5590,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GmpRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5612,7 +5612,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GuaranteedSupplyFunctionClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5634,7 +5634,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "LocationClassification",
         "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5746,7 +5746,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "QualityRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5857,7 +5857,7 @@
         "data": {
           "title": "GmpRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5875,7 +5875,7 @@
         "data": {
           "title": "GuaranteedSupplyFunctionClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5893,7 +5893,7 @@
         "data": {
           "title": "LocationClassification",
           "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5981,7 +5981,7 @@
         "data": {
           "title": "QualityRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6061,7 +6061,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ActuatingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1239",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ActuatingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6136,7 +6136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessSignalGeneratingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1210",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessSignalGeneratingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6243,7 +6243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1251",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6254,7 +6254,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -6293,7 +6293,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -6350,7 +6350,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6372,7 +6372,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6433,7 +6433,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6451,7 +6451,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6503,7 +6503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessSignalGeneratingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1118",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessSignalGeneratingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6622,7 +6622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1195",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimaryElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6697,7 +6697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TransmitterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1247",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TransmitterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6804,7 +6804,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TaggedPlantItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1337",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TaggedPlantItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6975,7 +6975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SensingLocationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1117",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SensingLocationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7001,7 +7001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1152",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7031,7 +7031,7 @@
     "schemaDefinitions": {
       "GmpRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "const": {
           "GmpRelevantFunction": 0,
           "NonGmpRelevantFunction": 1
@@ -7050,7 +7050,7 @@
       },
       "GuaranteedSupplyFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "const": {
           "GuaranteedSupplyFunction": 0,
           "NonGuaranteedSupplyFunction": 1
@@ -7069,7 +7069,7 @@
       },
       "LocationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "const": {
           "CentralLocation": 0,
           "ControlPanel": 1,
@@ -7093,7 +7093,7 @@
       },
       "QualityRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "const": {
           "NonQualityRelevantFunction": 0,
           "QualityRelevantFunction": 1
@@ -7153,7 +7153,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GmpRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7175,7 +7175,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GuaranteedSupplyFunctionClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7197,7 +7197,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "LocationClassification",
         "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7309,7 +7309,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "QualityRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7420,7 +7420,7 @@
         "data": {
           "title": "GmpRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7438,7 +7438,7 @@
         "data": {
           "title": "GuaranteedSupplyFunctionClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7456,7 +7456,7 @@
         "data": {
           "title": "LocationClassification",
           "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7544,7 +7544,7 @@
         "data": {
           "title": "QualityRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7624,7 +7624,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalLineFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1174",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalLineFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7636,7 +7636,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -7675,7 +7675,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -7732,7 +7732,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7754,7 +7754,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7815,7 +7815,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7833,7 +7833,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7885,7 +7885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MeasuringLineFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1181",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MeasuringLineFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7897,7 +7897,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -7936,7 +7936,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -7993,7 +7993,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8015,7 +8015,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8076,7 +8076,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8094,7 +8094,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8146,7 +8146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1219",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionTargetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8172,7 +8172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_OfflinePrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1220",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.OfflinePrimaryElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8184,7 +8184,7 @@
     "schemaDefinitions": {
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -8518,7 +8518,7 @@
       },
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -8611,7 +8611,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the device connection of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8687,7 +8687,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the OfflinePrimaryElement.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8783,7 +8783,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the location of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8874,7 +8874,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the device connection of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8934,7 +8934,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the OfflinePrimaryElement.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9010,7 +9010,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the location of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9064,7 +9064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionSourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1250",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionSourceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9090,7 +9090,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InlinePrimaryElementReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1263",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InlinePrimaryElementReferenceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9117,7 +9117,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSectionIso10209_2012Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1265",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSectionIso10209-2012Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -9225,7 +9225,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaIsa95LocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1270",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaIsa95LocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9251,7 +9251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IndustrialComplexIso10209_2012Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1272",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IndustrialComplexIso10209-2012Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -9359,7 +9359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantTrainLocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1277",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantTrainLocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9385,7 +9385,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessPlantParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1279",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessPlantParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9411,7 +9411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SiteIsa95Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1280",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiteIsa95Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -9519,7 +9519,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IndustrialComplexIso10209_2012ParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1284",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IndustrialComplexIso10209-2012ParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9545,7 +9545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TechnicalItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1285",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TechnicalItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9571,7 +9571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaIsa95Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1290",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaIsa95Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -9679,7 +9679,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSystemLocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1293",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSystemLocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9705,7 +9705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TechnicalItemParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1295",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TechnicalItemParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9731,7 +9731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSectionIso10209_2012ParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1296",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSectionIso10209-2012ParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9757,7 +9757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1297",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9865,7 +9865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessPlantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1300",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessPlantType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9973,7 +9973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_Isa95EnterpriseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1305",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.Isa95EnterpriseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10081,7 +10081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantTrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1309",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantTrainType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10189,7 +10189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_EjectorPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1312",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.EjectorPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10269,7 +10269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1716",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10421,7 +10421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1682",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10636,7 +10636,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1523",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10647,7 +10647,7 @@
     "schemaDefinitions": {
       "ChamberFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
         "const": {
           "Cooling": 0,
           "Heating": 1,
@@ -10735,7 +10735,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ChamberFunctionClassification",
         "description": "A specialization indicating the function of the Chamber.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -11022,7 +11022,7 @@
         "data": {
           "title": "ChamberFunctionClassification",
           "description": "A specialization indicating the function of the Chamber.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -11232,7 +11232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NozzleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1361",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NozzleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11249,7 +11249,7 @@
     "schemaDefinitions": {
       "NominalPressureStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
         "const": {
           "Class10000PsiArtefact": 0,
           "Class1000KpaArtefact": 1,
@@ -11537,7 +11537,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalPressureStandardClassification",
         "description": "The nominal pressure of the Nozzle, given as a reference to a nominal pressure standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -11626,7 +11626,7 @@
         "data": {
           "title": "NominalPressureStandardClassification",
           "description": "The nominal pressure of the Nozzle, given as a reference to a nominal pressure standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -11678,7 +11678,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_KneaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1316",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.KneaderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11830,7 +11830,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1454",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11863,7 +11863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MixingElementAssemblyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1562",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MixingElementAssemblyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11974,7 +11974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1326",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12126,7 +12126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1342",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12248,7 +12248,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DisplacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1656",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DisplacerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12391,7 +12391,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ThinFilmEvaporatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1350",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ThinFilmEvaporatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12549,7 +12549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatExchangerRotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1491",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatExchangerRotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12624,7 +12624,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpiralHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1369",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpiralHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12651,7 +12651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnPackingsArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1370",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnPackingsArrangementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12831,7 +12831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ChamberOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1377",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12863,7 +12863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ReciprocatingCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1379",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ReciprocatingCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12985,7 +12985,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1408",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13101,7 +13101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1387",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13291,7 +13291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompressorEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1636",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompressorEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13317,7 +13317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SubTaggedColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1399",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SubTaggedColumnSectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13470,7 +13470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnInternalsArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1489",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnInternalsArrangementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13496,7 +13496,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1415",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13648,7 +13648,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1425",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13728,7 +13728,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GasFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1431",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GasFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13922,7 +13922,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1619",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13949,7 +13949,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FilterUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1456",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FilterUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14276,7 +14276,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PressureVesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1445",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PressureVesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14356,7 +14356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialVesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1449",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialVesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14468,7 +14468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AirCoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1478",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AirCoolingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14626,7 +14626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SiloType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1490",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiloType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14653,7 +14653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1494",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnSectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14774,7 +14774,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PumpEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1502",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PumpEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14800,7 +14800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ReciprocatingPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1503",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ReciprocatingPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14922,7 +14922,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TaggedColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1511",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TaggedColumnSectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15172,7 +15172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ElectricHeaterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1557",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ElectricHeaterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15258,7 +15258,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TubeBundleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1592",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TubeBundleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15269,7 +15269,7 @@
     "schemaDefinitions": {
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -15720,7 +15720,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the tubes, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15837,7 +15837,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the tubes, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15875,7 +15875,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CentrifugalCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1566",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CentrifugalCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15997,7 +15997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ImpellerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1629",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ImpellerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16140,7 +16140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NozzleOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1574",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NozzleOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16172,7 +16172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlateAndShellHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1576",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlateAndShellHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16324,7 +16324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CentrifugalPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1584",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CentrifugalPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16446,7 +16446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnTraysArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1603",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnTraysArrangementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16590,7 +16590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1607",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16780,7 +16780,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AirEjectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1620",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AirEjectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16866,7 +16866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StaticMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1625",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StaticMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16946,7 +16946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AgitatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1637",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AgitatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17068,7 +17068,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AgitatorRotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1672",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AgitatorRotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17247,7 +17247,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AxialCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1645",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AxialCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17369,7 +17369,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShellAndTubeHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1653",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShellAndTubeHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17451,7 +17451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TankType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1663",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TankType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17531,7 +17531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessColumnType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1667",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessColumnType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17617,7 +17617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LiquidFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1694",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LiquidFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17811,7 +17811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1708",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17933,7 +17933,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TurbineFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1755",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TurbineFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17960,7 +17960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InlinePrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1793",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InlinePrimaryElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17972,7 +17972,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -18047,7 +18047,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the InlinePrimaryElement.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18180,7 +18180,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the InlinePrimaryElement.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18278,7 +18278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1995",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18295,7 +18295,7 @@
     "schemaDefinitions": {
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -18314,7 +18314,7 @@
       },
       "PipingClassArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
         "const": {
           "NonPipingClassArtefact": 0,
           "PipingClassArtefact": 1
@@ -18410,7 +18410,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingComponent is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18432,7 +18432,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingClassArtefactClassification",
         "description": "A specialization indicating if the PipingComponent is an artefact that is         described by a piping class.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18517,7 +18517,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingComponent is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18535,7 +18535,7 @@
         "data": {
           "title": "PipingClassArtefactClassification",
           "description": "A specialization indicating if the PipingComponent is an artefact that is         described by a piping class.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18573,7 +18573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1756",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18600,7 +18600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShutOffValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1845",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShutOffValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18612,7 +18612,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -18646,7 +18646,7 @@
       },
       "NumberOfPortsClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
         "const": {
           "FourPortValve": 0,
           "ThreePortValve": 1,
@@ -18670,7 +18670,7 @@
       },
       "OperationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
         "const": {
           "ContinuousOperation": 0,
           "IntermittentOperation": 1
@@ -18730,7 +18730,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18810,7 +18810,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NumberOfPortsClassification",
         "description": "A specialization indicating the number of ports of the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18832,7 +18832,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OperationClassification",
         "description": "A specialization indicating the operation of the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18925,7 +18925,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18989,7 +18989,7 @@
         "data": {
           "title": "NumberOfPortsClassification",
           "description": "A specialization indicating the number of ports of the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -19007,7 +19007,7 @@
         "data": {
           "title": "OperationClassification",
           "description": "A specialization indicating the operation of the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -19073,7 +19073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StrainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1757",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StrainerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19085,7 +19085,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -19160,7 +19160,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19311,7 +19311,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -19423,7 +19423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FunnelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1770",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FunnelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19450,7 +19450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFittingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1877",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFittingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19462,7 +19462,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -19537,7 +19537,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19688,7 +19688,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -19800,7 +19800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NeedleValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1771",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NeedleValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19827,7 +19827,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InLineMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1772",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InLineMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19854,7 +19854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1773",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19866,7 +19866,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -19941,7 +19941,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the CheckValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20092,7 +20092,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the CheckValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20204,7 +20204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1786",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeConnectorSymbolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20236,7 +20236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1788",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20263,7 +20263,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleBallValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1789",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleBallValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20290,7 +20290,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BallValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1790",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BallValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20317,7 +20317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlugValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1791",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlugValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20344,7 +20344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompensatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1792",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompensatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20371,7 +20371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlangedConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1805",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlangedConnectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20398,7 +20398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HoseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1806",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HoseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20425,7 +20425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingSourceItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1807",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingSourceItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20451,7 +20451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleGlobeValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1808",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleGlobeValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20478,7 +20478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PositiveDisplacementFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1809",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PositiveDisplacementFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20505,7 +20505,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VariableAreaFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1810",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VariableAreaFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20532,7 +20532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ElectromagneticFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1811",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ElectromagneticFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20559,7 +20559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SteamTrapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1812",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SteamTrapType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20571,7 +20571,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -20646,7 +20646,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20797,7 +20797,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20909,7 +20909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IlluminatedSightGlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1825",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IlluminatedSightGlassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20936,7 +20936,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingTargetItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1826",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingTargetItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20962,7 +20962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowInPipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1827",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowInPipeConnectorSymbolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20995,7 +20995,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowOutPipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1829",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowOutPipeConnectorSymbolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21028,7 +21028,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpringLoadedGlobeSafetyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1831",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpringLoadedGlobeSafetyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21055,7 +21055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SafetyValveOrFittingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1944",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SafetyValveOrFittingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21299,7 +21299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SilencerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1832",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SilencerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21311,7 +21311,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -21386,7 +21386,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21537,7 +21537,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21649,7 +21649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DirectPipingConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1860",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DirectPipingConnectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21676,7 +21676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1865",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21703,7 +21703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ConicalStrainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1866",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConicalStrainerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21730,7 +21730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SightGlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1867",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SightGlassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21757,7 +21757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BreatherValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1868",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BreatherValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21784,7 +21784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GlobeValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1869",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GlobeValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21811,7 +21811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFlangeSpacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1870",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFlangeSpacerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21838,7 +21838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BlindFlangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1871",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BlindFlangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21865,7 +21865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RuptureDiscType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1872",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RuptureDiscType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21892,7 +21892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StraightwayValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1873",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StraightwayValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21919,7 +21919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GlobeCheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1874",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GlobeCheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21946,7 +21946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeTeeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1875",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeTeeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21973,7 +21973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpringLoadedAngleGlobeSafetyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1876",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpringLoadedAngleGlobeSafetyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22000,7 +22000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1890",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22027,7 +22027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumetricFlowDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1895",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumetricFlowDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22054,7 +22054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFlangeSpadeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1896",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFlangeSpadeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22081,7 +22081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ClampedFlangeCouplingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1897",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ClampedFlangeCouplingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22108,7 +22108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PenetrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1936",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PenetrationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22135,7 +22135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SwingCheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1937",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SwingCheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22162,7 +22162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VenturiTubeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1955",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VenturiTubeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22189,7 +22189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowNozzleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1956",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowNozzleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22216,7 +22216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AnglePlugValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1957",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AnglePlugValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22243,7 +22243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VentilationDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1958",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VentilationDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22255,7 +22255,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -22330,7 +22330,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22481,7 +22481,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22593,7 +22593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeCouplingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1971",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeCouplingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22620,7 +22620,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlameArrestorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1972",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlameArrestorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22632,7 +22632,7 @@
     "schemaDefinitions": {
       "DetonationProofArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
         "const": {
           "DetonationProofArtefact": 0,
           "NonDetonationProofArtefact": 1
@@ -22651,7 +22651,7 @@
       },
       "ExplosionProofArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
         "const": {
           "ExplosionProofArtefact": 0,
           "NonExplosionProofArtefact": 1
@@ -22670,7 +22670,7 @@
       },
       "FireResistantArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
         "const": {
           "FireResistantArtefact": 0,
           "NonFireResistantArtefact": 1
@@ -22712,7 +22712,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "DetonationProofArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is detonation-proof.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22734,7 +22734,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ExplosionProofArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is explosion-proof.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22756,7 +22756,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "FireResistantArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is fire-resistant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22781,7 +22781,7 @@
         "data": {
           "title": "DetonationProofArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is detonation-proof.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22799,7 +22799,7 @@
         "data": {
           "title": "ExplosionProofArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is explosion-proof.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22817,7 +22817,7 @@
         "data": {
           "title": "FireResistantArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is fire-resistant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22841,7 +22841,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_OrificePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1976",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.OrificePlateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22853,7 +22853,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -22928,7 +22928,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23079,7 +23079,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23191,7 +23191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ButterflyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1994",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ButterflyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23218,7 +23218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GateValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2003",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GateValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23245,7 +23245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeReducerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2004",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeReducerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23272,7 +23272,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LineBlindType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2005",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LineBlindType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23299,7 +23299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNodeOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2006",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNodeOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23331,7 +23331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotationalSpeedType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2014",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotationalSpeedType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23443,7 +23443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatTransferCoefficientType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2018",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTransferCoefficientType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23555,7 +23555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TemperatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2022",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TemperatureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23667,7 +23667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PhysicalQuantityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2026",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PhysicalQuantityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23746,7 +23746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2029",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23858,7 +23858,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumeFlowRateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2033",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumeFlowRateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23970,7 +23970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PowerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2037",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PowerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24082,7 +24082,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LengthType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LengthType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24194,7 +24194,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PercentageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2045",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PercentageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24306,7 +24306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2049",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24418,7 +24418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2053",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24530,7 +24530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PressureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2057",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PressureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24642,7 +24642,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2061",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24754,7 +24754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -24775,7 +24775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24796,7 +24796,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -24817,7 +24817,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -24829,7 +24829,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -24850,7 +24850,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -24862,7 +24862,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -24883,7 +24883,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -24900,7 +24900,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -24920,7 +24920,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -24946,7 +24946,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {

--- a/wot-codegen/opc-output-integrated/DI.TM.json
+++ b/wot-codegen/opc-output-integrated/DI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -135,7 +135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -157,7 +157,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -179,7 +179,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -201,7 +201,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -211,7 +211,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -233,7 +233,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -326,7 +326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15035",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -533,7 +533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ITagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15048",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ITagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -590,7 +590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IDeviceHealthType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15051",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IDeviceHealthType",
     "links": [
       {
         "rel": "tm:extends",
@@ -607,7 +607,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -657,7 +657,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -676,7 +676,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -700,7 +700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ISupportInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15054",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ISupportInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -756,7 +756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IAssetLocationIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=118",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IAssetLocationIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -767,7 +767,7 @@
     "schemaDefinitions": {
       "LocationIndicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "const": {
           "Visual": 0,
           "Audible": 1
@@ -796,7 +796,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=413",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IndicationDuration" ],
           "properties": {
             "IndicationDuration": {
@@ -840,7 +840,7 @@
       "SupportedIndicationTypes": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "LocationIndicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -856,7 +856,7 @@
       "UsedIndicationType": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "LocationIndicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -882,7 +882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1085,7 +1085,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1132,7 +1132,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -1194,7 +1194,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1347,7 +1347,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1371,7 +1371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1416,7 +1416,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1442,7 +1442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1487,7 +1487,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15106",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1557,7 +1557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_BlockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.DI.BlockType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1661,7 +1661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceHealthDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15143",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1688,7 +1688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FailureAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15292",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FailureAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1715,7 +1715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_CheckFunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15441",
+    "dov:typeRef": "org.opcfoundation.UA.DI.CheckFunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1742,7 +1742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_OffSpecAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15590",
+    "dov:typeRef": "org.opcfoundation.UA.DI.OffSpecAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1769,7 +1769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_MaintenanceRequiredAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15739",
+    "dov:typeRef": "org.opcfoundation.UA.DI.MaintenanceRequiredAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1796,7 +1796,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfigurableObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfigurableObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1835,7 +1835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_BaseLifetimeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=473",
+    "dov:typeRef": "org.opcfoundation.UA.DI.BaseLifetimeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1861,7 +1861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TimeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=474",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TimeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1887,7 +1887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NumberOfPartsIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=475",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NumberOfPartsIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1913,7 +1913,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NumberOfUsagesIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=476",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NumberOfUsagesIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1939,7 +1939,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LengthIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=477",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LengthIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1965,7 +1965,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DiameterIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=478",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DiameterIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1991,7 +1991,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SubstanceVolumeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=479",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SubstanceVolumeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2017,7 +2017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=480",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IOperationCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2092,7 +2092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TransferServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6526",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TransferServicesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2108,7 +2108,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6532",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TransferID", "SequenceNumber", "MaxParameterResultsToReturn", "OmitGoodResults" ],
           "properties": {
             "TransferID": {
@@ -2133,7 +2133,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6533",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FetchResultData" ],
           "properties": {
             "FetchResultData": {
@@ -2153,7 +2153,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6530",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferID", "InitTransferStatus" ],
           "properties": {
             "TransferID": {
@@ -2180,7 +2180,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6528",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferID", "InitTransferStatus" ],
           "properties": {
             "TransferID": {
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareUpdateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareUpdateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2266,7 +2266,7 @@
     "schemaDefinitions": {
       "SoftwareClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "const": {
           "Firmware": 0,
           "Application": 1,
@@ -2322,7 +2322,7 @@
       "SoftwareClass": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "SoftwareClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2438,7 +2438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=135",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareLoadingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2501,7 +2501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PrepareForUpdateStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=213",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PrepareForUpdateStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2652,7 +2652,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_InstallationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=249",
+    "dov:typeRef": "org.opcfoundation.UA.DI.InstallationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2721,7 +2721,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=269",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -2744,7 +2744,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=266",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManufacturerUri", "SoftwareRevision", "PatchIdentifiers", "Hash" ],
           "properties": {
             "ManufacturerUri": {
@@ -2864,7 +2864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PowerCycleStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=285",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PowerCycleStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2914,7 +2914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfirmationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=307",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfirmationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3013,7 +3013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PackageLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=137",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PackageLoadingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3102,7 +3102,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareVersionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=212",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareVersionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3234,7 +3234,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DirectLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=153",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DirectLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3246,7 +3246,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -3296,7 +3296,7 @@
       "UpdateBehavior": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "UpdateBehavior",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3328,7 +3328,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "UpdateBehavior",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+          "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3352,7 +3352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_CachedLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=171",
+    "dov:typeRef": "org.opcfoundation.UA.DI.CachedLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3376,7 +3376,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -3413,7 +3413,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=190",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManufacturerUri", "SoftwareRevision", "PatchIdentifiers" ],
           "properties": {
             "ManufacturerUri": {
@@ -3432,12 +3432,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateBehavior" ],
           "properties": {
             "UpdateBehavior": {
               "title": "UpdateBehavior",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+              "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3467,7 +3467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FileSystemLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=192",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FileSystemLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3485,7 +3485,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -3522,7 +3522,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=207",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -3535,12 +3535,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=208",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateBehavior" ],
           "properties": {
             "UpdateBehavior": {
               "title": "UpdateBehavior",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+              "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3559,7 +3559,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=210",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -3572,7 +3572,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=211",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorCode", "ErrorMessage" ],
           "properties": {
             "ErrorCode": {
@@ -3608,7 +3608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=364",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3620,7 +3620,7 @@
     "schemaDefinitions": {
       "SoftwareClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "const": {
           "Firmware": 0,
           "Application": 1,
@@ -3659,7 +3659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=404",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Subclass", "Name" ],
           "properties": {
             "Subclass": {
@@ -3682,7 +3682,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=406",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -3703,7 +3703,7 @@
       "SoftwareClass": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "SoftwareClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3729,7 +3729,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3750,7 +3750,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3776,7 +3776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3802,7 +3802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InstrumentDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18347",
+    "dov:typeRef": "org.opcfoundation.UA.InstrumentDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3829,7 +3829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3874,7 +3874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3901,7 +3901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3940,7 +3940,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3971,7 +3971,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3999,7 +3999,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4027,7 +4027,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4064,7 +4064,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4092,7 +4092,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4417,7 +4417,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4444,7 +4444,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4469,7 +4469,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4575,7 +4575,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4602,7 +4602,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4627,7 +4627,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4649,7 +4649,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4908,7 +4908,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5004,7 +5004,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -5108,7 +5108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5192,7 +5192,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5211,7 +5211,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -5231,7 +5231,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -5263,7 +5263,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5306,7 +5306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5448,7 +5448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5533,7 +5533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5579,7 +5579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5625,7 +5625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5651,7 +5651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5677,7 +5677,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5705,7 +5705,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -5717,7 +5717,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -5736,7 +5736,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -5746,7 +5746,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -5773,7 +5773,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -5783,7 +5783,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -5831,7 +5831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5950,7 +5950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5964,7 +5964,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -5974,7 +5974,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -5993,7 +5993,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -6006,7 +6006,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -6030,7 +6030,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -6049,7 +6049,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -6068,7 +6068,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {

--- a/wot-codegen/opc-output-integrated/ECM.TM.json
+++ b/wot-codegen/opc-output-integrated/ECM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_AccuracyDomainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.AccuracyDomainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -38,7 +38,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileD0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileD0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -245,7 +245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileD1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileD1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -646,7 +646,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -680,7 +680,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -773,7 +773,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -851,7 +851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1014,7 +1014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE2Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE2Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1177,7 +1177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE3Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE3Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1211,7 +1211,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1289,7 +1289,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1367,7 +1367,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1443,7 +1443,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1521,7 +1521,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1599,7 +1599,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPpDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPpDataType",
         "required": [ "L1L2", "L2L3", "L3L1" ],
         "properties": {
           "L1L2": {
@@ -1740,7 +1740,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1811,7 +1811,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1882,7 +1882,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1951,7 +1951,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -2022,7 +2022,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -2093,7 +2093,7 @@
         "data": {
           "title": "AcPpDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPpDataType",
           "required": [ "L1L2", "L2L3", "L3L1" ],
           "properties": {
             "L1L2": {
@@ -2170,7 +2170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyDevicePowerOffType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyDevicePowerOffType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2198,7 +2198,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6110",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -2349,7 +2349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyMeasurementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2536,7 +2536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModesContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModesContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2568,7 +2568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2854,7 +2854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModeStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModeStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2883,7 +2883,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "StandbyModeTransitionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.StandbyModeTransitionDataType",
         "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
         "properties": {
           "IDDestination": {
@@ -2922,7 +2922,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "EnergyStateInformationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStateInformationDataType",
         "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
         "properties": {
           "IDSource": {
@@ -2965,7 +2965,7 @@
         "data": {
           "title": "StandbyModeTransitionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.StandbyModeTransitionDataType",
           "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
           "properties": {
             "IDDestination": {
@@ -3005,7 +3005,7 @@
         "data": {
           "title": "EnergyStateInformationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStateInformationDataType",
           "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
           "properties": {
             "IDSource": {
@@ -3052,7 +3052,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyStandbyManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStandbyManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3103,7 +3103,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentTimeToOperate", "ReturnCode" ],
           "properties": {
             "CurrentTimeToOperate": {
@@ -3131,7 +3131,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PauseTime" ],
           "properties": {
             "PauseTime": {
@@ -3143,7 +3143,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -3187,7 +3187,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ModeID" ],
           "properties": {
             "ModeID": {
@@ -3200,7 +3200,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EffectiveModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "EffectiveModeID": {
@@ -3316,7 +3316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3337,7 +3337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3363,7 +3363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3385,7 +3385,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -3407,7 +3407,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -3429,7 +3429,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -3439,7 +3439,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -3461,7 +3461,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/FDI5.TM.json
+++ b/wot-codegen/opc-output-integrated/FDI5.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_ActionType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=11",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ActionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_ActionServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=21",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ActionServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -55,7 +55,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=29",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionNodeId" ],
           "properties": {
             "ActionNodeId": {
@@ -65,7 +65,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=30",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AbortActionError" ],
           "properties": {
             "AbortActionError": {
@@ -87,7 +87,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=23",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionName", "MethodArguments" ],
           "properties": {
             "ActionName": {
@@ -100,7 +100,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=24",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ActionNodeId", "InvokeActionError" ],
           "properties": {
             "ActionNodeId": {
@@ -125,7 +125,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=26",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionNodeId", "Response" ],
           "properties": {
             "ActionNodeId": {
@@ -138,7 +138,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=27",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RespondActionError" ],
           "properties": {
             "RespondActionError": {
@@ -171,7 +171,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_EditContextType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=54",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.EditContextType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     "schemaDefinitions": {
       "WindowModeType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=194",
+        "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.WindowModeType",
         "const": {
           "ModalWindow": 1,
           "NonModalWindow": 2,
@@ -207,7 +207,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -217,13 +217,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=66",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyStatus" ],
           "properties": {
             "ApplyStatus": {
               "title": "ApplyResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=44",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ApplyResult",
               "required": [ "Status", "TransferIncidents" ],
               "properties": {
                 "Status": {
@@ -236,7 +236,7 @@
                   "items": {
                     "title": "TransferIncident",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=43",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.TransferIncident",
                     "required": [ "ContextNodeId", "StatusCode", "Diagnostics" ],
                     "properties": {
                       "ContextNodeId": {
@@ -267,7 +267,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=71",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -277,7 +277,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=72",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DiscardStatus" ],
           "properties": {
             "DiscardStatus": {
@@ -299,7 +299,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=56",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ParentId", "TargetWindowMode" ],
           "properties": {
             "ParentId": {
@@ -307,7 +307,7 @@
             },
             "TargetWindowMode": {
               "title": "WindowModeType",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=194",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.WindowModeType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -316,7 +316,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=57",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EditContextId", "GetEditContextStatus" ],
           "properties": {
             "EditContextId": {
@@ -341,7 +341,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId", "NodesToRegister" ],
           "properties": {
             "EditContextId": {
@@ -352,13 +352,13 @@
               "items": {
                 "title": "RegistrationParameters",
                 "type": "object",
-                "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=37",
+                "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegistrationParameters",
                 "required": [ "Path", "SelectionFlags" ],
                 "properties": {
                   "Path": {
                     "title": "RelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -366,7 +366,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -398,13 +398,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=60",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RegisterNodesStatus" ],
           "properties": {
             "RegisterNodesStatus": {
               "title": "RegisterNodesResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=39",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisterNodesResult",
               "required": [ "Status", "RegisteredNodes" ],
               "properties": {
                 "Status": {
@@ -417,7 +417,7 @@
                   "items": {
                     "title": "RegisteredNode",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=38",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisteredNode",
                     "required": [ "NodeStatus", "OnlineContextNodeId", "OnlineDeviceNodeId", "OfflineContextNodeId", "OfflineDeviceNodeId" ],
                     "properties": {
                       "NodeStatus": {
@@ -456,7 +456,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId", "NodesToRegister" ],
           "properties": {
             "EditContextId": {
@@ -467,13 +467,13 @@
               "items": {
                 "title": "RegistrationParameters",
                 "type": "object",
-                "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=37",
+                "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegistrationParameters",
                 "required": [ "Path", "SelectionFlags" ],
                 "properties": {
                   "Path": {
                     "title": "RelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -481,7 +481,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -513,13 +513,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RegisterNodesStatus" ],
           "properties": {
             "RegisterNodesStatus": {
               "title": "RegisterNodesResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=39",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisterNodesResult",
               "required": [ "Status", "RegisteredNodes" ],
               "properties": {
                 "Status": {
@@ -532,7 +532,7 @@
                   "items": {
                     "title": "RegisteredNode",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=38",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisteredNode",
                     "required": [ "NodeStatus", "OnlineContextNodeId", "OnlineDeviceNodeId", "OfflineContextNodeId", "OfflineDeviceNodeId" ],
                     "properties": {
                       "NodeStatus": {
@@ -571,7 +571,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=68",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -581,7 +581,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResetStatus" ],
           "properties": {
             "ResetStatus": {
@@ -614,7 +614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_DirectDeviceAccessType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=82",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.DirectDeviceAccessType",
     "dov:isComposite": true,
     "links": [
       {
@@ -630,7 +630,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=90",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InvalidateCache" ],
           "properties": {
             "InvalidateCache": {
@@ -640,7 +640,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=91",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EndDirectAccessError" ],
           "properties": {
             "EndDirectAccessError": {
@@ -662,7 +662,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=84",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -672,7 +672,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=85",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitDirectAccessError" ],
           "properties": {
             "InitDirectAccessError": {
@@ -694,7 +694,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=87",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SendData", "ReceiveData" ],
           "properties": {
             "SendData": {
@@ -707,7 +707,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=88",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferError" ],
           "properties": {
             "TransferError": {
@@ -740,7 +740,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/FDI7.TM.json
+++ b/wot-codegen/opc-output-integrated/FDI7.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Foundation_H1",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1371",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Foundation_H1",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Foundation_HSE",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1372",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Foundation_HSE",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profibus_DP",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1373",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profibus_DP",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profibus_PA",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1374",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profibus_PA",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profinet_IO",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1375",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profinet_IO",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_HART",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1376",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.HART",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ISA100_Wireless",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1377",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ISA100_Wireless",
     "dov:isComposite": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_GenericProtocol",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1378",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.GenericProtocol",
     "dov:isComposite": true,
     "links": [
       {
@@ -243,7 +243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Foundation_H1",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1380",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Foundation_H1",
     "dov:isComposite": true,
     "links": [
       {
@@ -317,7 +317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Foundation_HSE",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1424",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Foundation_HSE",
     "dov:isComposite": true,
     "links": [
       {
@@ -382,7 +382,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Profibus_DP",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1467",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Profibus_DP",
     "dov:isComposite": true,
     "links": [
       {
@@ -430,7 +430,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Profinet_IO",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1509",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Profinet_IO",
     "dov:isComposite": true,
     "links": [
       {
@@ -522,7 +522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP5",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1554",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP5",
     "dov:isComposite": true,
     "links": [
       {
@@ -641,7 +641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP6",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1601",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP6",
     "dov:isComposite": true,
     "links": [
       {
@@ -760,7 +760,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP7",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1648",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP7",
     "dov:isComposite": true,
     "links": [
       {
@@ -879,7 +879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_ISA100_Wireless",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1695",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_ISA100_Wireless",
     "dov:isComposite": true,
     "links": [
       {
@@ -994,7 +994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_GenericConnectionPoint",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1742",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.GenericConnectionPoint",
     "dov:isComposite": true,
     "links": [
       {
@@ -1053,7 +1053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_CommunicationServerType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=11",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.CommunicationServerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1098,7 +1098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=93",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1152,7 +1152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFH1DeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=324",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFH1DeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1191,7 +1191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFH1ServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=997",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFH1ServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1223,7 +1223,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=233",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1255,7 +1255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFHSEDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=452",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFHSEDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1294,7 +1294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFHSEServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1073",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFHSEServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1326,7 +1326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFIBUSDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=580",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFIBUSDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1365,7 +1365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFIBUSServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1149",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFIBUSServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1397,7 +1397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFINETDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=705",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFINETDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1436,7 +1436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFINETServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1222",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFINETServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1468,7 +1468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationHARType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=830",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationHARType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1507,7 +1507,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationHARTServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1295",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationHARTServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1539,7 +1539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationISA100_WirelessDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1788",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationISA100_WirelessDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1572,7 +1572,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationISA100_WirelessServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=2057",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationISA100_WirelessServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1604,7 +1604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationGENERICDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1913",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationGENERICDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1662,7 +1662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationGENERICServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=2133",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationGENERICServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1694,7 +1694,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1720,7 +1720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1765,7 +1765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1821,7 +1821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1892,7 +1892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1914,7 +1914,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -1936,7 +1936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -1958,7 +1958,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -1968,7 +1968,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -1990,7 +1990,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -2083,7 +2083,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2128,7 +2128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2175,7 +2175,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -2237,7 +2237,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2390,7 +2390,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2414,7 +2414,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2617,7 +2617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2638,7 +2638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/FX.AC.TM.json
+++ b/wot-codegen/opc-output-integrated/FX.AC.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AcDescriptorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AcDescriptorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -61,7 +61,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AssetConnectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AssetConnectorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -186,7 +186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ClampBlockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ClampBlockType",
     "dov:isComposite": true,
     "links": [
       {
@@ -306,7 +306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ClampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ClampType",
     "links": [
       {
         "rel": "tm:extends",
@@ -400,7 +400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SlotType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SlotType",
     "dov:isComposite": true,
     "links": [
       {
@@ -477,7 +477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SocketType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SocketType",
     "dov:isComposite": true,
     "links": [
       {
@@ -572,7 +572,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AutomationComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AutomationComponentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -632,7 +632,7 @@
     "schemaDefinitions": {
       "DeviceHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
         "const": {
           "DeviceFailure": 0,
           "DeviceCheckFunction": 1,
@@ -660,7 +660,7 @@
       },
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -688,7 +688,7 @@
       },
       "FxCommandMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FxCommandMask",
         "const": {
           "VerifyAssetCmd": 0,
           "VerifyFunctionalEntityCmd": 1,
@@ -742,7 +742,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -765,7 +765,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -793,7 +793,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -837,7 +837,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConnectionEndpoints", "Remove" ],
           "properties": {
             "ConnectionEndpoints": {
@@ -853,7 +853,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1306",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -876,12 +876,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1303",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CommandMask", "AssetVerifications", "ConnectionEndpointConfigurations", "ReserveCommunicationIds", "CommunicationConfigurations" ],
           "properties": {
             "CommandMask": {
               "title": "FxCommandMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1024",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FxCommandMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -891,7 +891,7 @@
               "items": {
                 "title": "AssetVerificationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1048",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationDataType",
                 "required": [ "AssetToVerify", "VerificationMode", "ExpectedVerificationResult", "ExpectedVerificationVariables", "ExpectedAdditionalVerificationVariables" ],
                 "properties": {
                   "AssetToVerify": {
@@ -899,14 +899,14 @@
                   },
                   "VerificationMode": {
                     "title": "AssetVerificationModeEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "ExpectedVerificationResult": {
                     "title": "AssetVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -916,7 +916,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -934,13 +934,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -971,7 +971,7 @@
               "items": {
                 "title": "ConnectionEndpointConfigurationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1044",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointConfigurationDataType",
                 "required": [ "FunctionalEntityNode", "ConnectionEndpoint", "ExpectedVerificationVariables", "ControlGroups", "ConfigurationData", "CommunicationLinks" ],
                 "properties": {
                   "FunctionalEntityNode": {
@@ -980,12 +980,12 @@
                   "ConnectionEndpoint": {
                     "title": "ConnectionEndpointDefinitionDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointDefinitionDataType",
                     "properties": {
                       "Parameter": {
                         "title": "ConnectionEndpointParameterDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3009",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointParameterDataType",
                         "required": [ "Name", "ConnectionEndpointTypeId", "InputVariableIds", "OutputVariableIds", "IsPersistent", "CleanupTimeout", "RelatedEndpoint", "IsPreconfigured" ],
                         "properties": {
                           "Name": {
@@ -1016,7 +1016,7 @@
                           "RelatedEndpoint": {
                             "title": "RelatedEndpointDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
                             "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
                             "properties": {
                               "Address": {
@@ -1027,7 +1027,7 @@
                                 "items": {
                                   "title": "PortableQualifiedName",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                                  "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                                   "required": [ "NamespaceUri", "Name" ],
                                   "properties": {
                                     "NamespaceUri": {
@@ -1059,13 +1059,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -1099,13 +1099,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -1150,7 +1150,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1304",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetVerificationResults", "ConnectionEndpointConfigurationResults", "ReserveCommunicationIdsResults", "CommunicationConfigurationResults" ],
           "properties": {
             "AssetVerificationResults": {
@@ -1158,7 +1158,7 @@
               "items": {
                 "title": "AssetVerificationResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1038",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultDataType",
                 "required": [ "VerificationStatus", "VerificationResult", "VerificationVariablesErrors", "VerificationAdditionalVariablesErrors" ],
                 "properties": {
                   "VerificationStatus": {
@@ -1166,7 +1166,7 @@
                   },
                   "VerificationResult": {
                     "title": "AssetVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1191,7 +1191,7 @@
               "items": {
                 "title": "ConnectionEndpointConfigurationResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointConfigurationResultDataType",
                 "required": [ "ConnectionEndpointId", "FunctionalEntityNodeResult", "ConnectionEndpointResult", "VerificationResult", "VerificationStatus", "VerificationVariablesErrors", "EstablishControlResult", "ConfigurationDataResult", "ReassignControlResult", "CommunicationLinksResult", "EnableCommunicationResult" ],
                 "properties": {
                   "ConnectionEndpointId": {
@@ -1205,7 +1205,7 @@
                   },
                   "VerificationResult": {
                     "title": "FunctionalEntityVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1274,19 +1274,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "AggregatedHealthDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.AggregatedHealthDataType",
         "required": [ "AggregatedDeviceHealth", "AggregatedOperationalHealth" ],
         "properties": {
           "AggregatedDeviceHealth": {
             "title": "DeviceHealthOptionSet",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "AggregatedOperationalHealth": {
             "title": "OperationalHealthOptionSet",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1310,7 +1310,7 @@
       "AggregatedHealth_AggregatedDeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "DeviceHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1327,7 +1327,7 @@
       "AggregatedHealth_AggregatedOperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1360,19 +1360,19 @@
         "data": {
           "title": "AggregatedHealthDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.AggregatedHealthDataType",
           "required": [ "AggregatedDeviceHealth", "AggregatedOperationalHealth" ],
           "properties": {
             "AggregatedDeviceHealth": {
               "title": "DeviceHealthOptionSet",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "AggregatedOperationalHealth": {
               "title": "OperationalHealthOptionSet",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1392,7 +1392,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "DeviceHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1410,7 +1410,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1435,7 +1435,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AutomationComponentCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AutomationComponentCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1461,7 +1461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_PublisherCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1472,7 +1472,7 @@
     "schemaDefinitions": {
       "FxTimeUnitsEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
         "const": {
           "Nanosecond": 0,
           "Microsecond": 1,
@@ -1559,7 +1559,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -1584,7 +1584,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1611,7 +1611,7 @@
         "items": {
           "title": "PublisherQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherQosDataType",
           "required": [ "QosCategory", "DatagramQos" ],
           "properties": {
             "QosCategory": {
@@ -1677,7 +1677,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -1702,7 +1702,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1725,7 +1725,7 @@
           "items": {
             "title": "PublisherQosDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3011",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherQosDataType",
             "required": [ "QosCategory", "DatagramQos" ],
             "properties": {
               "QosCategory": {
@@ -1759,7 +1759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SubscriberCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1770,7 +1770,7 @@
     "schemaDefinitions": {
       "FxTimeUnitsEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
         "const": {
           "Nanosecond": 0,
           "Microsecond": 1,
@@ -1857,7 +1857,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -1882,7 +1882,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1909,7 +1909,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -1934,7 +1934,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1961,7 +1961,7 @@
         "items": {
           "title": "SubscriberQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberQosDataType",
           "required": [ "QosCategory", "DatagramQos" ],
           "properties": {
             "QosCategory": {
@@ -2027,7 +2027,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -2052,7 +2052,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2075,7 +2075,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -2100,7 +2100,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2123,7 +2123,7 @@
           "items": {
             "title": "SubscriberQosDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberQosDataType",
             "required": [ "QosCategory", "DatagramQos" ],
             "properties": {
               "QosCategory": {
@@ -2157,7 +2157,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AuditUaFxEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AuditUaFxEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2184,7 +2184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AuditConnectionCleanupEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AuditConnectionCleanupEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2214,7 +2214,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "RelatedEndpointDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
         "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
         "properties": {
           "Address": {
@@ -2225,7 +2225,7 @@
             "items": {
               "title": "PortableQualifiedName",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
               "required": [ "NamespaceUri", "Name" ],
               "properties": {
                 "NamespaceUri": {
@@ -2285,7 +2285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IAssetExtensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IAssetExtensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2323,7 +2323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IAssetRevisionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IAssetRevisionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2334,7 +2334,7 @@
     "schemaDefinitions": {
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -2357,7 +2357,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -2401,14 +2401,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1422",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "type": "array",
               "items": {
                 "title": "AssetVerificationModeEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2419,7 +2419,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2436,12 +2436,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1423",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2553,7 +2553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IFunctionalEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IFunctionalEntityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2636,7 +2636,7 @@
     "schemaDefinitions": {
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -2664,7 +2664,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -2708,7 +2708,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1420",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExpectedVerificationVariables" ],
           "properties": {
             "ExpectedVerificationVariables": {
@@ -2716,13 +2716,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -2749,12 +2749,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1421",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "FunctionalEntityVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2783,7 +2783,7 @@
         "items": {
           "title": "ApplicationIdentifierDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationIdentifierDataType",
           "required": [ "Name", "UniqueIdentifier" ],
           "properties": {
             "Name": {
@@ -2792,7 +2792,7 @@
             "UniqueIdentifier": {
               "title": "ApplicationId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationId",
               "properties": {
                 "IdNumeric": {
                   "type": "integer",
@@ -2849,7 +2849,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -2907,7 +2907,7 @@
       "OperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2926,7 +2926,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2950,7 +2950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FunctionalEntityCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FunctionalEntityCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2976,7 +2976,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConfigurationDataFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConfigurationDataFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2991,7 +2991,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6398",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariablesToClear" ],
           "properties": {
             "VariablesToClear": {
@@ -3004,7 +3004,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -3027,7 +3027,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "StoredVariables" ],
           "properties": {
             "StoredVariables": {
@@ -3035,13 +3035,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -3078,7 +3078,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariablesToStore" ],
           "properties": {
             "VariablesToStore": {
@@ -3091,7 +3091,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -3125,7 +3125,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConnectionEndpointsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3143,7 +3143,7 @@
     "schemaDefinitions": {
       "CommHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
         "const": {
           "CommInitial": 0,
           "CommPreOperational": 1,
@@ -3183,7 +3183,7 @@
       "CommHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "CommHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3202,7 +3202,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "CommHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3226,7 +3226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConnectionEndpointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3243,7 +3243,7 @@
     "schemaDefinitions": {
       "ConnectionEndpointStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
         "const": {
           "Initial": 0,
           "Ready": 1,
@@ -3392,7 +3392,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "RelatedEndpointDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
         "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
         "properties": {
           "Address": {
@@ -3403,7 +3403,7 @@
             "items": {
               "title": "PortableQualifiedName",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
               "required": [ "NamespaceUri", "Name" ],
               "properties": {
                 "NamespaceUri": {
@@ -3436,7 +3436,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "ConnectionEndpointStatusEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3528,7 +3528,7 @@
         "data": {
           "title": "RelatedEndpointDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
           "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
           "properties": {
             "Address": {
@@ -3539,7 +3539,7 @@
               "items": {
                 "title": "PortableQualifiedName",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                 "required": [ "NamespaceUri", "Name" ],
                 "properties": {
                   "NamespaceUri": {
@@ -3568,7 +3568,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "ConnectionEndpointStatusEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3592,7 +3592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlGroupsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlGroupsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3625,7 +3625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3676,7 +3676,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6093",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LockContext" ],
           "properties": {
             "LockContext": {
@@ -3686,7 +3686,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6094",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LockStatus" ],
           "properties": {
             "LockStatus": {
@@ -3708,7 +3708,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6366",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LockContext" ],
           "properties": {
             "LockContext": {
@@ -3718,7 +3718,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LockStatus" ],
           "properties": {
             "LockStatus": {
@@ -3778,7 +3778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlItemFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlItemFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3840,7 +3840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_InputsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.InputsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3879,7 +3879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_OutputsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.OutputsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3918,7 +3918,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_PubSubConnectionEndpointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.PubSubConnectionEndpointType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3930,7 +3930,7 @@
     "schemaDefinitions": {
       "PubSubConnectionEndpointModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
         "const": {
           "PublisherSubscriber": 1,
           "Publisher": 2,
@@ -3975,7 +3975,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "PubSubConnectionEndpointModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3999,7 +3999,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "PubSubConnectionEndpointModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4023,7 +4023,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FunctionalEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FunctionalEntityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4113,7 +4113,7 @@
     "schemaDefinitions": {
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -4141,7 +4141,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -4185,7 +4185,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1358",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExpectedVerificationVariables" ],
           "properties": {
             "ExpectedVerificationVariables": {
@@ -4193,13 +4193,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -4226,12 +4226,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1359",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "FunctionalEntityVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4260,7 +4260,7 @@
         "items": {
           "title": "ApplicationIdentifierDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationIdentifierDataType",
           "required": [ "Name", "UniqueIdentifier" ],
           "properties": {
             "Name": {
@@ -4269,7 +4269,7 @@
             "UniqueIdentifier": {
               "title": "ApplicationId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationId",
               "properties": {
                 "IdNumeric": {
                   "type": "integer",
@@ -4326,7 +4326,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -4384,7 +4384,7 @@
       "OperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4403,7 +4403,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4427,7 +4427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FxAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4456,7 +4456,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -4489,7 +4489,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -4512,7 +4512,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -4561,12 +4561,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1356",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables", "ExpectedAdditionalVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "title": "AssetVerificationModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4576,7 +4576,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -4594,13 +4594,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -4627,12 +4627,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1357",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors", "VerificationAdditionalVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4734,7 +4734,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5004,7 +5004,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5028,7 +5028,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -5049,7 +5049,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5070,7 +5070,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -5091,7 +5091,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -5103,7 +5103,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -5124,7 +5124,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -5136,7 +5136,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -5157,7 +5157,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -5174,7 +5174,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -5194,7 +5194,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -5220,7 +5220,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -5341,7 +5341,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5367,7 +5367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19352",
+    "dov:typeRef": "org.opcfoundation.UA.LogObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5378,7 +5378,7 @@
     "schemaDefinitions": {
       "LogRecordMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+        "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
         "const": {
           "EventType": 0,
           "SourceNode": 1,
@@ -5416,7 +5416,7 @@
       "GetRecords": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartTime", "EndTime", "MaxReturnRecords", "MinimumSeverity", "RequestMask", "ContinuationPointIn" ],
           "properties": {
             "StartTime": {
@@ -5439,7 +5439,7 @@
             },
             "RequestMask": {
               "title": "LogRecordMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5452,13 +5452,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "ContinuationPointOut" ],
           "properties": {
             "Results": {
               "title": "LogRecordsDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19745",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordsDataType",
               "required": [ "LogRecordArray" ],
               "properties": {
                 "LogRecordArray": {
@@ -5466,7 +5466,7 @@
                   "items": {
                     "title": "LogRecord",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19361",
+                    "dov:typeRef": "org.opcfoundation.UA.LogRecord",
                     "required": [ "Time", "Severity", "Message" ],
                     "properties": {
                       "Time": {
@@ -5493,7 +5493,7 @@
                       "TraceContext": {
                         "title": "TraceContextDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19747",
+                        "dov:typeRef": "org.opcfoundation.UA.TraceContextDataType",
                         "required": [ "ParentSpanId", "ParentIdentifier" ],
                         "properties": {
                           "ParentSpanId": {
@@ -5511,7 +5511,7 @@
                         "items": {
                           "title": "NameValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19748",
+                          "dov:typeRef": "org.opcfoundation.UA.NameValuePair",
                           "required": [ "Name", "Value" ],
                           "properties": {
                             "Name": {
@@ -5596,7 +5596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5697,7 +5697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5793,7 +5793,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -5897,7 +5897,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5923,7 +5923,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5994,7 +5994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6016,7 +6016,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -6038,7 +6038,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -6060,7 +6060,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -6070,7 +6070,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -6092,7 +6092,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/FX.CM.TM.json
+++ b/wot-codegen/opc-output-integrated/FX.CM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_AssetVerificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1247",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.AssetVerificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -47,7 +47,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -93,12 +93,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -115,7 +115,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -123,13 +123,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -149,7 +149,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -186,18 +186,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -214,7 +214,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -222,13 +222,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -248,7 +248,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -297,7 +297,7 @@
       "ExpectedVerificationResult": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "AssetVerificationResultEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -321,18 +321,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -349,7 +349,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -357,13 +357,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -383,7 +383,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -432,7 +432,7 @@
       "VerificationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "AssetVerificationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -457,12 +457,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -479,7 +479,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -487,13 +487,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -513,7 +513,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -546,18 +546,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -574,7 +574,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -582,13 +582,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -608,7 +608,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -653,7 +653,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "AssetVerificationResultEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -673,18 +673,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -701,7 +701,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -709,13 +709,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -735,7 +735,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -780,7 +780,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "AssetVerificationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -804,7 +804,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_AutomationComponentConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1246",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.AutomationComponentConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -851,12 +851,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -873,7 +873,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -881,13 +881,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -907,7 +907,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -945,12 +945,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -967,7 +967,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -975,13 +975,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1001,7 +1001,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1038,7 +1038,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CommunicationModelConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationModelConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1064,7 +1064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CloseConnectionErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CloseConnectionErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1091,7 +1091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_EstablishConnectionErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.EstablishConnectionErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1118,7 +1118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1130,7 +1130,7 @@
     "schemaDefinitions": {
       "FxProcessEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "const": {
           "ActionEstablishConnectionsEnabled": 0,
           "ActionEstablishConnectionsDisabled": 1,
@@ -1185,7 +1185,7 @@
       "Action": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "FxProcessEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1250,7 +1250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingFailedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingFailedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1277,7 +1277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingStartedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingStartedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1304,7 +1304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingSucceededEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingSucceededEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1331,7 +1331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CommunicationFlowConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1357,7 +1357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_PubSubCommunicationFlowConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PubSubCommunicationFlowConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1375,7 +1375,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -1422,7 +1422,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "NetworkAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+        "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
         "required": [ "NetworkInterface" ],
         "properties": {
           "NetworkInterface": {
@@ -1482,7 +1482,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "CommunicationFlowQosDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowQosDataType",
         "required": [ "QosCategory", "TransmitQos", "ReceiveQos" ],
         "properties": {
           "QosCategory": {
@@ -1535,7 +1535,7 @@
       "SecurityMode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1577,7 +1577,7 @@
         "data": {
           "title": "NetworkAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
           "required": [ "NetworkInterface" ],
           "properties": {
             "NetworkInterface": {
@@ -1625,7 +1625,7 @@
         "data": {
           "title": "CommunicationFlowQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowQosDataType",
           "required": [ "QosCategory", "TransmitQos", "ReceiveQos" ],
           "properties": {
             "QosCategory": {
@@ -1670,7 +1670,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "MessageSecurityMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+          "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1707,7 +1707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_SubscriberConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.SubscriberConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1741,7 +1741,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "NetworkAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+        "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
         "required": [ "NetworkInterface" ],
         "properties": {
           "NetworkInterface": {
@@ -1807,7 +1807,7 @@
         "data": {
           "title": "NetworkAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
           "required": [ "NetworkInterface" ],
           "properties": {
             "NetworkInterface": {
@@ -1864,7 +1864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_PubSubCommunicationModelConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PubSubCommunicationModelConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1876,7 +1876,7 @@
     "schemaDefinitions": {
       "PubSubConfigurationRefMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
         "const": {
           "ElementAdd": 0,
           "ElementMatch": 1,
@@ -1936,7 +1936,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -1948,7 +1948,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -1972,7 +1972,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -1996,7 +1996,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -2020,7 +2020,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -2121,12 +2121,12 @@
         "items": {
           "title": "PubSubConfigurationRefDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
           "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
           "properties": {
             "ConfigurationMask": {
               "title": "PubSubConfigurationRefMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2168,18 +2168,18 @@
         "items": {
           "title": "PubSubConfigurationValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
           "required": [ "ConfigurationElement", "Name", "Identifier" ],
           "properties": {
             "ConfigurationElement": {
               "title": "PubSubConfigurationRefDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
               "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
               "properties": {
                 "ConfigurationMask": {
                   "title": "PubSubConfigurationRefMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                  "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2248,7 +2248,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PubSubConfiguration2DataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23602",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfiguration2DataType",
         "required": [ "SubscribedDataSets", "DataSetClasses", "DefaultSecurityKeyServices", "SecurityGroups", "PubSubKeyPushTargets", "ConfigurationVersion", "ConfigurationProperties" ],
         "properties": {
           "SubscribedDataSets": {
@@ -2256,7 +2256,7 @@
             "items": {
               "title": "StandaloneSubscribedDataSetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+              "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
               "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -2271,7 +2271,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -2285,7 +2285,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -2296,7 +2296,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -2336,7 +2336,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -2359,7 +2359,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -2387,7 +2387,7 @@
             "items": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -2401,7 +2401,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -2412,7 +2412,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2452,7 +2452,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -2475,7 +2475,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -2498,7 +2498,7 @@
             "items": {
               "title": "EndpointDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
               "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
               "properties": {
                 "EndpointUrl": {
@@ -2507,7 +2507,7 @@
                 "Server": {
                   "title": "ApplicationDescription",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                   "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                   "properties": {
                     "ApplicationUri": {
@@ -2521,7 +2521,7 @@
                     },
                     "ApplicationType": {
                       "title": "ApplicationType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                      "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2546,7 +2546,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2559,7 +2559,7 @@
                   "items": {
                     "title": "UserTokenPolicy",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                     "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                     "properties": {
                       "PolicyId": {
@@ -2567,7 +2567,7 @@
                       },
                       "TokenType": {
                         "title": "UserTokenType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2600,7 +2600,7 @@
             "items": {
               "title": "SecurityGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+              "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
               "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
               "properties": {
                 "Name": {
@@ -2637,7 +2637,7 @@
                   "items": {
                     "title": "RolePermissionType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                    "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                     "required": [ "RoleId", "Permissions" ],
                     "properties": {
                       "RoleId": {
@@ -2645,7 +2645,7 @@
                       },
                       "Permissions": {
                         "title": "PermissionType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2658,7 +2658,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -2679,7 +2679,7 @@
             "items": {
               "title": "PubSubKeyPushTargetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
               "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
               "properties": {
                 "ApplicationUri": {
@@ -2700,7 +2700,7 @@
                 "UserTokenType": {
                   "title": "UserTokenPolicy",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                   "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                   "properties": {
                     "PolicyId": {
@@ -2708,7 +2708,7 @@
                     },
                     "TokenType": {
                       "title": "UserTokenType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                      "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2738,7 +2738,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -2770,7 +2770,7 @@
             "items": {
               "title": "KeyValuePair",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
               "required": [ "Key", "Value" ],
               "properties": {
                 "Key": {
@@ -2804,7 +2804,7 @@
         "items": {
           "title": "NodeIdTranslationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.NodeIdTranslationDataType",
           "required": [ "NodePlaceholder", "PortableNode" ],
           "properties": {
             "NodePlaceholder": {
@@ -2813,12 +2813,12 @@
             "PortableNode": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -2835,7 +2835,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -2843,13 +2843,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2869,7 +2869,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2912,12 +2912,12 @@
           "items": {
             "title": "PubSubConfigurationRefDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
             "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
             "properties": {
               "ConfigurationMask": {
                 "title": "PubSubConfigurationRefMask",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2955,18 +2955,18 @@
           "items": {
             "title": "PubSubConfigurationValueDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
             "required": [ "ConfigurationElement", "Name", "Identifier" ],
             "properties": {
               "ConfigurationElement": {
                 "title": "PubSubConfigurationRefDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                 "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                 "properties": {
                   "ConfigurationMask": {
                     "title": "PubSubConfigurationRefMask",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3027,7 +3027,7 @@
         "data": {
           "title": "PubSubConfiguration2DataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23602",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfiguration2DataType",
           "required": [ "SubscribedDataSets", "DataSetClasses", "DefaultSecurityKeyServices", "SecurityGroups", "PubSubKeyPushTargets", "ConfigurationVersion", "ConfigurationProperties" ],
           "properties": {
             "SubscribedDataSets": {
@@ -3035,7 +3035,7 @@
               "items": {
                 "title": "StandaloneSubscribedDataSetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+                "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
                 "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
                 "properties": {
                   "Name": {
@@ -3050,7 +3050,7 @@
                   "DataSetMetaData": {
                     "title": "DataSetMetaDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                     "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                     "properties": {
                       "Name": {
@@ -3064,7 +3064,7 @@
                         "items": {
                           "title": "FieldMetaData",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                          "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                           "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                           "properties": {
                             "Name": {
@@ -3075,7 +3075,7 @@
                             },
                             "FieldFlags": {
                               "title": "DataSetFieldFlags",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -3115,7 +3115,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -3138,7 +3138,7 @@
                       "ConfigurationVersion": {
                         "title": "ConfigurationVersionDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                        "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                         "required": [ "MajorVersion", "MinorVersion" ],
                         "properties": {
                           "MajorVersion": {
@@ -3166,7 +3166,7 @@
               "items": {
                 "title": "DataSetMetaDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                 "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                 "properties": {
                   "Name": {
@@ -3180,7 +3180,7 @@
                     "items": {
                       "title": "FieldMetaData",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                      "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                       "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                       "properties": {
                         "Name": {
@@ -3191,7 +3191,7 @@
                         },
                         "FieldFlags": {
                           "title": "DataSetFieldFlags",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3231,7 +3231,7 @@
                           "items": {
                             "title": "KeyValuePair",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                            "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                             "required": [ "Key", "Value" ],
                             "properties": {
                               "Key": {
@@ -3254,7 +3254,7 @@
                   "ConfigurationVersion": {
                     "title": "ConfigurationVersionDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                    "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                     "required": [ "MajorVersion", "MinorVersion" ],
                     "properties": {
                       "MajorVersion": {
@@ -3277,7 +3277,7 @@
               "items": {
                 "title": "EndpointDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                 "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                 "properties": {
                   "EndpointUrl": {
@@ -3286,7 +3286,7 @@
                   "Server": {
                     "title": "ApplicationDescription",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                     "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                     "properties": {
                       "ApplicationUri": {
@@ -3300,7 +3300,7 @@
                       },
                       "ApplicationType": {
                         "title": "ApplicationType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -3325,7 +3325,7 @@
                   },
                   "SecurityMode": {
                     "title": "MessageSecurityMode",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                    "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3338,7 +3338,7 @@
                     "items": {
                       "title": "UserTokenPolicy",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                      "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                       "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                       "properties": {
                         "PolicyId": {
@@ -3346,7 +3346,7 @@
                         },
                         "TokenType": {
                           "title": "UserTokenType",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                          "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3379,7 +3379,7 @@
               "items": {
                 "title": "SecurityGroupDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+                "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
                 "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
                 "properties": {
                   "Name": {
@@ -3416,7 +3416,7 @@
                     "items": {
                       "title": "RolePermissionType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                      "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                       "required": [ "RoleId", "Permissions" ],
                       "properties": {
                         "RoleId": {
@@ -3424,7 +3424,7 @@
                         },
                         "Permissions": {
                           "title": "PermissionType",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                          "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3437,7 +3437,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -3458,7 +3458,7 @@
               "items": {
                 "title": "PubSubKeyPushTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
                 "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
                 "properties": {
                   "ApplicationUri": {
@@ -3479,7 +3479,7 @@
                   "UserTokenType": {
                     "title": "UserTokenPolicy",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                     "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                     "properties": {
                       "PolicyId": {
@@ -3487,7 +3487,7 @@
                       },
                       "TokenType": {
                         "title": "UserTokenType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -3517,7 +3517,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -3549,7 +3549,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -3579,7 +3579,7 @@
           "items": {
             "title": "NodeIdTranslationDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.NodeIdTranslationDataType",
             "required": [ "NodePlaceholder", "PortableNode" ],
             "properties": {
               "NodePlaceholder": {
@@ -3588,12 +3588,12 @@
               "PortableNode": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3610,7 +3610,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -3618,13 +3618,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3644,7 +3644,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3684,7 +3684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3728,7 +3728,7 @@
     "schemaDefinitions": {
       "LastActivityMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
         "const": {
           "EstablishEnabled": 0,
           "EstablishDisabled": 1,
@@ -3771,7 +3771,7 @@
       },
       "ConnectionStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
         "const": {
           "ConnectionNotMonitored": 0,
           "ConnectionNotEstablished": 1,
@@ -3814,7 +3814,7 @@
       },
       "FxErrorEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
         "const": {
           "NoError": 0,
           "UnknownStatus": 1,
@@ -3947,7 +3947,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -3971,7 +3971,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -4072,7 +4072,7 @@
         "items": {
           "title": "ConnectionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionDiagnosticsDataType",
           "required": [ "Name", "LastActivity", "ConnectionState", "ErrorEndpoint1", "Endpoint1Status", "ErrorEndpoint2", "Endpoint2Status" ],
           "properties": {
             "Name": {
@@ -4081,21 +4081,21 @@
             },
             "LastActivity": {
               "title": "LastActivityMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "ConnectionState": {
               "title": "ConnectionStateEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "ErrorEndpoint1": {
               "title": "FxErrorEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4105,7 +4105,7 @@
             },
             "ErrorEndpoint2": {
               "title": "FxErrorEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4142,7 +4142,7 @@
         "items": {
           "title": "PubSubKeyPushTargetDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
           "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
           "properties": {
             "ApplicationUri": {
@@ -4163,7 +4163,7 @@
             "UserTokenType": {
               "title": "UserTokenPolicy",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
               "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
               "properties": {
                 "PolicyId": {
@@ -4171,7 +4171,7 @@
                 },
                 "TokenType": {
                   "title": "UserTokenType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -4201,7 +4201,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -4259,7 +4259,7 @@
         "items": {
           "title": "SecurityGroupDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+          "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
           "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
           "properties": {
             "Name": {
@@ -4296,7 +4296,7 @@
               "items": {
                 "title": "RolePermissionType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                 "required": [ "RoleId", "Permissions" ],
                 "properties": {
                   "RoleId": {
@@ -4304,7 +4304,7 @@
                   },
                   "Permissions": {
                     "title": "PermissionType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                    "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4317,7 +4317,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -4350,7 +4350,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "SecurityKeyServerAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.SecurityKeyServerAddressDataType",
         "required": [ "Address", "SecurityPolicyUri", "ServerUri", "UsePushModel" ],
         "properties": {
           "Address": {
@@ -4476,7 +4476,7 @@
           "items": {
             "title": "ConnectionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionDiagnosticsDataType",
             "required": [ "Name", "LastActivity", "ConnectionState", "ErrorEndpoint1", "Endpoint1Status", "ErrorEndpoint2", "Endpoint2Status" ],
             "properties": {
               "Name": {
@@ -4485,21 +4485,21 @@
               },
               "LastActivity": {
                 "title": "LastActivityMask",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "ConnectionState": {
                 "title": "ConnectionStateEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "ErrorEndpoint1": {
                 "title": "FxErrorEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4509,7 +4509,7 @@
               },
               "ErrorEndpoint2": {
                 "title": "FxErrorEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4535,7 +4535,7 @@
           "items": {
             "title": "PubSubKeyPushTargetDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
             "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
             "properties": {
               "ApplicationUri": {
@@ -4556,7 +4556,7 @@
               "UserTokenType": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -4564,7 +4564,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4594,7 +4594,7 @@
                 "items": {
                   "title": "KeyValuePair",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                  "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                   "required": [ "Key", "Value" ],
                   "properties": {
                     "Key": {
@@ -4631,7 +4631,7 @@
           "items": {
             "title": "SecurityGroupDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+            "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
             "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
             "properties": {
               "Name": {
@@ -4668,7 +4668,7 @@
                 "items": {
                   "title": "RolePermissionType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                  "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                   "required": [ "RoleId", "Permissions" ],
                   "properties": {
                     "RoleId": {
@@ -4676,7 +4676,7 @@
                     },
                     "Permissions": {
                       "title": "PermissionType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                      "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -4689,7 +4689,7 @@
                 "items": {
                   "title": "KeyValuePair",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                  "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                   "required": [ "Key", "Value" ],
                   "properties": {
                     "Key": {
@@ -4718,7 +4718,7 @@
         "data": {
           "title": "SecurityKeyServerAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.SecurityKeyServerAddressDataType",
           "required": [ "Address", "SecurityPolicyUri", "ServerUri", "UsePushModel" ],
           "properties": {
             "Address": {
@@ -4826,7 +4826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4864,7 +4864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionEndpointConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1129",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionEndpointConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4906,18 +4906,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -4934,7 +4934,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -4942,13 +4942,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -4968,7 +4968,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5020,12 +5020,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5042,7 +5042,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5050,13 +5050,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5076,7 +5076,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5114,18 +5114,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -5142,7 +5142,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -5150,13 +5150,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5176,7 +5176,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5226,12 +5226,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -5248,7 +5248,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -5256,13 +5256,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -5282,7 +5282,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -5322,18 +5322,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -5350,7 +5350,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -5358,13 +5358,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5384,7 +5384,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5432,12 +5432,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -5454,7 +5454,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -5462,13 +5462,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5488,7 +5488,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5522,18 +5522,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -5550,7 +5550,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -5558,13 +5558,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5584,7 +5584,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5630,12 +5630,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5652,7 +5652,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5660,13 +5660,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5686,7 +5686,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5723,7 +5723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionEndpointParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1261",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionEndpointParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5792,7 +5792,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeId",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
         "required": [ "NamespaceUri", "Identifier" ],
         "properties": {
           "NamespaceUri": {
@@ -5822,12 +5822,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5844,7 +5844,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5852,13 +5852,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5878,7 +5878,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5967,12 +5967,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5989,7 +5989,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5997,13 +5997,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6023,7 +6023,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6123,7 +6123,7 @@
         "data": {
           "title": "PortableNodeId",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
           "required": [ "NamespaceUri", "Identifier" ],
           "properties": {
             "NamespaceUri": {
@@ -6149,12 +6149,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -6171,7 +6171,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -6179,13 +6179,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6205,7 +6205,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6278,12 +6278,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -6300,7 +6300,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -6308,13 +6308,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6334,7 +6334,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6398,7 +6398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6501,7 +6501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6542,7 +6542,7 @@
     "schemaDefinitions": {
       "FxEditEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxEditEnum",
         "const": {
           "StartEditing": 0,
           "CommitUpdates": 1,
@@ -6565,7 +6565,7 @@
       },
       "FxProcessEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "const": {
           "ActionEstablishConnectionsEnabled": 0,
           "ActionEstablishConnectionsDisabled": 1,
@@ -6624,12 +6624,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1265",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Action", "ConnectionConfigurationSets" ],
           "properties": {
             "Action": {
               "title": "FxEditEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3001",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxEditEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6644,7 +6644,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1267",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -6667,12 +6667,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1270",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Action", "ConnectionConfigurationSets" ],
           "properties": {
             "Action": {
               "title": "FxProcessEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6687,7 +6687,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1271",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -6751,7 +6751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6777,7 +6777,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6788,7 +6788,7 @@
     "schemaDefinitions": {
       "ConnectionConfigurationSetOperation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=13054",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetOperation",
         "const": {
           "ElementAdd": 0,
           "ElementRemove": 1,
@@ -6815,7 +6815,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=16032",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "RequireCompleteUpdate", "Operations" ],
           "properties": {
             "FileHandle": {
@@ -6830,7 +6830,7 @@
               "type": "array",
               "items": {
                 "title": "ConnectionConfigurationSetOperation",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=13054",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetOperation",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -6840,7 +6840,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=16033",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ChangesApplied", "OperationResults", "ConfigurationObjects" ],
           "properties": {
             "ChangesApplied": {
@@ -6883,7 +6883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -6904,7 +6904,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseLogEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19362",
+    "dov:typeRef": "org.opcfoundation.UA.BaseLogEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6982,7 +6982,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7078,7 +7078,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -7182,7 +7182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7324,7 +7324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7409,7 +7409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7455,7 +7455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7501,7 +7501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7527,7 +7527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7548,7 +7548,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -7569,7 +7569,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -7581,7 +7581,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -7602,7 +7602,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -7614,7 +7614,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -7635,7 +7635,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -7652,7 +7652,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -7672,7 +7672,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -7698,7 +7698,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -7819,7 +7819,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19352",
+    "dov:typeRef": "org.opcfoundation.UA.LogObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7830,7 +7830,7 @@
     "schemaDefinitions": {
       "LogRecordMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+        "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
         "const": {
           "EventType": 0,
           "SourceNode": 1,
@@ -7868,7 +7868,7 @@
       "GetRecords": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartTime", "EndTime", "MaxReturnRecords", "MinimumSeverity", "RequestMask", "ContinuationPointIn" ],
           "properties": {
             "StartTime": {
@@ -7891,7 +7891,7 @@
             },
             "RequestMask": {
               "title": "LogRecordMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7904,13 +7904,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "ContinuationPointOut" ],
           "properties": {
             "Results": {
               "title": "LogRecordsDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19745",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordsDataType",
               "required": [ "LogRecordArray" ],
               "properties": {
                 "LogRecordArray": {
@@ -7918,7 +7918,7 @@
                   "items": {
                     "title": "LogRecord",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19361",
+                    "dov:typeRef": "org.opcfoundation.UA.LogRecord",
                     "required": [ "Time", "Severity", "Message" ],
                     "properties": {
                       "Time": {
@@ -7945,7 +7945,7 @@
                       "TraceContext": {
                         "title": "TraceContextDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19747",
+                        "dov:typeRef": "org.opcfoundation.UA.TraceContextDataType",
                         "required": [ "ParentSpanId", "ParentIdentifier" ],
                         "properties": {
                           "ParentSpanId": {
@@ -7963,7 +7963,7 @@
                         "items": {
                           "title": "NameValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19748",
+                          "dov:typeRef": "org.opcfoundation.UA.NameValuePair",
                           "required": [ "Name", "Value" ],
                           "properties": {
                             "Name": {
@@ -8048,7 +8048,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8070,7 +8070,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -8092,7 +8092,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -8114,7 +8114,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -8124,7 +8124,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -8146,7 +8146,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -8239,7 +8239,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/FX.Data.TM.json
+++ b/wot-codegen/opc-output-integrated/FX.Data.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_Data_AuditUpdateMethodResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AuditUpdateMethodResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -68,7 +68,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateMethodEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2127",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateMethodEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -154,7 +154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -255,7 +255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -351,7 +351,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -455,7 +455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/GDS.TM.json
+++ b/wot-codegen/opc-output-integrated/GDS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_DirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.DirectoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26,7 +26,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -54,7 +54,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -64,7 +64,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=17",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Applications" ],
           "properties": {
             "Applications": {
@@ -72,7 +72,7 @@
               "items": {
                 "title": "ApplicationRecordDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+                "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
                 "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
                 "properties": {
                   "ApplicationId": {
@@ -83,7 +83,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -126,7 +126,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=211",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -136,13 +136,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=212",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -153,7 +153,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -195,7 +195,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=869",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartingRecordId", "MaxRecordsToReturn", "ApplicationName", "ApplicationUri", "ApplicationType", "ProductUri", "Capabilities" ],
           "properties": {
             "StartingRecordId": {
@@ -232,7 +232,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=870",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LastCounterResetTime", "NextRecordId", "Applications" ],
           "properties": {
             "LastCounterResetTime": {
@@ -249,7 +249,7 @@
               "items": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -263,7 +263,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -297,7 +297,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=24",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartingRecordId", "MaxRecordsToReturn", "ApplicationName", "ApplicationUri", "ProductUri", "ServerCapabilities" ],
           "properties": {
             "StartingRecordId": {
@@ -329,7 +329,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=25",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LastCounterResetTime", "Servers" ],
           "properties": {
             "LastCounterResetTime": {
@@ -341,7 +341,7 @@
               "items": {
                 "title": "ServerOnNetwork",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12189",
+                "dov:typeRef": "org.opcfoundation.UA.ServerOnNetwork",
                 "required": [ "RecordId", "ServerName", "DiscoveryUrl", "ServerCapabilities" ],
                 "properties": {
                   "RecordId": {
@@ -378,13 +378,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=19",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -395,7 +395,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -427,7 +427,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=20",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -447,7 +447,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=22",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -467,13 +467,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=189",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -484,7 +484,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -537,7 +537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_ApplicationRegistrationChangedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRegistrationChangedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -564,7 +564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=63",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -579,7 +579,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=160",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Certificate" ],
           "properties": {
             "Certificate": {
@@ -590,7 +590,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateStatus", "ValidityTime" ],
           "properties": {
             "CertificateStatus": {
@@ -614,7 +614,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=86",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "RequestId" ],
           "properties": {
             "ApplicationId": {
@@ -627,7 +627,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=87",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificate", "PrivateKey", "IssuerCertificates" ],
           "properties": {
             "Certificate": {
@@ -659,7 +659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=370",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -669,7 +669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=371",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateGroupIds" ],
           "properties": {
             "CertificateGroupIds": {
@@ -692,7 +692,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=90",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId" ],
           "properties": {
             "ApplicationId": {
@@ -705,7 +705,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=108",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateTypeIds", "Certificates" ],
           "properties": {
             "CertificateTypeIds": {
@@ -735,7 +735,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=223",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId" ],
           "properties": {
             "ApplicationId": {
@@ -751,7 +751,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=224",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateRequired" ],
           "properties": {
             "UpdateRequired": {
@@ -771,7 +771,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId" ],
           "properties": {
             "ApplicationId": {
@@ -784,7 +784,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=199",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TrustListId" ],
           "properties": {
             "TrustListId": {
@@ -804,7 +804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=15004",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "Certificate" ],
           "properties": {
             "ApplicationId": {
@@ -828,7 +828,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=77",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId", "SubjectName", "DomainNames", "PrivateKeyFormat", "PrivateKeyPassword" ],
           "properties": {
             "ApplicationId": {
@@ -859,7 +859,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=78",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -879,7 +879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=80",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId", "CertificateRequest" ],
           "properties": {
             "ApplicationId": {
@@ -899,7 +899,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=81",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -930,7 +930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=91",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -988,7 +988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateDeliveredAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=109",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateDeliveredAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1046,7 +1046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateRevokedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateRevokedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1073,7 +1073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialManagementFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialManagementFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1105,7 +1105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1127,7 +1127,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1027",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestId", "CancelRequest" ],
           "properties": {
             "RequestId": {
@@ -1140,7 +1140,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1028",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CredentialId", "CredentialSecret", "CertificateThumbprint", "SecurityPolicyUri", "GrantedRoles" ],
           "properties": {
             "CredentialId": {
@@ -1176,7 +1176,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId" ],
           "properties": {
             "CredentialId": {
@@ -1196,7 +1196,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri", "PublicKey", "SecurityPolicyUri", "RequestedRoles" ],
           "properties": {
             "ApplicationUri": {
@@ -1219,7 +1219,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -1292,7 +1292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1319,7 +1319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialDeliveredAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialDeliveredAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1346,7 +1346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialRevokedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialRevokedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1373,7 +1373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AuthorizationServicesFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=233",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AuthorizationServicesFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1399,7 +1399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AuthorizationServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=966",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AuthorizationServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1410,7 +1410,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -1445,7 +1445,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1005",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ServiceUri", "ServiceCertificate", "UserTokenPolicies" ],
           "properties": {
             "ServiceUri": {
@@ -1460,7 +1460,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -1468,7 +1468,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1499,13 +1499,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=970",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IdentityToken", "ResourceId" ],
           "properties": {
             "IdentityToken": {
               "title": "UserIdentityToken",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=316",
+              "dov:typeRef": "org.opcfoundation.UA.UserIdentityToken",
               "required": [ "PolicyId" ],
               "properties": {
                 "PolicyId": {
@@ -1520,7 +1520,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=971",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AccessToken" ],
           "properties": {
             "AccessToken": {
@@ -1569,7 +1569,7 @@
         "items": {
           "title": "UserTokenPolicy",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
           "properties": {
             "PolicyId": {
@@ -1577,7 +1577,7 @@
             },
             "TokenType": {
               "title": "UserTokenType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1615,7 +1615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AccessTokenIssuedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=975",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AccessTokenIssuedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1642,7 +1642,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1668,7 +1668,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1689,7 +1689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateMethodEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2127",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateMethodEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1775,7 +1775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1876,7 +1876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1972,7 +1972,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2076,7 +2076,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18011",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialAuditEventType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/GMS.TM.json
+++ b/wot-codegen/opc-output-integrated/GMS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorWarningAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorWarningAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_IntermediateResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.IntermediateResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -126,7 +126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CharacteristicType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CharacteristicType",
     "links": [
       {
         "rel": "tm:extends",
@@ -137,7 +137,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -296,7 +296,7 @@
       "ResultEvaluation": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ResultEvaluationEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -425,7 +425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_MultiSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.MultiSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -443,7 +443,7 @@
     "schemaDefinitions": {
       "ToolAlignmentState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "const": {
           "Fixed": 0,
           "Indexed": 1,
@@ -480,7 +480,7 @@
       "Alignment": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolAlignmentState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -548,7 +548,7 @@
     "schemaDefinitions": {
       "ToolAlignmentState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "const": {
           "Fixed": 0,
           "Indexed": 1,
@@ -568,7 +568,7 @@
       },
       "ToolIsQualifiedStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolIsQualifiedStatus",
         "const": {
           "Qualified": 0,
           "Imprecise": 1,
@@ -627,7 +627,7 @@
       "Alignment": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolAlignmentState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -708,7 +708,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -743,7 +743,7 @@
       "IsQualifiedStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolIsQualifiedStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolIsQualifiedStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -862,7 +862,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CorrectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CorrectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1109,7 +1109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_LoadingMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.LoadingMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1214,7 +1214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_ToolMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.ToolMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1272,7 +1272,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1316,7 +1316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1383,7 +1383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1440,7 +1440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1478,7 +1478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1510,7 +1510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1522,7 +1522,7 @@
     "schemaDefinitions": {
       "MeasurementReasonEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.MeasurementReasonEnum",
         "const": {
           "ContinuousMeasurements": 0,
           "SpecialMeasurement": 1,
@@ -1606,7 +1606,7 @@
       "MeasurementReason": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "MeasurementReasonEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.MeasurementReasonEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1655,7 +1655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSPartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSPartType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1906,7 +1906,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CalibrationPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CalibrationPrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2035,7 +2035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_RotaryTableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.RotaryTableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2109,7 +2109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorExchangeRackType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorExchangeRackType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2164,7 +2164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_TipExchangeRackType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.TipExchangeRackType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2219,7 +2219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2461,7 +2461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2500,7 +2500,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -2531,7 +2531,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2559,7 +2559,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2587,7 +2587,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2624,7 +2624,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2652,7 +2652,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2977,7 +2977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3004,7 +3004,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3029,7 +3029,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3135,7 +3135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3162,7 +3162,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3187,7 +3187,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -3209,7 +3209,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -3468,7 +3468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3564,7 +3564,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3668,7 +3668,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3689,7 +3689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3773,7 +3773,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3792,7 +3792,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -3812,7 +3812,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -3844,7 +3844,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3887,7 +3887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4029,7 +4029,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4114,7 +4114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4160,7 +4160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4206,7 +4206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4232,7 +4232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4258,7 +4258,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4272,7 +4272,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -4282,7 +4282,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -4301,7 +4301,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -4314,7 +4314,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -4338,7 +4338,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -4357,7 +4357,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -4376,7 +4376,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -4407,7 +4407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4452,7 +4452,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4478,7 +4478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4506,7 +4506,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -4518,7 +4518,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -4537,7 +4537,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -4547,7 +4547,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -4574,7 +4574,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -4584,7 +4584,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -4632,7 +4632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4751,7 +4751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4763,7 +4763,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -4816,14 +4816,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -4889,7 +4889,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -4924,7 +4924,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4979,14 +4979,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -5052,7 +5052,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -5087,7 +5087,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -5140,7 +5140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5164,7 +5164,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -5193,7 +5193,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -5289,7 +5289,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -5303,7 +5303,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -5335,7 +5335,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -5348,7 +5348,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -5361,14 +5361,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -5434,7 +5434,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -5469,7 +5469,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -5524,7 +5524,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -5541,7 +5541,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -5554,14 +5554,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -5627,7 +5627,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -5662,7 +5662,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -5716,14 +5716,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5731,12 +5731,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -5758,7 +5758,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -5766,7 +5766,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -5803,7 +5803,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -5839,7 +5839,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -5852,7 +5852,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5903,7 +5903,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5917,14 +5917,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -5937,7 +5937,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -5979,7 +5979,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=51",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6012,7 +6012,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6075,7 +6075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6092,7 +6092,7 @@
     "schemaDefinitions": {
       "ToolManagement": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "const": {
           "NumberBased": 0,
           "GroupBased": 1,
@@ -6160,7 +6160,7 @@
       "ControlIdentifierInterpretation": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ToolManagement",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6246,7 +6246,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ToolManagement",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6310,7 +6310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6355,7 +6355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6381,7 +6381,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6413,7 +6413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6463,7 +6463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6495,7 +6495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6558,7 +6558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6602,7 +6602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6619,7 +6619,7 @@
     "schemaDefinitions": {
       "MachineOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "const": {
           "Manual": 0,
           "Automatic": 1,
@@ -6700,7 +6700,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "MachineOperationMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6761,7 +6761,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "MachineOperationMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6800,7 +6800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ObligationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ObligationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6888,7 +6888,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6926,7 +6926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6952,7 +6952,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7002,7 +7002,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7048,7 +7048,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7092,7 +7092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7186,7 +7186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=59",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7250,7 +7250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7366,7 +7366,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7541,7 +7541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7567,7 +7567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7634,7 +7634,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=29",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7855,7 +7855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7971,7 +7971,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=56",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7988,7 +7988,7 @@
     "schemaDefinitions": {
       "PartQuality": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "const": {
           "CapabilityUnavailable": 0,
           "Good": 1,
@@ -8021,7 +8021,7 @@
       },
       "ProcessIrregularity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "const": {
           "CapabilityUnavailable": 0,
           "Detected": 1,
@@ -8102,7 +8102,7 @@
       "PartQuality": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "PartQuality",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8118,7 +8118,7 @@
       "ProcessIrregularity": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ProcessIrregularity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8137,7 +8137,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "PartQuality",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8154,7 +8154,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ProcessIrregularity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8178,7 +8178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8294,7 +8294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8376,7 +8376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8628,7 +8628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8699,7 +8699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8723,7 +8723,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -8770,7 +8770,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8801,7 +8801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8812,7 +8812,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -8859,7 +8859,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8904,7 +8904,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8944,7 +8944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/GPOS.TM.json
+++ b/wot-codegen/opc-output-integrated/GPOS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GPOS_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.GPOS.ZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -83,14 +83,14 @@
           "title": "GroundControlPointDataType",
           "description": "Defines a pair of coordinates - local and global - to allow geo-references from local coordinate to a global coordinate system",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.RSL.GroundControlPointDataType",
           "required": [ "GlobalPosition", "LocalPosition" ],
           "properties": {
             "GlobalPosition": {
               "title": "S3DGeographicCoordinateDataType",
               "description": "Represents a geographic coordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
               "required": [ "Longitude", "Latitude" ],
               "properties": {
                 "Longitude": {
@@ -117,7 +117,7 @@
               "title": "ThreeDCartesianCoordinates",
               "description": "Local position in metric coordinates (in meter)",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
               "required": [ "X", "Y", "Z" ],
               "properties": {
                 "X": {
@@ -176,7 +176,7 @@
         "title": "S3DGeographicCoordinateDataType",
         "description": "Represents a geographic coordinate",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
         "required": [ "Longitude", "Latitude" ],
         "properties": {
           "Longitude": {
@@ -279,14 +279,14 @@
             "title": "GroundControlPointDataType",
             "description": "Defines a pair of coordinates - local and global - to allow geo-references from local coordinate to a global coordinate system",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.RSL.GroundControlPointDataType",
             "required": [ "GlobalPosition", "LocalPosition" ],
             "properties": {
               "GlobalPosition": {
                 "title": "S3DGeographicCoordinateDataType",
                 "description": "Represents a geographic coordinate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
                 "required": [ "Longitude", "Latitude" ],
                 "properties": {
                   "Longitude": {
@@ -313,7 +313,7 @@
                 "title": "ThreeDCartesianCoordinates",
                 "description": "Local position in metric coordinates (in meter)",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+                "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
                 "required": [ "X", "Y", "Z" ],
                 "properties": {
                   "X": {
@@ -350,7 +350,7 @@
           "title": "S3DGeographicCoordinateDataType",
           "description": "Represents a geographic coordinate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
           "required": [ "Longitude", "Latitude" ],
           "properties": {
             "Longitude": {
@@ -408,7 +408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/Glass.Flat.TM.json
+++ b/wot-codegen/opc-output-integrated/Glass.Flat.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -115,7 +115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_CommunicationErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CommunicationErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -142,7 +142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -169,7 +169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialExitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialExitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialMissingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialMissingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -223,7 +223,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialReceivedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialReceivedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -250,7 +250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_IntermediateStepEvent",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.IntermediateStepEvent",
     "dov:isEvent": true,
     "links": [
       {
@@ -323,7 +323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InterruptedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InterruptedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -379,7 +379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_EmergencyButtonPressedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.EmergencyButtonPressedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -406,7 +406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MotorTemperatureTooHighEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MotorTemperatureTooHighEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -433,7 +433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_OpenSecurityFenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.OpenSecurityFenceType",
     "dov:isEvent": true,
     "links": [
       {
@@ -460,7 +460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_OutOfJobEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.OutOfJobEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -487,7 +487,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProcessParameterOutOfRangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProcessParameterOutOfRangeType",
     "dov:isEvent": true,
     "links": [
       {
@@ -514,7 +514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ToolMissingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ToolMissingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -541,7 +541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_JobMovedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.JobMovedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -614,7 +614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_BaseMaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.BaseMaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -861,7 +861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_AssemblyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.AssemblyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -887,7 +887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_FoilType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FoilType",
     "dov:isComposite": true,
     "links": [
       {
@@ -966,7 +966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GasMixType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GasMixType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1114,7 +1114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1125,7 +1125,7 @@
     "schemaDefinitions": {
       "CoatingClassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoatingClassEnumeration",
         "const": {
           "HardCoating": 0,
           "SoftCoating": 1,
@@ -1149,7 +1149,7 @@
       },
       "SignificantSideEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SignificantSideEnumeration",
         "const": {
           "Indifferent": 0,
           "Top": 1,
@@ -1169,7 +1169,7 @@
       },
       "StructureAlignmentEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.StructureAlignmentEnumeration",
         "const": {
           "Indifferent": 0,
           "Longitudinal": 1,
@@ -1228,7 +1228,7 @@
       "CoatingClass": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "CoatingClassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoatingClassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1334,7 +1334,7 @@
       "SignificantSide": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "SignificantSideEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SignificantSideEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1355,7 +1355,7 @@
       "StructureAlignment": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "StructureAlignmentEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.StructureAlignmentEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1553,7 +1553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_PackagingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.PackagingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1688,7 +1688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_SealingMaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SealingMaterialType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1824,7 +1824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_SpacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1836,7 +1836,7 @@
     "schemaDefinitions": {
       "SpacerMaterialClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerMaterialClass",
         "const": {
           "Other": 0,
           "Metalic": 1,
@@ -1943,7 +1943,7 @@
       "SpacerMaterialClass": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "SpacerMaterialClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerMaterialClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2036,7 +2036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ConfigurationRulesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ConfigurationRulesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2047,7 +2047,7 @@
     "schemaDefinitions": {
       "CoordinateSystemEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoordinateSystemEnumeration",
         "const": {
           "Unknown": 0,
           "System1": 1,
@@ -2111,7 +2111,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -2145,7 +2145,7 @@
         "items": {
           "title": "FileFormatType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FileFormatType",
           "required": [ "Name", "FileExtension", "Version" ],
           "properties": {
             "Name": {
@@ -2171,7 +2171,7 @@
       "MachineProcessingCoordinateSystem": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "CoordinateSystemEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoordinateSystemEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2202,7 +2202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2228,7 +2228,7 @@
         "items": {
           "title": "UserProfileType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.UserProfileType",
           "required": [ "Name", "LoginTime", "Language", "MeasurementFormat", "AccessLevel", "OpcUaUser" ],
           "properties": {
             "Name": {
@@ -2274,7 +2274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ManualFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ManualFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2328,7 +2328,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2379,7 +2379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2412,7 +2412,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Target", "Source", "Before" ],
           "properties": {
             "Target": {
@@ -2438,7 +2438,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6123",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier" ],
           "properties": {
             "Identifier": {
@@ -2458,7 +2458,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "Name", "InputMaterial", "OutputMaterial" ],
           "properties": {
             "Identifier": {
@@ -2483,7 +2483,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -2589,7 +2589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionPlanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionPlanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2615,7 +2615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InstructionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InstructionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2650,7 +2650,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "FileFormatType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FileFormatType",
         "required": [ "Name", "FileExtension", "Version" ],
         "properties": {
           "Name": {
@@ -2690,7 +2690,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionJobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2937,7 +2937,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3094,7 +3094,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InitializingSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InitializingSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3162,7 +3162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_AssemblyJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.AssemblyJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3201,7 +3201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_CuttingJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CuttingJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3240,7 +3240,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProcessingJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProcessingJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3279,7 +3279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3375,7 +3375,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3479,7 +3479,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3500,7 +3500,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3526,7 +3526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3547,7 +3547,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3568,7 +3568,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3580,7 +3580,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -3601,7 +3601,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -3613,7 +3613,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3634,7 +3634,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -3651,7 +3651,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -3671,7 +3671,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -3697,7 +3697,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -3818,7 +3818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3863,7 +3863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4005,7 +4005,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4090,7 +4090,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4136,7 +4136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4182,7 +4182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4208,7 +4208,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4290,7 +4290,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4542,7 +4542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4613,7 +4613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4635,7 +4635,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4657,7 +4657,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4679,7 +4679,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4689,7 +4689,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4711,7 +4711,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/Glass.Flat.v2.TM.json
+++ b/wot-codegen/opc-output-integrated/Glass.Flat.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -119,7 +119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_ConfigurationRulesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ConfigurationRulesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     "schemaDefinitions": {
       "CoordinateSystemEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.CoordinateSystemEnumeration",
         "const": {
           "Unknown": 0,
           "System1": 1,
@@ -194,7 +194,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -228,7 +228,7 @@
         "items": {
           "title": "FileFormatDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.FileFormatDataType",
           "required": [ "Name", "FileExtension", "Version" ],
           "properties": {
             "Name": {
@@ -254,7 +254,7 @@
       "MachineProcessingCoordinateSystem": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/v2/",
         "title": "CoordinateSystemEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.CoordinateSystemEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -285,7 +285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -316,7 +316,7 @@
         "items": {
           "title": "UserProfileDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.UserProfileDataType",
           "required": [ "Name", "LoginTime", "Language", "MeasurementFormat", "AccessLevel", "OpcUaUser" ],
           "properties": {
             "Name": {
@@ -355,7 +355,7 @@
         "items": {
           "title": "ProcessingCategoryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingCategoryDataType",
           "required": [ "ID", "Description", "SupportedParameter", "SupportedAssignment", "SupportedVariable", "SupportsTransformation", "SupportsSubProcessing" ],
           "properties": {
             "ID": {
@@ -369,7 +369,7 @@
               "items": {
                 "title": "ProcessingParameterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingParameterDataType",
                 "required": [ "Name", "Description", "ValueType", "TypicalValue", "Mandatory", "EClass" ],
                 "properties": {
                   "Name": {
@@ -381,7 +381,7 @@
                   "ValueType": {
                     "title": "ValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ValueDataType",
                     "required": [ "Name", "Description", "BaseUnit", "PossibleValue" ],
                     "properties": {
                       "Name": {
@@ -407,7 +407,7 @@
                   "EClass": {
                     "title": "EClassTermDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.EClassTermDataType",
                     "required": [ "ID", "Description", "EClass" ],
                     "properties": {
                       "ID": {
@@ -435,7 +435,7 @@
               "items": {
                 "title": "ProcessingParameterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingParameterDataType",
                 "required": [ "Name", "Description", "ValueType", "TypicalValue", "Mandatory", "EClass" ],
                 "properties": {
                   "Name": {
@@ -447,7 +447,7 @@
                   "ValueType": {
                     "title": "ValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ValueDataType",
                     "required": [ "Name", "Description", "BaseUnit", "PossibleValue" ],
                     "properties": {
                       "Name": {
@@ -473,7 +473,7 @@
                   "EClass": {
                     "title": "EClassTermDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.EClassTermDataType",
                     "required": [ "ID", "Description", "EClass" ],
                     "properties": {
                       "ID": {
@@ -529,7 +529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_ManualFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ManualFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -640,7 +640,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -736,7 +736,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -840,7 +840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -861,7 +861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -887,7 +887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -908,7 +908,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -929,7 +929,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -941,7 +941,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -962,7 +962,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -974,7 +974,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -995,7 +995,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -1012,7 +1012,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -1032,7 +1032,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -1058,7 +1058,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -1179,7 +1179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1193,7 +1193,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -1203,7 +1203,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -1222,7 +1222,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -1235,7 +1235,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1259,7 +1259,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -1278,7 +1278,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -1297,7 +1297,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -1328,7 +1328,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1410,7 +1410,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1662,7 +1662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/I4AAS.TM.json
+++ b/wot-codegen/opc-output-integrated/I4AAS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAdministrativeInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAdministrativeInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -80,7 +80,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAssetAdministrationShellType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetAdministrationShellType",
     "dov:isComposite": true,
     "links": [
       {
@@ -149,7 +149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASConceptDictionaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASConceptDictionaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -175,7 +175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASReferenceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -199,7 +199,7 @@
     "schemaDefinitions": {
       "AASKeyElementsDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyElementsDataType",
         "const": {
           "AccessPermissionRule": 0,
           "AnnotatedRelationshipElement": 1,
@@ -327,7 +327,7 @@
       },
       "AASKeyTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyTypeDataType",
         "const": {
           "IdShort": 0,
           "FragmentId": 1,
@@ -380,12 +380,12 @@
         "items": {
           "title": "AASKeyDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyDataType",
           "required": [ "Type", "Local", "Value", "IdType" ],
           "properties": {
             "Type": {
               "title": "AASKeyElementsDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyElementsDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -398,7 +398,7 @@
             },
             "IdType": {
               "title": "AASKeyTypeDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyTypeDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -432,7 +432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -461,7 +461,7 @@
     "schemaDefinitions": {
       "AASModelingKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "const": {
           "Template": 0,
           "Instance": 1
@@ -496,7 +496,7 @@
       "ModelingKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASModelingKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -527,7 +527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASQualifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASQualifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -544,7 +544,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -668,7 +668,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -699,7 +699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -722,7 +722,7 @@
     "schemaDefinitions": {
       "AASModelingKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "const": {
           "Template": 0,
           "Instance": 1
@@ -774,7 +774,7 @@
       "ModelingKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASModelingKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -805,7 +805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASViewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASViewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -843,7 +843,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -872,7 +872,7 @@
     "schemaDefinitions": {
       "AASAssetKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetKindDataType",
         "const": {
           "Type": 0,
           "Instance": 1
@@ -907,7 +907,7 @@
       "AssetKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASAssetKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -938,7 +938,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASDataSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -964,7 +964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASDataSpecificationIEC61360Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataSpecificationIEC61360Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -1006,7 +1006,7 @@
     "schemaDefinitions": {
       "AASCategoryDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCategoryDataType",
         "const": {
           "CONSTANT": 0,
           "PARAMETER": 1,
@@ -1034,7 +1034,7 @@
       },
       "AASDataTypeIEC61360DataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataTypeIEC61360DataType",
         "const": {
           "BOOLEAN": 0,
           "DATE": 1,
@@ -1102,7 +1102,7 @@
       },
       "AASLevelTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASLevelTypeDataType",
         "const": {
           "Min": 0,
           "Max": 1,
@@ -1147,7 +1147,7 @@
       "Category": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASCategoryDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCategoryDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1168,7 +1168,7 @@
       "DataType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASDataTypeIEC61360DataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataTypeIEC61360DataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1223,7 +1223,7 @@
       "LevelType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASLevelTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASLevelTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1374,7 +1374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIdentifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1385,7 +1385,7 @@
     "schemaDefinitions": {
       "AASIdentifierTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierTypeDataType",
         "const": {
           "IRDI": 0,
           "IRI": 1,
@@ -1442,7 +1442,7 @@
       "IdType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASIdentifierTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1473,7 +1473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_ValueListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.ValueListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1499,7 +1499,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASBlobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASBlobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1532,7 +1532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASCapabilityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCapabilityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1559,7 +1559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1583,7 +1583,7 @@
     "schemaDefinitions": {
       "AASEntityTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityTypeDataType",
         "const": {
           "CoManagedEntity": 0,
           "SelfManagedEntity": 1
@@ -1618,7 +1618,7 @@
       "EntityType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASEntityTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1649,7 +1649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEventType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1676,7 +1676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1755,7 +1755,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASMultiLanguagePropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASMultiLanguagePropertyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1820,7 +1820,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASOperationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1857,7 +1857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASPropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASPropertyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1875,7 +1875,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -1982,7 +1982,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2013,7 +2013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASRangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASRangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2025,7 +2025,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -2150,7 +2150,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2181,7 +2181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASReferenceElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASReferenceElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2214,7 +2214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASRelationshipElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASRelationshipElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2253,7 +2253,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAnnotatedRelationshipElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAnnotatedRelationshipElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2286,7 +2286,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelElementCollectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelElementCollectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2348,7 +2348,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASOrderedSubmodelElementCollectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASOrderedSubmodelElementCollectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2375,7 +2375,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_IAASReferableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.IAASReferableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2431,7 +2431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_IAASIdentifiableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.IAASIdentifiableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2470,7 +2470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASCustomConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCustomConceptDescriptionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2509,7 +2509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIrdiConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIrdiConceptDescriptionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2548,7 +2548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIriConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIriConceptDescriptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2586,7 +2586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2607,7 +2607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2633,7 +2633,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2654,7 +2654,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -2675,7 +2675,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -2687,7 +2687,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -2708,7 +2708,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -2720,7 +2720,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -2741,7 +2741,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -2758,7 +2758,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -2778,7 +2778,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -2804,7 +2804,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -2925,7 +2925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2951,7 +2951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17589",
+    "dov:typeRef": "org.opcfoundation.UA.DictionaryEntryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2983,7 +2983,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IrdiDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17598",
+    "dov:typeRef": "org.opcfoundation.UA.IrdiDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3010,7 +3010,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UriDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17600",
+    "dov:typeRef": "org.opcfoundation.UA.UriDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/IA.TM.json
+++ b/wot-codegen/opc-output-integrated/IA.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_AcousticSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IA.AcousticSignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BaseCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BaseCalibrationTargetCategoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_DynamicCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.IA.DynamicCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -156,7 +156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_OneTimeCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.IA.OneTimeCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ReusableCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ReusableCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -210,7 +210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ReusableDeviceCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ReusableDeviceCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -237,7 +237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -305,7 +305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IAggregateStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IAggregateStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -361,7 +361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IRollingStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IRollingStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -438,7 +438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_CalibrationTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.IA.CalibrationTargetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -577,7 +577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ControlChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ControlChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -588,7 +588,7 @@
     "schemaDefinitions": {
       "SignalColor": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "const": {
           "Off": 0,
           "Red": 1,
@@ -637,7 +637,7 @@
       },
       "SignalModeLight": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "const": {
           "Continuous": 0,
           "Blinking": 1,
@@ -689,7 +689,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalColor",
         "description": "Indicates in what mode (continuously on, blinking, flashing) the channel operates when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -731,7 +731,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalModeLight",
         "description": "Contains a list of audio signals used by this acoustic stacklight element.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -774,7 +774,7 @@
         "data": {
           "title": "SignalColor",
           "description": "Indicates in what mode (continuously on, blinking, flashing) the channel operates when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -808,7 +808,7 @@
         "data": {
           "title": "SignalModeLight",
           "description": "Contains a list of audio signals used by this acoustic stacklight element.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -832,7 +832,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -856,7 +856,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -903,7 +903,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -934,7 +934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -945,7 +945,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -992,7 +992,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1037,7 +1037,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1077,7 +1077,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1103,7 +1103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1121,7 +1121,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -1177,7 +1177,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
         "description": "Contains the health status information of the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1202,7 +1202,7 @@
         "data": {
           "title": "DeviceHealthEnumeration",
           "description": "Contains the health status information of the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1226,7 +1226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1313,7 +1313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementAcousticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementAcousticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1433,7 +1433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementLightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementLightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1451,7 +1451,7 @@
     "schemaDefinitions": {
       "SignalColor": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "const": {
           "Off": 0,
           "Red": 1,
@@ -1500,7 +1500,7 @@
       },
       "SignalModeLight": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "const": {
           "Continuous": 0,
           "Blinking": 1,
@@ -1572,7 +1572,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalColor",
         "description": "Indicates the colour the lamp element has when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1594,7 +1594,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalModeLight",
         "description": "Shows in what way the lamp is used (continuous light, flashing, blinking) when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1616,7 +1616,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "RGBWDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.IA.RGBWDataType",
         "required": [ "Red", "Green", "Blue" ],
         "properties": {
           "Red": {
@@ -1681,7 +1681,7 @@
         "data": {
           "title": "SignalColor",
           "description": "Indicates the colour the lamp element has when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1699,7 +1699,7 @@
         "data": {
           "title": "SignalModeLight",
           "description": "Shows in what way the lamp is used (continuous light, flashing, blinking) when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1717,7 +1717,7 @@
         "data": {
           "title": "RGBWDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.IA.RGBWDataType",
           "required": [ "Red", "Green", "Blue" ],
           "properties": {
             "Red": {
@@ -1765,7 +1765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1786,7 +1786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1812,7 +1812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1838,7 +1838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1883,7 +1883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/IJT.Base.TM.json
+++ b/wot-codegen/opc-output-integrated/IJT.Base.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AcceptedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AcceptedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AddedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1096",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AddedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetConnectedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetConnectedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetDisabledConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetDisabledConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetDisconnectedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetDisconnectedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetEnabledConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetEnabledConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetLocationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetLocationConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_CertificateConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.CertificateConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ConfigurationChangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ConfigurationChangeConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_DataValidationFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DataValidationFailureConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_EntityExpiryWarningConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityExpiryWarningConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -305,7 +305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ErrorConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ErrorConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -332,7 +332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ExpiredEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ExpiredEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -359,7 +359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_HardwareConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.HardwareConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IncompatibleEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IncompatibleEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -413,7 +413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_InputValidationFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.InputValidationFailureConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -440,7 +440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_InvalidEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.InvalidEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemUserLoggedInConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemUserLoggedInConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -494,7 +494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemUserLoggedOutConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemUserLoggedOutConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -521,7 +521,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LicenseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LicenseConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -548,7 +548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LocationInZoneConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LocationInZoneConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -575,7 +575,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LocationOutOfZoneConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LocationOutOfZoneConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -602,7 +602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_MissingEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.MissingEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -629,7 +629,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_NotAvailableEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.NotAvailableEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -656,7 +656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_NotSupportedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.NotSupportedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -683,7 +683,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ReceivedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1105",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReceivedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -710,7 +710,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RejectedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1093",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RejectedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -737,7 +737,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RemovedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1102",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RemovedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -764,7 +764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SelectedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SelectedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -791,7 +791,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SelectedProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SelectedProcessConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -818,7 +818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SoftwareConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SoftwareConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -845,7 +845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_StartedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.StartedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -872,7 +872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_StoppedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.StoppedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -899,7 +899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ThresholdViolationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ThresholdViolationConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -926,7 +926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ThresholdViolationResolvedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ThresholdViolationResolvedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -953,7 +953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_UnacknowledgedResultsConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.UnacknowledgedResultsConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_UpdatedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1099",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.UpdatedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1007,7 +1007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1055,7 +1055,7 @@
           "title": "EntityDataType",
           "description": "This structure provides the identification data for a given entity in the system.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
           "required": [ "EntityId", "EntityType" ],
           "properties": {
             "Name": {
@@ -1148,7 +1148,7 @@
           "title": "ReportedValueDataType",
           "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
           "required": [ "CurrentValue" ],
           "properties": {
             "PhysicalQuantity": {
@@ -1185,7 +1185,7 @@
               "title": "EUInformation",
               "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1242,7 +1242,7 @@
             "title": "EntityDataType",
             "description": "This structure provides the identification data for a given entity in the system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
             "required": [ "EntityId", "EntityType" ],
             "properties": {
               "Name": {
@@ -1339,7 +1339,7 @@
             "title": "ReportedValueDataType",
             "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
             "required": [ "CurrentValue" ],
             "properties": {
               "PhysicalQuantity": {
@@ -1376,7 +1376,7 @@
                 "title": "EUInformation",
                 "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -1418,7 +1418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1466,7 +1466,7 @@
           "title": "EntityDataType",
           "description": "This structure provides the identification data for a given entity in the system.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
           "required": [ "EntityId", "EntityType" ],
           "properties": {
             "Name": {
@@ -1559,7 +1559,7 @@
           "title": "ReportedValueDataType",
           "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
           "required": [ "CurrentValue" ],
           "properties": {
             "PhysicalQuantity": {
@@ -1596,7 +1596,7 @@
               "title": "EUInformation",
               "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1653,7 +1653,7 @@
             "title": "EntityDataType",
             "description": "This structure provides the identification data for a given entity in the system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
             "required": [ "EntityId", "EntityType" ],
             "properties": {
               "Name": {
@@ -1750,7 +1750,7 @@
             "title": "ReportedValueDataType",
             "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
             "required": [ "CurrentValue" ],
             "properties": {
               "PhysicalQuantity": {
@@ -1787,7 +1787,7 @@
                 "title": "EUInformation",
                 "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -1829,7 +1829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1841,7 +1841,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -1894,14 +1894,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -1967,7 +1967,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -2002,7 +2002,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2057,14 +2057,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -2130,7 +2130,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -2165,7 +2165,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RequestedResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RequestedResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2245,7 +2245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IJoiningAdditionalInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IJoiningAdditionalInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2317,7 +2317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IJoiningSystemAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IJoiningSystemAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2367,7 +2367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IAccessoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IAccessoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2399,7 +2399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IBatteryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IBatteryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2431,7 +2431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ICableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ICableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2463,7 +2463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2495,7 +2495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IFeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IFeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2527,7 +2527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IMemoryDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IMemoryDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2559,7 +2559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IPowerSupplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IPowerSupplyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2591,7 +2591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2623,7 +2623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IServoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IServoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISoftwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2681,7 +2681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISubComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISubComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2713,7 +2713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2745,7 +2745,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IVirtualStationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IVirtualStationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2771,7 +2771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2981,7 +2981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningProcessManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3004,7 +3004,7 @@
         "description": "The Method AbortJoiningProcess is used to abort the input joining process if it is under execution.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6368",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "AbortMessage" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3015,7 +3015,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3039,7 +3039,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6369",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3067,7 +3067,7 @@
         "description": "The Method DecrementJoiningProcessCounter used to decrement the counter of the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6360",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "DecrementCount" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3078,7 +3078,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3104,7 +3104,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6361",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3132,7 +3132,7 @@
         "description": "The Method DeleteJoiningProcess is used to delete the input joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6127",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3143,7 +3143,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3163,7 +3163,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6140",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3191,7 +3191,7 @@
         "description": "The Method DeselectJoiningProcess is used to deselect any selected joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6356",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3202,7 +3202,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6357",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3230,7 +3230,7 @@
         "description": "The Method GetJoiningProcess is used to get the joining process based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3245,21 +3245,21 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6449",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcess", "SelectionName", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcess": {
               "title": "JoiningProcessDataType",
               "description": "This structure provides the base container for any joining process in a joining system.   Note: This specification defines the meta data of a JoiningProcess, and the actual content of the Joining Process is application specific.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessDataType",
               "required": [ "JoiningProcessMetaData", "JoiningProcessContent" ],
               "properties": {
                 "JoiningProcessMetaData": {
                   "title": "JoiningProcessMetaDataType",
                   "description": "This structure provides the meta data which describes the joining process.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                   "required": [ "JoiningProcessId" ],
                   "properties": {
                     "JoiningProcessId": {
@@ -3305,7 +3305,7 @@
                         "title": "EntityDataType",
                         "description": "This structure provides the identification data for a given entity in the system.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                         "required": [ "EntityId", "EntityType" ],
                         "properties": {
                           "Name": {
@@ -3378,7 +3378,7 @@
         "description": "The Method GetJoiningProcessList is used to get the list of joining process meta data available in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6348",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3389,7 +3389,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6349",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcessList", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcessList": {
@@ -3399,7 +3399,7 @@
                 "title": "JoiningProcessMetaDataType",
                 "description": "This structure provides the meta data which describes the joining process.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                 "required": [ "JoiningProcessId" ],
                 "properties": {
                   "JoiningProcessId": {
@@ -3445,7 +3445,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -3505,7 +3505,7 @@
         "description": "The Method GetJoiningProcessRevisionList is used to get the list available revisions of a specific joining process based on the joiningProcessOriginId.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6350",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3520,7 +3520,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6351",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcessList", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcessList": {
@@ -3530,7 +3530,7 @@
                 "title": "JoiningProcessMetaDataType",
                 "description": "This structure provides the meta data which describes the joining process.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                 "required": [ "JoiningProcessId" ],
                 "properties": {
                   "JoiningProcessId": {
@@ -3576,7 +3576,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -3636,7 +3636,7 @@
         "description": "The Method GetSelectedJoiningProgram is used to get the selected joining program for a given asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6461",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3647,14 +3647,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6462",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SelectedJoiningProgram", "Status", "StatusMessage" ],
           "properties": {
             "SelectedJoiningProgram": {
               "title": "JoiningProcessMetaDataType",
               "description": "This structure provides the meta data which describes the joining process.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
               "required": [ "JoiningProcessId" ],
               "properties": {
                 "JoiningProcessId": {
@@ -3700,7 +3700,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -3759,7 +3759,7 @@
         "description": "The Method IncrementJoiningProcessCounter is used to increment the counter of the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6358",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "IncrementCount" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3770,7 +3770,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3796,7 +3796,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6359",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3824,7 +3824,7 @@
         "description": "The Method ResetJoiningProcess is used to reset/restart the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6366",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3835,7 +3835,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3855,7 +3855,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3883,7 +3883,7 @@
         "description": "The Method SelectJoiningProcess is used to select the joining process based on the input arguments.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3894,7 +3894,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3914,7 +3914,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3942,7 +3942,7 @@
         "description": "The Method SendJoiningProcess is used to send a joining process to the joining system. It can be used to insert a joining program or joining batch or joining job or any other process applicable to a joining system. It shall overwrite the joining process if it already exists in the joining system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6340",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcess", "SelectionName" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3953,14 +3953,14 @@
               "title": "JoiningProcessDataType",
               "description": "This structure provides the base container for any joining process in a joining system.   Note: This specification defines the meta data of a JoiningProcess, and the actual content of the Joining Process is application specific.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessDataType",
               "required": [ "JoiningProcessMetaData", "JoiningProcessContent" ],
               "properties": {
                 "JoiningProcessMetaData": {
                   "title": "JoiningProcessMetaDataType",
                   "description": "This structure provides the meta data which describes the joining process.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                   "required": [ "JoiningProcessId" ],
                   "properties": {
                     "JoiningProcessId": {
@@ -4006,7 +4006,7 @@
                         "title": "EntityDataType",
                         "description": "This structure provides the identification data for a given entity in the system.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                         "required": [ "EntityId", "EntityType" ],
                         "properties": {
                           "Name": {
@@ -4058,7 +4058,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6347",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4086,7 +4086,7 @@
         "description": "The Method SetJoiningProcessCounter is used to set the counter of a sequential joining processes (such as Job, etc.) to the given input value.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6362",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "CounterValue" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4097,7 +4097,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4123,7 +4123,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6363",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4151,7 +4151,7 @@
         "description": "The Method SetJoiningProcessMapping is used to set the mapping of the joining process in a joining system. It can be used to map a joining process to a selection name.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6352",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4162,7 +4162,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4182,7 +4182,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6353",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4210,7 +4210,7 @@
         "description": "The Method SetJoiningProcessSize is used to set the size of the batch joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6364",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "MaxCounterSize" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4221,7 +4221,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4247,7 +4247,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6365",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4275,7 +4275,7 @@
         "description": "The Method StartJoiningProcess is used to start the input joining process.   Note: It is not intended to be used in a hard real-time use case.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6374",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "AssociatedEntities" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4286,7 +4286,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4309,7 +4309,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -4345,7 +4345,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6375",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4373,7 +4373,7 @@
         "description": "The Method StartSelectedJoining is used to start the selected joining. The joining operation can be selected using SelectJoiningProcess or SelectJoint.   Note: It is not intended to be used in a hard real-time use case.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6408",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "DeselectAfterJoining" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4388,7 +4388,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6409",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4438,7 +4438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemAssetMethodSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemAssetMethodSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4461,7 +4461,7 @@
         "description": "The Method DisconnectAsset is used to disconnect or connect the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6047",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Disconnect" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4476,7 +4476,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4504,7 +4504,7 @@
         "description": "The Method EnableAsset is used to Enable or Disable a given asset. It is mostly applicable for Tool.  The joining system can report a respective event when an asset is enabled or disabled.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Enable" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4519,7 +4519,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6046",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4547,7 +4547,7 @@
         "description": "The Method ExecuteOperation is an application specific interface to execute any generic operations supported by a joining system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "OperationType", "OperationText", "VendorName" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4572,7 +4572,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4600,7 +4600,7 @@
         "description": "The Method GetErrorInformation is used to get the error information based on the input identifier. The details returned from the joining system is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6088",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "ErrorId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4615,7 +4615,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorContent", "Status", "StatusMessage" ],
           "properties": {
             "ErrorContent": {
@@ -4647,7 +4647,7 @@
         "description": "The Method GetFeedbackFileList is used to get the list of feedback files from the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4658,7 +4658,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FeedbackFileList", "Status", "StatusMessage" ],
           "properties": {
             "FeedbackFileList": {
@@ -4693,7 +4693,7 @@
         "description": "The Method GetIdentifiers is used to get the list of identifiers available in the system which were managed by external systems.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierNames" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4711,7 +4711,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntityList", "Status", "StatusMessage" ],
           "properties": {
             "EntityList": {
@@ -4721,7 +4721,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -4778,7 +4778,7 @@
         "description": "The Method GetIOSignals is used to get the list of available signals from the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "SignalIdList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4796,7 +4796,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SignalList", "Status", "StatusMessage" ],
           "properties": {
             "SignalList": {
@@ -4806,7 +4806,7 @@
                 "title": "SignalDataType",
                 "description": "This structure contains the signal information which is used in SetIOSignals and GetIOSignals methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SignalDataType",
                 "required": [ "SignalId", "SignalValue", "SignalDescription", "SignalType" ],
                 "properties": {
                   "SignalId": {
@@ -4855,7 +4855,7 @@
         "description": "The Method RebootAsset is used to reboot an asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4866,7 +4866,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4894,7 +4894,7 @@
         "description": "The Method ResetIdentifiers is used to reset the specified identifiers.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6081",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierList", "ResetAll", "ResetLatest" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4920,7 +4920,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6085",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4948,7 +4948,7 @@
         "description": "The Method SendFeedback is used to send any type of feedback to a given asset. The feedback can be a text input or other types of feedback supported by the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "FeedbackType", "FeedbackText", "FeedbackFile" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4973,7 +4973,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5001,7 +5001,7 @@
         "description": "The Method SendIdentifiers is used to send one or more identifiers to the joining system.  These identifiers can be used for selection of a joining process, etc.  These identifiers can often be part of the generated result.   The input argument to this method is an array of EntityDataType structure where every entity in the joining system can be associated to a specific type for filtering.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "EntityList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5015,7 +5015,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -5051,7 +5051,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6078",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5079,7 +5079,7 @@
         "description": "The Method SendTextIdentifiers is used to send one or more identifiers to a joining system.   These identifiers can be used for selection of a joining process, etc.  These identifiers can often be part of the generated result.   Note: The decision on which set of identifiers are used for the selection of a joining process and which set of identifiers should be part of the generated result is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6079",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5097,7 +5097,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6080",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5125,7 +5125,7 @@
         "description": "The Method SetCalibration is used to set the calibration information of a given asset.   It is intended to set the basic calibration information and does not cover the certification process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "CalibrationData" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5136,7 +5136,7 @@
               "title": "CalibrationDataType",
               "description": "This structure contains the Calibration information. It is used as an input argument in SetCalibration method.  Note: The input data sent in SetCalibration shall be updated in the respective parameters of the asset under Maintenance/Calibration.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.CalibrationDataType",
               "required": [ "LastCalibration" ],
               "properties": {
                 "LastCalibration": {
@@ -5173,7 +5173,7 @@
                   "title": "EUInformation",
                   "description": "It defines the engineering unit of the value.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -5198,7 +5198,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5226,7 +5226,7 @@
         "description": "The Method SetIOSignals is used to set a list of IO signals of the asset. The type of operations mapped to each signal is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "SignalList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5240,7 +5240,7 @@
                 "title": "SignalDataType",
                 "description": "This structure contains the signal information which is used in SetIOSignals and GetIOSignals methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SignalDataType",
                 "required": [ "SignalId", "SignalValue", "SignalDescription", "SignalType" ],
                 "properties": {
                   "SignalId": {
@@ -5268,7 +5268,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SignalStatusList", "Status", "StatusMessage" ],
           "properties": {
             "SignalStatusList": {
@@ -5305,7 +5305,7 @@
         "description": "The Method SetOfflineTimer is used to set the offline timer for the asset to determine how long the asset can perform the joining operations in an offline mode.   Note: If an asset performs the joining operation in offline mode after setting the offline timer, the corresponding results generated shall have the IsGeneratedOffline flag set to TRUE.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "OfflineTimer" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5321,7 +5321,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5349,7 +5349,7 @@
         "description": "The Method SetTime is used to set the time of the asset manually. It is recommended to be used only when an asset does not have automated time synchronization.  The joining system can report a respective event when the time is configured manually using this method.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6406",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "InputTime" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5365,7 +5365,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6407",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5415,7 +5415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5454,7 +5454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JointManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5477,7 +5477,7 @@
         "description": "The Method DeleteJoint is used to delete the joint based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5496,7 +5496,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6151",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5524,7 +5524,7 @@
         "description": "The Method DeleteJointComponent is used to delete the joint component based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6162",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponentId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5539,7 +5539,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6163",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5567,7 +5567,7 @@
         "description": "The Method DeleteJointDesign is used to delete the joint design based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6153",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesignId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5582,7 +5582,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5610,7 +5610,7 @@
         "description": "The Method GetJoint is used to get the joint based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6310",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5625,14 +5625,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6311",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Joint", "Status", "StatusMessage" ],
           "properties": {
             "Joint": {
               "title": "JointDataType",
               "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
               "required": [ "JointId" ],
               "properties": {
                 "JointId": {
@@ -5686,7 +5686,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -5749,7 +5749,7 @@
         "description": "The Method GetJointComponent is used to get the joint component based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6314",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponentId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5764,14 +5764,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6315",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointComponent", "Status", "StatusMessage" ],
           "properties": {
             "JointComponent": {
               "title": "JointComponentDataType",
               "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
               "required": [ "JointComponentId" ],
               "properties": {
                 "JointComponentId": {
@@ -5825,7 +5825,7 @@
         "description": "The Method GetJointComponentList is used to get the list of available joint components in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5836,7 +5836,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointComponentList", "Status", "StatusMessage" ],
           "properties": {
             "JointComponentList": {
@@ -5846,7 +5846,7 @@
                 "title": "JointComponentDataType",
                 "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
                 "required": [ "JointComponentId" ],
                 "properties": {
                   "JointComponentId": {
@@ -5901,7 +5901,7 @@
         "description": "The Method GetJointDesign is used to get the joint design based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6312",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesignId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5916,14 +5916,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6313",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointDesign", "Status", "StatusMessage" ],
           "properties": {
             "JointDesign": {
               "title": "JointDesignDataType",
               "description": "This structure provides the design information of a given joint.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
               "required": [ "JointDesignId" ],
               "properties": {
                 "JointDesignId": {
@@ -5945,7 +5945,7 @@
                     "title": "DesignValueDataType",
                     "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                     "properties": {
                       "PhysicalQuantity": {
                         "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -5965,7 +5965,7 @@
                         "title": "EUInformation",
                         "description": "It is the engineering unit of the design value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6021,7 +6021,7 @@
         "description": "The Method GetJointDesignList is used to get the list of available joint designs in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6304",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6032,7 +6032,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointDesignList", "Status", "StatusMessage" ],
           "properties": {
             "JointDesignList": {
@@ -6042,7 +6042,7 @@
                 "title": "JointDesignDataType",
                 "description": "This structure provides the design information of a given joint.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
                 "required": [ "JointDesignId" ],
                 "properties": {
                   "JointDesignId": {
@@ -6064,7 +6064,7 @@
                       "title": "DesignValueDataType",
                       "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                       "properties": {
                         "PhysicalQuantity": {
                           "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -6084,7 +6084,7 @@
                           "title": "EUInformation",
                           "description": "It is the engineering unit of the design value.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6141,7 +6141,7 @@
         "description": "The Method GetJointList is used to get the list of available joints in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6235",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6152,7 +6152,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6303",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointList", "Status", "StatusMessage" ],
           "properties": {
             "JointList": {
@@ -6162,7 +6162,7 @@
                 "title": "JointDataType",
                 "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
                 "required": [ "JointId" ],
                 "properties": {
                   "JointId": {
@@ -6216,7 +6216,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -6280,7 +6280,7 @@
         "description": "The Method GetJointRevisionList is used to get the list available revisions of a specific joint based on the JointOriginId.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6308",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6295,7 +6295,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6309",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointList", "Status", "StatusMessage" ],
           "properties": {
             "JointList": {
@@ -6305,7 +6305,7 @@
                 "title": "JointDataType",
                 "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
                 "required": [ "JointId" ],
                 "properties": {
                   "JointId": {
@@ -6359,7 +6359,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -6423,7 +6423,7 @@
         "description": "The Method SelectJoint is used to select the joint and the associated joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6229",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6442,7 +6442,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6230",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6470,7 +6470,7 @@
         "description": "The Method SendJoint is used to send a joint to a joining system. If the input joint already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6183",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Joint" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6481,7 +6481,7 @@
               "title": "JointDataType",
               "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
               "required": [ "JointId" ],
               "properties": {
                 "JointId": {
@@ -6535,7 +6535,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -6577,7 +6577,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6605,7 +6605,7 @@
         "description": "The Method SendJointComponent is used to send a joint component to a joining system. If the input joint component already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponent" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6616,7 +6616,7 @@
               "title": "JointComponentDataType",
               "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
               "required": [ "JointComponentId" ],
               "properties": {
                 "JointComponentId": {
@@ -6649,7 +6649,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6228",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6677,7 +6677,7 @@
         "description": "The Method SendJointDesign is used to send a joint design to a joining system. If the input joint design already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesign" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6688,7 +6688,7 @@
               "title": "JointDesignDataType",
               "description": "This structure provides the design information of a given joint.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
               "required": [ "JointDesignId" ],
               "properties": {
                 "JointDesignId": {
@@ -6710,7 +6710,7 @@
                     "title": "DesignValueDataType",
                     "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                     "properties": {
                       "PhysicalQuantity": {
                         "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -6730,7 +6730,7 @@
                         "title": "EUInformation",
                         "description": "It is the engineering unit of the design value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6765,7 +6765,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6815,7 +6815,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6836,7 +6836,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IJT/Base/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6459",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromSequenceNumber", "ToSequenceNumber", "FromTime", "ToTime", "RequestedMinimumDurationBetweenResults" ],
           "properties": {
             "FromSequenceNumber": {
@@ -6870,7 +6870,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6460",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedMinimumDurationBetweenResults", "Status", "StatusMessage" ],
           "properties": {
             "RevisedMinimumDurationBetweenResults": {
@@ -6902,7 +6902,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IJT/Base/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6470",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaxResults", "RequestedMinimumDurationBetweenResults" ],
           "properties": {
             "MaxResults": {
@@ -6920,7 +6920,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6471",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedMinimumDurationBetweenResults", "UnacknowledgedResultCount", "Status", "StatusMessage" ],
           "properties": {
             "RevisedMinimumDurationBetweenResults": {
@@ -6969,7 +6969,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6995,7 +6995,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -7016,7 +7016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7043,7 +7043,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7068,7 +7068,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7174,7 +7174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7201,7 +7201,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7226,7 +7226,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -7248,7 +7248,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -7507,7 +7507,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7603,7 +7603,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -7707,7 +7707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7733,7 +7733,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7759,7 +7759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7787,7 +7787,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -7799,7 +7799,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -7818,7 +7818,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -7828,7 +7828,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -7855,7 +7855,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -7865,7 +7865,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -7913,7 +7913,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8032,7 +8032,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8174,7 +8174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8259,7 +8259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8285,7 +8285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8331,7 +8331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8377,7 +8377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8389,7 +8389,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -8442,14 +8442,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -8515,7 +8515,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -8550,7 +8550,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -8605,14 +8605,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -8678,7 +8678,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -8713,7 +8713,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -8766,7 +8766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8790,7 +8790,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -8819,7 +8819,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -8915,7 +8915,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -8929,7 +8929,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -8961,7 +8961,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -8974,7 +8974,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -8987,14 +8987,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -9060,7 +9060,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -9095,7 +9095,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -9150,7 +9150,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -9167,7 +9167,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -9180,14 +9180,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -9253,7 +9253,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -9288,7 +9288,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -9342,14 +9342,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -9357,12 +9357,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -9384,7 +9384,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -9392,7 +9392,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -9429,7 +9429,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -9465,7 +9465,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -9478,7 +9478,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -9529,7 +9529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9543,14 +9543,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -9563,7 +9563,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -9605,7 +9605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/IJT.Tightening.TM.json
+++ b/wot-codegen/opc-output-integrated/IJT.Tightening.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Tightening_ITighteningToolParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Tightening/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Tightening.ITighteningToolParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -395,7 +395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -421,7 +421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/IOLink.TM.json
+++ b/wot-codegen/opc-output-integrated/IOLink.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_DeviceVariantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.DeviceVariantType",
     "links": [
       {
         "rel": "tm:extends",
@@ -304,7 +304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -330,7 +330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -356,7 +356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -383,7 +383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -409,7 +409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -454,7 +454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -481,7 +481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -520,7 +520,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -551,7 +551,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -579,7 +579,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -607,7 +607,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -644,7 +644,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -672,7 +672,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -997,7 +997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1024,7 +1024,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1049,7 +1049,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1155,7 +1155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1182,7 +1182,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1207,7 +1207,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -1229,7 +1229,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -1488,7 +1488,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1584,7 +1584,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -1688,7 +1688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1709,7 +1709,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1793,7 +1793,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1812,7 +1812,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -1832,7 +1832,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -1864,7 +1864,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1907,7 +1907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2049,7 +2049,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2134,7 +2134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2180,7 +2180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2226,7 +2226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2252,7 +2252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2278,7 +2278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2334,7 +2334,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2405,7 +2405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2427,7 +2427,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -2449,7 +2449,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -2471,7 +2471,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -2481,7 +2481,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -2503,7 +2503,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/ISA95.TM.json
+++ b/wot-codegen/opc-output-integrated/ISA95.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95ClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4957",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95ClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95ObjectType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4958",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95ObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95TestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4959",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95TestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_QualificationTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4977",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.QualificationTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PersonnelClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4996",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PersonnelClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -145,7 +145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PersonType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5131",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PersonType",
     "dov:isComposite": true,
     "links": [
       {
@@ -186,7 +186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetCapabilityTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5057",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetCapabilityTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -212,7 +212,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5078",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -245,7 +245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5085",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -331,7 +331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentCapabilityTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5015",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentCapabilityTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -357,7 +357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5034",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -390,7 +390,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5040",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -483,7 +483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5172",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -509,7 +509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5209",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -549,7 +549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialDefinitionType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5219",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialDefinitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -589,7 +589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialLotType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5232",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialLotType",
     "links": [
       {
         "rel": "tm:extends",
@@ -636,7 +636,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialSublotType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5259",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialSublotType",
     "links": [
       {
         "rel": "tm:extends",
@@ -683,7 +683,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/LADS.TM.json
+++ b/wot-codegen/opc-output-integrated/LADS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSComponentsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSOperationCountersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSOperationCountersType",
     "dov:isComposite": true,
     "links": [
       {
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -113,7 +113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -139,7 +139,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -165,7 +165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramTemplateSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramTemplateSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -191,7 +191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramTemplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramTemplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -217,7 +217,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SupportedPropertiesSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SupportedPropertiesSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -243,7 +243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SupportedPropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SupportedPropertyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -269,7 +269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultFileSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultFileSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -295,7 +295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -321,7 +321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -347,7 +347,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultType",
     "links": [
       {
         "rel": "tm:extends",
@@ -373,7 +373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_CoverStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.CoverStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -399,7 +399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSDeviceStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSDeviceStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -425,7 +425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -451,7 +451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_RunningStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.RunningStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -477,7 +477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MaintenanceSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MaintenanceSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -503,7 +503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MaintenanceTaskType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MaintenanceTaskType",
     "dov:isEvent": true,
     "links": [
       {
@@ -530,7 +530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -557,7 +557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -609,7 +609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -635,7 +635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_BaseControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.BaseControlFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -661,7 +661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -688,7 +688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithTotalizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithTotalizerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -715,7 +715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_DiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.DiscreteControlFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -741,7 +741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiStateDiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiStateDiscreteControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -768,7 +768,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TwoStateDiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TwoStateDiscreteControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -795,7 +795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_BaseSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.BaseSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -821,7 +821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogScalarSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogScalarSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -874,7 +874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_DiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.DiscreteSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -900,7 +900,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_CoverFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.CoverFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -927,7 +927,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramManagerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramManagerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -953,7 +953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TimerControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TimerControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogScalarSensorFunctionWithCompensationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogScalarSensorFunctionWithCompensationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1007,7 +1007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerTuningParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerTuningParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1033,7 +1033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_PidControllerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.PidControllerParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1060,7 +1060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TwoStateDiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TwoStateDiscreteSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1087,7 +1087,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiStateDiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiStateDiscreteSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1114,7 +1114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1140,7 +1140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControlFunctionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControlFunctionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1166,7 +1166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiModeAnalogControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiModeAnalogControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1193,7 +1193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1219,7 +1219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerParameterSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerParameterSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1245,7 +1245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithComposedTargetValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithComposedTargetValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1272,7 +1272,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1299,7 +1299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithRelativeTargetValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithRelativeTargetValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1326,7 +1326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogArraySensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogArraySensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_VariableSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.VariableSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1379,7 +1379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1405,7 +1405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1426,7 +1426,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1452,7 +1452,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1594,7 +1594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1679,7 +1679,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InstrumentDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18347",
+    "dov:typeRef": "org.opcfoundation.UA.InstrumentDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1706,7 +1706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1751,7 +1751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1778,7 +1778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1817,7 +1817,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -1848,7 +1848,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1876,7 +1876,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1904,7 +1904,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1941,7 +1941,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1969,7 +1969,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2294,7 +2294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2321,7 +2321,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2346,7 +2346,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2452,7 +2452,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2479,7 +2479,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2504,7 +2504,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -2526,7 +2526,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -2785,7 +2785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2881,7 +2881,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2985,7 +2985,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3069,7 +3069,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3088,7 +3088,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -3108,7 +3108,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -3140,7 +3140,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3183,7 +3183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3229,7 +3229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3275,7 +3275,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3301,7 +3301,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineComponentsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3363,7 +3363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3476,7 +3476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3651,7 +3651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3722,7 +3722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_MaintenanceRequiredAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15739",
+    "dov:typeRef": "org.opcfoundation.UA.DI.MaintenanceRequiredAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3749,7 +3749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceHealthDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15143",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3776,7 +3776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3823,7 +3823,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -3885,7 +3885,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4038,7 +4038,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4062,7 +4062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4265,7 +4265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4321,7 +4321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4343,7 +4343,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4365,7 +4365,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4387,7 +4387,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4397,7 +4397,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4419,7 +4419,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -4512,7 +4512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4557,7 +4557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4583,7 +4583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/LaserSystems.TM.json
+++ b/wot-codegen/opc-output-integrated/LaserSystems.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ActivityDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ActivityDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -146,7 +146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ConditionDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ConditionDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -346,7 +346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ConsumptionDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ConsumptionDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -446,7 +446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemOperationCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -527,7 +527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -621,7 +621,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1108,7 +1108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1140,7 +1140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1191,7 +1191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemMaintenancePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemMaintenancePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1267,7 +1267,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemUtilityChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemUtilityChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1343,7 +1343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_RecipeSettingsAndOverviewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.RecipeSettingsAndOverviewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1510,7 +1510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1555,7 +1555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_LaserMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=36",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1567,7 +1567,7 @@
     "schemaDefinitions": {
       "LaserState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "const": {
           "Undefined": 0,
           "Ready": 1,
@@ -1624,7 +1624,7 @@
       "LaserState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "LaserState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1656,7 +1656,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "LaserState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1680,7 +1680,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1706,7 +1706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1744,7 +1744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1770,7 +1770,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1820,7 +1820,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1866,7 +1866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MaintenancePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MaintenancePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1930,7 +1930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_UtilityChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.UtilityChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1994,7 +1994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2015,7 +2015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2041,7 +2041,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2086,7 +2086,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2228,7 +2228,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2313,7 +2313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2359,7 +2359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2405,7 +2405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2518,7 +2518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2589,7 +2589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2613,7 +2613,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -2660,7 +2660,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2691,7 +2691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2702,7 +2702,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -2749,7 +2749,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2794,7 +2794,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2834,7 +2834,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/MDIS.TM.json
+++ b/wot-codegen/opc-output-integrated/MDIS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=194",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISBaseObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35,7 +35,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=196",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -213,7 +213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISAggregateObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1315",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISAggregateObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -329,7 +329,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISChokeObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISChokeObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -340,7 +340,7 @@
     "schemaDefinitions": {
       "ChokeMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "const": {
           "Moving": 1,
           "Stopped": 2
@@ -358,7 +358,7 @@
       },
       "SetCalculatedPositionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
         "const": {
           "Initial": 0,
           "Inprogress": 1,
@@ -386,7 +386,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -409,7 +409,7 @@
       },
       "ChokeCommandEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=701",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeCommandEnum",
         "const": {
           "Close": 1,
           "Open": 2
@@ -453,7 +453,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Position": {
@@ -469,7 +469,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -488,7 +488,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -511,13 +511,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1158",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "Steps", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Direction": {
               "title": "ChokeCommandEnum",
               "description": "The direction for the valve, true is opening a valve, false if closing the valve",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=701",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeCommandEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -535,7 +535,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -605,7 +605,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ChokeMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -659,7 +659,7 @@
       "SetCalculatedPositionStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "SetCalculatedPositionEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -772,7 +772,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ChokeMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -830,7 +830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "SetCalculatedPositionEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -854,7 +854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISCIMVObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15114",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISCIMVObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -877,7 +877,7 @@
     "schemaDefinitions": {
       "CIMVMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
         "const": {
           "MoveClose": 1,
           "MoveOpen": 2,
@@ -900,7 +900,7 @@
       },
       "CIMVOperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
         "const": {
           "Position": 1,
           "Flow": 2,
@@ -923,7 +923,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -972,7 +972,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15167",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Initial" ],
           "properties": {
             "Initial": {
@@ -995,7 +995,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FlowRate", "SEM", "ShutdownRequest" ],
           "properties": {
             "FlowRate": {
@@ -1007,7 +1007,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1030,13 +1030,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "Delta", "SEM", "ShutdownRequest" ],
           "properties": {
             "Direction": {
               "title": "CIMVMoveEnum",
               "description": "Direction to move – Open or Close",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1050,7 +1050,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1073,13 +1073,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode", "SEM", "ShutdownRequest" ],
           "properties": {
             "Mode": {
               "title": "CIMVOperationModeEnum",
               "description": "Enumeration indicating the requested operation mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1087,7 +1087,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1110,7 +1110,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15173",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "SEM", "ShutdownRequest" ],
           "properties": {
             "Position": {
@@ -1122,7 +1122,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1214,7 +1214,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CIMVMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1266,7 +1266,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CIMVOperationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1428,7 +1428,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CIMVMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1484,7 +1484,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CIMVOperationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1583,7 +1583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISCounterObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15098",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISCounterObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1610,7 +1610,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15101",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Initial" ],
           "properties": {
             "Initial": {
@@ -1667,7 +1667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15015",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1678,7 +1678,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -1737,13 +1737,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15029",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1763,7 +1763,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1806,7 +1806,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1856,7 +1856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=889",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1919,7 +1919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1230",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1934,7 +1934,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State" ],
           "properties": {
             "State": {
@@ -1966,7 +1966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15032",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1977,7 +1977,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -2036,13 +2036,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15546",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2062,7 +2062,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2109,7 +2109,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2163,7 +2163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1214",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2230,7 +2230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1242",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2245,7 +2245,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1253",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State" ],
           "properties": {
             "State": {
@@ -2279,7 +2279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISElectricChokeObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15076",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISElectricChokeObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2290,7 +2290,7 @@
     "schemaDefinitions": {
       "ChokeMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "const": {
           "Moving": 1,
           "Stopped": 2
@@ -2308,7 +2308,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -2357,7 +2357,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15093",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Position": {
@@ -2373,7 +2373,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2443,7 +2443,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ChokeMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2540,7 +2540,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ChokeMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2590,7 +2590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15547",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2601,7 +2601,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -2665,13 +2665,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15075",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2691,7 +2691,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2757,7 +2757,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2811,7 +2811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=971",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3059,7 +3059,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1254",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3074,7 +3074,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1278",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -3108,7 +3108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISMotorObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15190",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISMotorObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3119,7 +3119,7 @@
     "schemaDefinitions": {
       "MotorOperationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
         "const": {
           "Off": 1,
           "Auto": 2,
@@ -3158,13 +3158,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15210",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "MotorOperationEnum",
               "description": "Mode to operate in (i.e. Auto or Manual)",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3183,7 +3183,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15206",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OverrideInterlocks" ],
           "properties": {
             "OverrideInterlocks": {
@@ -3204,7 +3204,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15208",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OverrideInterlocks" ],
           "properties": {
             "OverrideInterlocks": {
@@ -3274,7 +3274,7 @@
       "Operation": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "MotorOperationEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3357,7 +3357,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "MotorOperationEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3394,7 +3394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISValveObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=794",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISValveObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3412,7 +3412,7 @@
     "schemaDefinitions": {
       "CommandEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
         "const": {
           "Close": 1,
           "Open": 2,
@@ -3435,7 +3435,7 @@
       },
       "ValvePositionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
         "const": {
           "Closed": 1,
           "Open": 2,
@@ -3463,7 +3463,7 @@
       },
       "SignatureStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
         "const": {
           "NotAvailable": 1,
           "Completed": 2,
@@ -3486,7 +3486,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -3525,13 +3525,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "OverrideInterlock", "SEM", "Signature", "ShutdownRequest" ],
           "properties": {
             "Direction": {
               "title": "CommandEnum",
               "description": "The enumeration indicates whether the command is to open the valve or to close the valve",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3543,7 +3543,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3620,7 +3620,7 @@
       "LastCommand": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CommandEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3673,7 +3673,7 @@
       "Position": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ValvePositionEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3689,7 +3689,7 @@
       "SignatureRequestStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "SignatureStatusEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3747,7 +3747,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CommandEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3790,7 +3790,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ValvePositionEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3807,7 +3807,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "SignatureStatusEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3831,7 +3831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInformationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1471",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInformationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3872,7 +3872,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "MDISVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1289",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISVersionDataType",
         "required": [ "MajorVersion", "MinorVersion", "Build" ],
         "properties": {
           "MajorVersion": {
@@ -3907,7 +3907,7 @@
         "data": {
           "title": "MDISVersionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1289",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISVersionDataType",
           "required": [ "MajorVersion", "MinorVersion", "Build" ],
           "properties": {
             "MajorVersion": {
@@ -3946,7 +3946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISTimeSyncObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1468",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISTimeSyncObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3961,7 +3961,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1470",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetTime" ],
           "properties": {
             "TargetTime": {
@@ -3994,7 +3994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4015,7 +4015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4036,7 +4036,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -4057,7 +4057,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -4069,7 +4069,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -4090,7 +4090,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -4102,7 +4102,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -4123,7 +4123,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -4140,7 +4140,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -4160,7 +4160,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -4186,7 +4186,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -4307,7 +4307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/MTConnect.v2.TM.json
+++ b/wot-codegen/opc-output-integrated/MTConnect.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2059",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -124,7 +124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2021",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2053",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDescriptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -336,7 +336,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2044",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2015",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -448,7 +448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTCompositionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2067",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCompositionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -534,7 +534,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTSensorConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2046",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSensorConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -622,7 +622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2074",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -649,7 +649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AuxiliariesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2076",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AuxiliariesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -676,7 +676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BarFeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2082",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BarFeederType",
     "dov:isComposite": true,
     "links": [
       {
@@ -703,7 +703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EnvironmentalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2102",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EnvironmentalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2112",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoaderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -757,7 +757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2134",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -784,7 +784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolingDeliveryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2140",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolingDeliveryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -811,7 +811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WasteDisposalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2142",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WasteDisposalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -838,7 +838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2078",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -865,7 +865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2110",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -892,7 +892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2132",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -919,7 +919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2086",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckType",
     "dov:isComposite": true,
     "links": [
       {
@@ -946,7 +946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2088",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -973,7 +973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2120",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1000,7 +1000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2096",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1027,7 +1027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_InterfacesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2108",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.InterfacesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1054,7 +1054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BarFeederInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2080",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BarFeederInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1081,7 +1081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2084",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1108,7 +1108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2094",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1135,7 +1135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialHandlerInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2116",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialHandlerInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1162,7 +1162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResourcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2130",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResourcesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1189,7 +1189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2118",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1216,7 +1216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2136",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StockType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1243,7 +1243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PersonnelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2122",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PersonnelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1270,7 +1270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SystemsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2138",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SystemsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1297,7 +1297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CoolantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2090",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CoolantType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1324,7 +1324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DielectricType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2092",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DielectricType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1351,7 +1351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ElectricType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2098",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ElectricType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1378,7 +1378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EnclosureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2100",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EnclosureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1405,7 +1405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2104",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FeederType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1432,7 +1432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HydraulicType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2106",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HydraulicType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1459,7 +1459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LubricationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2114",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LubricationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1486,7 +1486,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PneumaticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2124",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PneumaticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1513,7 +1513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessPowerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2126",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessPowerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1540,7 +1540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProtectiveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2128",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProtectiveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1567,7 +1567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2629",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1593,7 +1593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDataItemClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2425",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDataItemClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1619,7 +1619,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConstraintType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2647",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConstraintType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1713,7 +1713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2631",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1739,7 +1739,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTMessageEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2656",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTMessageEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1785,7 +1785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=4326",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1797,7 +1797,7 @@
     "schemaDefinitions": {
       "MTSeverityDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2669",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSeverityDataType",
         "const": {
           "FAULT": 0,
           "NORMAL": 1,
@@ -1821,7 +1821,7 @@
       },
       "QualifierDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2668",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.QualifierDataType",
         "const": {
           "HIGH": 0,
           "LOW": 1
@@ -1879,7 +1879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTSeverityDataType",
         "description": "        The condition type is derived from the UA \\uamodel{ContitionType}. When        the \\mtmodel{Warning} or \\mtmodel{Fault} state occurs, an        \\mtuatype{MTConditionEventType} \\uamodel{Event} is created with the        \\mtmodel{ActiveState} set to \\uamodel{True} and \\uamodel{Retain} set to        \\uamodel{True}. The severity is used to represent the MTConnect condition        states of Warning and Fault with the values of 500 and 1000 respectively.        A new \\uamodel{NodeId} will be created for every unique instance of the        MTConnect \\mtmodel{Condition} reported. When the \\mtmodel{Condition} goes        back to Normal, the \\mtmodel{ActiveState} is set to \\uamodel{False} and        \\uamodel{Retain} is also set to \\uamodel{False} with the \\uamodel{NodeId}        of the associated \\mtmodel{Condition}. If multiple MTConnect        \\mtmodel{Condition}s have been cleared at the same time, all currently        active \\mtuatype{MTConditionEventType} \\uamodel{Event}s will need to        deactivated. The \\mtuatype{MTConditionEventType} must set the        \\uamodel{BaseEvent} \\uamodel{SourceNode} to the related        \\mtuatype{MTConditionType} that represents the meta-data for this        Condition. The \\mtuatype{MTConditionEventType} will never be instantiated        in the \\uaterm{AddressSpace} as an \\uamodel{Object}.       ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2669",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSeverityDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1948,7 +1948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "QualifierDataType",
         "description": "        The condition type is derived from the UA \\uamodel{ContitionType}. When        the \\mtmodel{Warning} or \\mtmodel{Fault} state occurs, an        \\mtuatype{MTConditionEventType} \\uamodel{Event} is created with the        \\mtmodel{ActiveState} set to \\uamodel{True} and \\uamodel{Retain} set to        \\uamodel{True}. The severity is used to represent the MTConnect condition        states of Warning and Fault with the values of 500 and 1000 respectively.        A new \\uamodel{NodeId} will be created for every unique instance of the        MTConnect \\mtmodel{Condition} reported. When the \\mtmodel{Condition} goes        back to Normal, the \\mtmodel{ActiveState} is set to \\uamodel{False} and        \\uamodel{Retain} is also set to \\uamodel{False} with the \\uamodel{NodeId}        of the associated \\mtmodel{Condition}. If multiple MTConnect        \\mtmodel{Condition}s have been cleared at the same time, all currently        active \\mtuatype{MTConditionEventType} \\uamodel{Event}s will need to        deactivated. The \\mtuatype{MTConditionEventType} must set the        \\uamodel{BaseEvent} \\uamodel{SourceNode} to the related        \\mtuatype{MTConditionType} that represents the meta-data for this        Condition. The \\mtuatype{MTConditionEventType} will never be instantiated        in the \\uaterm{AddressSpace} as an \\uamodel{Object}.       ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2668",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.QualifierDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1974,7 +1974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2660",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1992,7 +1992,7 @@
     "schemaDefinitions": {
       "MTCategoryType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2634",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCategoryType",
         "const": {
           "EVENT": 0,
           "CONDITION": 1,
@@ -2016,7 +2016,7 @@
       },
       "MTRepresentationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2633",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTRepresentationType",
         "const": {
           "DISCRETE": 0,
           "TIME_SERIES": 1,
@@ -2053,7 +2053,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTCategoryType",
         "description": "        The data item mixin will inject the properties and the methods into the        related classes. This facility is similar to the Ruby module mixin or the        Scala traits. data entity describing a piece of information reported about        a piece of equipment.      ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2634",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCategoryType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2124,7 +2124,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTRepresentationType",
         "description": "        The data item mixin will inject the properties and the methods into the        related classes. This facility is similar to the Ruby module mixin or the        Scala traits. data entity describing a piece of information reported about        a piece of equipment.      ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2633",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTRepresentationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2191,7 +2191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTMessageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2427",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTMessageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTSampleClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2345",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSampleClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2244,7 +2244,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AccelerationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2265",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AccelerationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2271,7 +2271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AccumulatedTimeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2267",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AccumulatedTimeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2298,7 +2298,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AmperageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2273",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AmperageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2325,7 +2325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngleClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2275",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngleClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2352,7 +2352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngularAccelerationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2269",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngularAccelerationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2379,7 +2379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngularVelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2271",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngularVelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2406,7 +2406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisFeedrateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2277",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisFeedrateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2433,7 +2433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ClockTimeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2279",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ClockTimeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2460,7 +2460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ConcentrationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2281",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ConcentrationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2487,7 +2487,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ConductivityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2283",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ConductivityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2514,7 +2514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DisplacementClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2285",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DisplacementClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2541,7 +2541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ElectricalEnergyClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2287",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ElectricalEnergyClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2568,7 +2568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EquipmentTimerClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2289",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EquipmentTimerClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2595,7 +2595,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FillLevelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2291",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FillLevelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2622,7 +2622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FlowClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2293",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FlowClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2649,7 +2649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FrequencyClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2295",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FrequencyClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2676,7 +2676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LengthClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2297",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LengthClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2703,7 +2703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearForceClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearForceClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2730,7 +2730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2263",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2757,7 +2757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MassClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2301",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MassClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2784,7 +2784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathFeedrateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2303",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathFeedrateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2811,7 +2811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathPositionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2305",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathPositionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2838,7 +2838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PHClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PHClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2865,7 +2865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PositionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PositionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2892,7 +2892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PowerFactorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PowerFactorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2919,7 +2919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PressureClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2313",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PressureClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2946,7 +2946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessTimerClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2315",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessTimerClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2973,7 +2973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResistenceClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2317",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResistenceClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3000,7 +3000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryVelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2319",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryVelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3027,7 +3027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SoundLevelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2321",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SoundLevelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3054,7 +3054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StrainClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2323",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StrainClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3081,7 +3081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TemperatureClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2325",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TemperatureClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3108,7 +3108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TensionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2327",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TensionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3135,7 +3135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TiltClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2329",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TiltClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3162,7 +3162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TorqueClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2331",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TorqueClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3189,7 +3189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2335",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3216,7 +3216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ViscosityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2339",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ViscosityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3243,7 +3243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2341",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3270,7 +3270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltAmpereClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2333",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltAmpereClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3297,7 +3297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltAmpereReactiveClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2337",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltAmpereReactiveClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3324,7 +3324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WattageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2343",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WattageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3351,7 +3351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTControlledVocabEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2144",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTControlledVocabEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3377,7 +3377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2146",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3426,7 +3426,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AvailabilityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2149",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AvailabilityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3475,7 +3475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisCouplingClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2152",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisCouplingClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3524,7 +3524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2155",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3573,7 +3573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2158",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3622,7 +3622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2161",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3671,7 +3671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2164",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3720,7 +3720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CloseChuckClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2256",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CloseChuckClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3769,7 +3769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CloseDoorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2250",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CloseDoorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3818,7 +3818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CompositionStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2173",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CompositionStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3867,7 +3867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2167",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3916,7 +3916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerModeOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2176",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerModeOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3965,7 +3965,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DirectionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2179",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DirectionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4014,7 +4014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2182",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4063,7 +4063,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EmergencyStopClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2185",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EmergencyStopClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4112,7 +4112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EndOfBarClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2188",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EndOfBarClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4161,7 +4161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EquipmentModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2191",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EquipmentModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4210,7 +4210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ExecutionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2170",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ExecutionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4259,7 +4259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FunctionalModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2194",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FunctionalModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4308,7 +4308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_InterfaceStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2227",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.InterfaceStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4357,7 +4357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialChangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2235",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialChangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4406,7 +4406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialFeedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2231",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialFeedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4455,7 +4455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialLoadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2241",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialLoadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4504,7 +4504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialRetractClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2238",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialRetractClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4553,7 +4553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialUnloadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2244",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialUnloadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4602,7 +4602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OpenChuckClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2253",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OpenChuckClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4651,7 +4651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OpenDoorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2247",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OpenDoorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4700,7 +4700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartChangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2259",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartChangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4749,7 +4749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2215",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4798,7 +4798,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PowerStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2218",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PowerStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4847,7 +4847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramEditClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2221",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramEditClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4896,7 +4896,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2224",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4945,7 +4945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SpindleInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2212",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SpindleInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4994,7 +4994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTNumericEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2359",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTNumericEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5020,7 +5020,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisFeedrateOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2347",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisFeedrateOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5047,7 +5047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BlockCountClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2349",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BlockCountClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5074,7 +5074,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HardnessClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2351",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HardnessClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5101,7 +5101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2353",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5128,7 +5128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartCountClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2355",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartCountClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5155,7 +5155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathFeedrateOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=3628",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathFeedrateOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5182,7 +5182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryVelocityOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2357",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryVelocityOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5209,7 +5209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTStringEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2361",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTStringEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5235,7 +5235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AssetChangedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2405",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AssetChangedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5262,7 +5262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AssetRemovedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2407",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AssetRemovedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5289,7 +5289,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2363",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5316,7 +5316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CoupledAxesClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2365",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CoupledAxesClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5343,7 +5343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2409",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5370,7 +5370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineLabelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2367",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineLabelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5397,7 +5397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2369",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5424,7 +5424,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MessageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2403",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MessageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5451,7 +5451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatorIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2371",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatorIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5478,7 +5478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PalletIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2373",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PalletIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5505,7 +5505,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2375",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5532,7 +5532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2377",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5559,7 +5559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2379",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5586,7 +5586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramCommentClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2385",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramCommentClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5613,7 +5613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramEditNameClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2381",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramEditNameClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5640,7 +5640,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramHeaderClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2383",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramHeaderClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5667,7 +5667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SerialNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2387",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SerialNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5694,7 +5694,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolAssetIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2389",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolAssetIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5721,7 +5721,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2391",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5748,7 +5748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolOffsetClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2393",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolOffsetClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5775,7 +5775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_UserClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2395",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.UserClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5802,7 +5802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WireClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2397",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WireClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5829,7 +5829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkholdingClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2399",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkholdingClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5856,7 +5856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkOffsetClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2401",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkOffsetClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5883,7 +5883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2411",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5910,7 +5910,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CommunicationsClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2413",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CommunicationsClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5937,7 +5937,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DataRangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2415",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DataRangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5964,7 +5964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HardwareClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2419",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HardwareClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5991,7 +5991,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LogicProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2417",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LogicProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6018,7 +6018,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MotionProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2421",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MotionProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6045,7 +6045,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SystemClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2423",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SystemClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6072,7 +6072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDataItemSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2476",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDataItemSubClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6098,7 +6098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AbsoluteSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2478",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AbsoluteSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6125,7 +6125,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActionSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2482",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActionSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6152,7 +6152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActualSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2480",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActualSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6179,7 +6179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AllSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2484",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AllSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6206,7 +6206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AlternatingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2486",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AlternatingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6233,7 +6233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2488",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6260,7 +6260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AuxiliarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2490",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AuxiliarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6287,7 +6287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BadSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2492",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BadSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6314,7 +6314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BrinellSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2494",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BrinellSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6341,7 +6341,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2496",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6368,7 +6368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CommandedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2498",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CommandedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6395,7 +6395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControlSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2502",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControlSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6422,7 +6422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2504",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6449,7 +6449,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DelaySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2506",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DelaySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6476,7 +6476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DirectSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2508",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DirectSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6503,7 +6503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DryRunSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2510",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DryRunSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6530,7 +6530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2512",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6557,7 +6557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FixtureSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2514",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FixtureSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6584,7 +6584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_GoodSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2500",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.GoodSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6611,7 +6611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_IncrementalSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2516",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.IncrementalSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6638,7 +6638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_JobSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2518",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.JobSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6665,7 +6665,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_KineticSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2520",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.KineticSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6692,7 +6692,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LateralSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2522",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LateralSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6719,7 +6719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LeebSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2524",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LeebSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6746,7 +6746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LengthSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2526",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LengthSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6773,7 +6773,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2528",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6800,7 +6800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2530",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6827,7 +6827,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoadedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2532",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoadedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6854,7 +6854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MachineAxisLockSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2534",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MachineAxisLockSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6881,7 +6881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaintenanceSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2536",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaintenanceSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6908,7 +6908,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ManualUnclampSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2538",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ManualUnclampSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6935,7 +6935,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaximumSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2540",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaximumSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6962,7 +6962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MinimumSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2542",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MinimumSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6989,7 +6989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MohsSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2544",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MohsSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7016,7 +7016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MoleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2546",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MoleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7043,7 +7043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MotionSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2548",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MotionSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7070,7 +7070,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_NoScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2550",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.NoScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7097,7 +7097,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2552",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7124,7 +7124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatorSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2554",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatorSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7151,7 +7151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OptionalStopSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2556",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OptionalStopSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7178,7 +7178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OverrideSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2558",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OverrideSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7205,7 +7205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PoweredSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2562",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PoweredSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7232,7 +7232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PrimarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2560",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PrimarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7259,7 +7259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProbeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2564",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProbeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7286,7 +7286,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2566",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7313,7 +7313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgrammedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2568",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgrammedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7340,7 +7340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RadialSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2570",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RadialSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7367,7 +7367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RapidSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2572",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RapidSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7394,7 +7394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RelativeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2574",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RelativeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7421,7 +7421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RemainingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2576",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RemainingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7448,7 +7448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RequestSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2578",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RequestSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7475,7 +7475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResponseSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2580",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResponseSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7502,7 +7502,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RockwellSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2582",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RockwellSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7529,7 +7529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2584",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7556,7 +7556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SetUpSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2586",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SetUpSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7583,7 +7583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ShoreSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2588",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ShoreSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7610,7 +7610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StandardSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2590",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StandardSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7637,7 +7637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SwitchedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2592",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SwitchedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7664,7 +7664,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TargetSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2594",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TargetSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7691,7 +7691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolChangeStopSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2596",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolChangeStopSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7718,7 +7718,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolEdgeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2598",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolEdgeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7745,7 +7745,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolGroupSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2600",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolGroupSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7772,7 +7772,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2602",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7799,7 +7799,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_UasbleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2604",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.UasbleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7826,7 +7826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VerticalSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2606",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VerticalSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7853,7 +7853,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VickersSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2610",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VickersSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7880,7 +7880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VolumeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2608",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VolumeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7907,7 +7907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WeightSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2612",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WeightSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7934,7 +7934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2614",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7961,7 +7961,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkpieceSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2616",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkpieceSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7988,7 +7988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -8009,7 +8009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8035,7 +8035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8131,7 +8131,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -8235,7 +8235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8262,7 +8262,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -8287,7 +8287,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -8309,7 +8309,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {

--- a/wot-codegen/opc-output-integrated/MachineTool.TM.json
+++ b/wot-codegen/opc-output-integrated/MachineTool.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_OperatorConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=47",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.OperatorConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ClampingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=48",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ClampingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ManualProcessStepConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ManualProcessStepConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MeasurementConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=53",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MeasurementConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartMissingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=54",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartMissingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProcessIrregularityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularityConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolBreakageConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=57",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolBreakageConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolChangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolChangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_UtilityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=60",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.UtilityConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_AlertType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=39",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.AlertType",
     "dov:isEvent": true,
     "links": [
       {
@@ -288,7 +288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_InterruptionConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=19",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.InterruptionConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -334,7 +334,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=35",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -380,7 +380,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -513,7 +513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -525,7 +525,7 @@
     "schemaDefinitions": {
       "PartQuality": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "const": {
           "CapabilityUnavailable": 0,
           "Good": 1,
@@ -558,7 +558,7 @@
       },
       "ProcessIrregularity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "const": {
           "CapabilityUnavailable": 0,
           "Detected": 1,
@@ -651,7 +651,7 @@
       "PartQuality": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "PartQuality",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -667,7 +667,7 @@
       "ProcessIrregularity": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ProcessIrregularity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -686,7 +686,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "PartQuality",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -703,7 +703,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ProcessIrregularity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -727,7 +727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=17",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -785,7 +785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=51",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -881,7 +881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -898,7 +898,7 @@
     "schemaDefinitions": {
       "ToolManagement": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "const": {
           "NumberBased": 0,
           "GroupBased": 1,
@@ -966,7 +966,7 @@
       "ControlIdentifierInterpretation": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ToolManagement",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1052,7 +1052,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ToolManagement",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1116,7 +1116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ChannelModifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=33",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelModifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1279,7 +1279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1324,7 +1324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ChannelMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=16",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1342,7 +1342,7 @@
     "schemaDefinitions": {
       "ChannelMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
         "const": {
           "Automatic": 0,
           "MdaMdi": 1,
@@ -1390,7 +1390,7 @@
       },
       "ChannelState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
         "const": {
           "Active": 0,
           "Interrupted": 1,
@@ -1430,7 +1430,7 @@
       "ChannelMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ChannelMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1446,7 +1446,7 @@
       "ChannelState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ChannelState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1493,7 +1493,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ChannelMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1510,7 +1510,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ChannelState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_CombinedChannelMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=46",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.CombinedChannelMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1591,7 +1591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1617,7 +1617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EDMGeneratorMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1629,7 +1629,7 @@
     "schemaDefinitions": {
       "EDMGeneratorState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
         "const": {
           "Undefined": 0,
           "Ready": 1,
@@ -1679,7 +1679,7 @@
       "EDMGeneratorState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "EDMGeneratorState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1710,7 +1710,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "EDMGeneratorState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1747,7 +1747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_LaserMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=36",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1759,7 +1759,7 @@
     "schemaDefinitions": {
       "LaserState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "const": {
           "Undefined": 0,
           "Ready": 1,
@@ -1816,7 +1816,7 @@
       "LaserState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "LaserState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1848,7 +1848,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "LaserState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1872,7 +1872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_SpindleMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.SpindleMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1990,7 +1990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2022,7 +2022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2072,7 +2072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2104,7 +2104,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2121,7 +2121,7 @@
     "schemaDefinitions": {
       "MachineOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "const": {
           "Manual": 0,
           "Automatic": 1,
@@ -2202,7 +2202,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "MachineOperationMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2263,7 +2263,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "MachineOperationMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2302,7 +2302,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ObligationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ObligationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2390,7 +2390,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2453,7 +2453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2497,7 +2497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2535,7 +2535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2561,7 +2561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2611,7 +2611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2657,7 +2657,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2701,7 +2701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2795,7 +2795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=59",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2859,7 +2859,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2975,7 +2975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3150,7 +3150,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3176,7 +3176,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3243,7 +3243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=29",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3464,7 +3464,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3580,7 +3580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3706,7 +3706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=56",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3723,7 +3723,7 @@
     "schemaDefinitions": {
       "PartQuality": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "const": {
           "CapabilityUnavailable": 0,
           "Good": 1,
@@ -3756,7 +3756,7 @@
       },
       "ProcessIrregularity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "const": {
           "CapabilityUnavailable": 0,
           "Detected": 1,
@@ -3837,7 +3837,7 @@
       "PartQuality": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "PartQuality",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3853,7 +3853,7 @@
       "ProcessIrregularity": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ProcessIrregularity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3872,7 +3872,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "PartQuality",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3889,7 +3889,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ProcessIrregularity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3913,7 +3913,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4029,7 +4029,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MaintenancePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MaintenancePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4093,7 +4093,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ManualActivityPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ManualActivityPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4157,7 +4157,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartLoadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartLoadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4296,7 +4296,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartUnloadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartUnloadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4435,7 +4435,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProcessChangeoverPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessChangeoverPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4524,7 +4524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobEndPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobEndPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4613,7 +4613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=45",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4752,7 +4752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolLoadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolLoadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4866,7 +4866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolUnloadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=18",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolUnloadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5005,7 +5005,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_UtilityChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.UtilityChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5069,7 +5069,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_SoftwareIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.SoftwareIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5138,7 +5138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5319,7 +5319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MaintenanceModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MaintenanceModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5375,7 +5375,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5401,7 +5401,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -5422,7 +5422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11164",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5448,7 +5448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5487,7 +5487,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -5518,7 +5518,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5546,7 +5546,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5574,7 +5574,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5611,7 +5611,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5639,7 +5639,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5964,7 +5964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5991,7 +5991,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6016,7 +6016,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6122,7 +6122,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6149,7 +6149,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6174,7 +6174,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -6196,7 +6196,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -6455,7 +6455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6551,7 +6551,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -6655,7 +6655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6739,7 +6739,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6758,7 +6758,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -6778,7 +6778,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -6810,7 +6810,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6853,7 +6853,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6995,7 +6995,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7080,7 +7080,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7126,7 +7126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7172,7 +7172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7198,7 +7198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7224,7 +7224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7332,7 +7332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7346,7 +7346,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -7356,7 +7356,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -7375,7 +7375,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -7388,7 +7388,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -7412,7 +7412,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -7431,7 +7431,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -7450,7 +7450,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -7481,7 +7481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7526,7 +7526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7552,7 +7552,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7634,7 +7634,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7886,7 +7886,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8061,7 +8061,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8132,7 +8132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8156,7 +8156,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -8203,7 +8203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8234,7 +8234,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8245,7 +8245,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -8292,7 +8292,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8337,7 +8337,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8377,7 +8377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/MachineVision.AMCM.TM.json
+++ b/wot-codegen/opc-output-integrated/MachineVision.AMCM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IVisionInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IVisionInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ICableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ICableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IComputingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IComputingDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IDisplayUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IDisplayUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILampType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILensType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILensType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILicenseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILicenseType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILightingControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILightingControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IPhysicalInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IPhysicalInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionItemFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionItemFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -268,7 +268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -539,7 +539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionComponentIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -810,7 +810,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionHealthInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionHealthInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -827,7 +827,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -883,7 +883,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
         "description": "indicates the status as defined by NAMUR Recommendation NE107. The DeviceHealthEnumeration DataType is formally defined in OPC 10000-100 Device Model",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -924,7 +924,7 @@
         "title": "SEMI_E10SystemStateDataType",
         "description": "denotes the SEMI E10 State of the item ",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.SEMI_E10SystemStateDataType",
         "required": [ "Id", "Priority" ],
         "properties": {
           "Id": {
@@ -979,7 +979,7 @@
         "data": {
           "title": "DeviceHealthEnumeration",
           "description": "indicates the status as defined by NAMUR Recommendation NE107. The DeviceHealthEnumeration DataType is formally defined in OPC 10000-100 Device Model",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1012,7 +1012,7 @@
           "title": "SEMI_E10SystemStateDataType",
           "description": "denotes the SEMI E10 State of the item ",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.SEMI_E10SystemStateDataType",
           "required": [ "Id", "Priority" ],
           "properties": {
             "Id": {
@@ -1062,7 +1062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionMaintenanceInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionMaintenanceInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1288,7 +1288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAcquisitionBackgroundType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAcquisitionBackgroundType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1315,7 +1315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageReceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageReceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1342,7 +1342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageTransceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageTransceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1369,7 +1369,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageTransmitterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageTransmitterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1396,7 +1396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionCableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionCableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1423,7 +1423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionClimateControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionClimateControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1450,7 +1450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionComputingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionComputingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1477,7 +1477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionDisplayUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionDisplayUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1504,7 +1504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionFrameGrabberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionFrameGrabberType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1531,7 +1531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionHousingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionHousingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1558,7 +1558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionImageSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionImageSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1585,7 +1585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLampType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1612,7 +1612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLensControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLensControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1639,7 +1639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLensType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLensType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1666,7 +1666,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLicenseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLicenseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1693,7 +1693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLightingControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLightingControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1720,7 +1720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionNetworkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionNetworkDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1747,7 +1747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionOpticalFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionOpticalFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1774,7 +1774,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionOtherOpticalEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionOtherOpticalEquipmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1801,7 +1801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPatternGeneratorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPatternGeneratorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1828,7 +1828,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPhysicalInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPhysicalInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1855,7 +1855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPowerSupplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPowerSupplyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1882,7 +1882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionSurroundingEnvironmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionSurroundingEnvironmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1909,7 +1909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionSystemAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionSystemAssetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2092,7 +2092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionTriggerSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionTriggerSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2119,7 +2119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionWayEncoderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionWayEncoderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2146,7 +2146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2172,7 +2172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2193,7 +2193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2219,7 +2219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2301,7 +2301,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2553,7 +2553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryComponentIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2622,7 +2622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/MachineVision.TM.json
+++ b/wot-codegen/opc-output-integrated/MachineVision.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AcquisitionDoneEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AcquisitionDoneEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38,7 +38,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -73,7 +73,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -173,7 +173,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -216,7 +216,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -259,7 +259,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -302,7 +302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -345,7 +345,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -371,7 +371,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -401,7 +401,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -431,7 +431,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -461,7 +461,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -513,7 +513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionErrorConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionErrorConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -540,7 +540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionPersistentErrorConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionPersistentErrorConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -567,7 +567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionWarningConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionWarningConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -594,7 +594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_EnterStepSequenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.EnterStepSequenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -652,7 +652,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_JobStartedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobStartedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -682,7 +682,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -717,7 +717,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_LeaveStepSequenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.LeaveStepSequenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -744,7 +744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_NextStepEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.NextStepEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -802,7 +802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -832,7 +832,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -867,7 +867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipePreparedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipePreparedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -897,7 +897,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -940,7 +940,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -983,7 +983,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1022,7 +1022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1070,7 +1070,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1113,7 +1113,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1156,7 +1156,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1199,7 +1199,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1276,7 +1276,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1302,7 +1302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1332,7 +1332,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1362,7 +1362,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProcessingTimesDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
         "required": [ "StartTime", "EndTime" ],
         "properties": {
           "StartTime": {
@@ -1404,7 +1404,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1455,7 +1455,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1509,7 +1509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1536,7 +1536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ErrorResolvedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ErrorResolvedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1563,7 +1563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_StateChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.StateChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1590,7 +1590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1637,7 +1637,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1680,7 +1680,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1723,7 +1723,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1766,7 +1766,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1809,7 +1809,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1835,7 +1835,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1865,7 +1865,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1895,7 +1895,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1925,7 +1925,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1960,7 +1960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionDiagnosticInfoEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionDiagnosticInfoEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1987,7 +1987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionInformationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionInformationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2014,7 +2014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionSafetyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionSafetyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2087,7 +2087,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2131,13 +2131,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6116",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2167,7 +2167,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6117",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2189,13 +2189,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6096",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2225,13 +2225,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6097",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Configuration", "TransferRequired", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2282,13 +2282,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId", "Timeout" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2323,7 +2323,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConfigurationHandle", "Configuration", "Error" ],
           "properties": {
             "ConfigurationHandle": {
@@ -2334,7 +2334,7 @@
             "Configuration": {
               "title": "ConfigurationDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
               "required": [ "InternalId", "LastModified" ],
               "properties": {
                 "HasTransferableDataOnFile": {
@@ -2345,7 +2345,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Identification of the configuration used by the environment. This argument must not be empty.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -2375,7 +2375,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -2427,7 +2427,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6104",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "MaxResults": {
@@ -2449,7 +2449,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6105",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "ConfigurationHandle", "ConfigurationList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -2470,7 +2470,7 @@
               "items": {
                 "title": "ConfigurationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
                 "required": [ "InternalId", "LastModified" ],
                 "properties": {
                   "HasTransferableDataOnFile": {
@@ -2481,7 +2481,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Identification of the configuration used by the environment. This argument must not be empty.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -2511,7 +2511,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -2564,7 +2564,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationHandle" ],
           "properties": {
             "ConfigurationHandle": {
@@ -2576,7 +2576,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6109",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2598,13 +2598,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2634,7 +2634,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6113",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2658,7 +2658,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ConfigurationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
         "required": [ "InternalId", "LastModified" ],
         "properties": {
           "HasTransferableDataOnFile": {
@@ -2669,7 +2669,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Identification of the configuration used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2699,7 +2699,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2752,7 +2752,7 @@
         "data": {
           "title": "ConfigurationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
           "required": [ "InternalId", "LastModified" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -2763,7 +2763,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Identification of the configuration used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2793,7 +2793,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2845,7 +2845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2879,7 +2879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ConfigurationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
         "required": [ "InternalId", "LastModified" ],
         "properties": {
           "HasTransferableDataOnFile": {
@@ -2890,7 +2890,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Identification of the configuration used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2920,7 +2920,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2974,7 +2974,7 @@
         "data": {
           "title": "ConfigurationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
           "required": [ "InternalId", "LastModified" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -2985,7 +2985,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Identification of the configuration used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3015,7 +3015,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3068,7 +3068,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3082,20 +3082,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6617",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ConfigurationTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The Id of the configuration to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -3127,7 +3127,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6618",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -3154,20 +3154,20 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6121",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ConfigurationTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The Id of the configuration to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -3199,7 +3199,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6122",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -3235,7 +3235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ProductFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3269,14 +3269,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductDataType",
         "required": [ "ExternalId" ],
         "properties": {
           "ExternalId": {
             "title": "ProductIdDataType",
             "description": "Identification of the product used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3312,14 +3312,14 @@
         "data": {
           "title": "ProductDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductDataType",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "ProductIdDataType",
               "description": "Identification of the product used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3354,7 +3354,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3386,7 +3386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3419,13 +3419,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6190",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3442,7 +3442,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -3464,7 +3464,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6202",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsCompleted", "Error" ],
           "properties": {
             "IsCompleted": {
@@ -3489,13 +3489,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6196",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3512,7 +3512,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6197",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -3534,7 +3534,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6205",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -3559,7 +3559,7 @@
         "title": "BinaryIdBaseDataType",
         "description": "Recipe ID for identifying the recipe outside the vision system. The ExternalID is only managed by the host system.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3603,7 +3603,7 @@
         "title": "BinaryIdBaseDataType",
         "description": "System-wide unique ID for identifying a recipe. This ID is assigned by the vision system.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3684,7 +3684,7 @@
         "items": {
           "title": "ProductIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3724,7 +3724,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3758,14 +3758,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
         "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
         "properties": {
           "ResultId": {
             "title": "ResultIdDataType",
             "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3796,7 +3796,7 @@
             "title": "MeasIdDataType",
             "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3813,7 +3813,7 @@
             "title": "PartIdDataType",
             "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3830,7 +3830,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3860,7 +3860,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3890,7 +3890,7 @@
             "title": "ProductIdDataType",
             "description": "productId which was used to trigger the job which created the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3907,7 +3907,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3937,7 +3937,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3967,7 +3967,7 @@
             "title": "JobIdDataType",
             "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3985,7 +3985,7 @@
             "title": "ProcessingTimesDataType",
             "description": "Collection of different processing times that were needed to create the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
             "required": [ "StartTime", "EndTime" ],
             "properties": {
               "StartTime": {
@@ -4058,7 +4058,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -4102,7 +4102,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -4164,7 +4164,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -4191,7 +4191,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -4241,14 +4241,14 @@
         "data": {
           "title": "ResultDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
           "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4279,7 +4279,7 @@
               "title": "MeasIdDataType",
               "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4296,7 +4296,7 @@
               "title": "PartIdDataType",
               "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4313,7 +4313,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4343,7 +4343,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4373,7 +4373,7 @@
               "title": "ProductIdDataType",
               "description": "productId which was used to trigger the job which created the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4390,7 +4390,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4420,7 +4420,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4450,7 +4450,7 @@
               "title": "JobIdDataType",
               "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4468,7 +4468,7 @@
               "title": "ProcessingTimesDataType",
               "description": "Collection of different processing times that were needed to create the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
               "required": [ "StartTime", "EndTime" ],
               "properties": {
                 "StartTime": {
@@ -4533,7 +4533,7 @@
         "data": {
           "title": "BinaryIdBaseDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4573,7 +4573,7 @@
         "data": {
           "title": "BinaryIdBaseDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4627,7 +4627,7 @@
         "data": {
           "title": "JobIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4650,7 +4650,7 @@
         "data": {
           "title": "ResultIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4695,7 +4695,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4724,7 +4724,7 @@
     "schemaDefinitions": {
       "TriStateBooleanDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.TriStateBooleanDataType",
         "const": {
           "FALSE_0": 0,
           "TRUE_1": 1,
@@ -4751,13 +4751,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "ProductId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4786,7 +4786,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4803,13 +4803,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Recipe", "Product", "TransferRequired", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4863,13 +4863,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "ProductId", "IsPrepared", "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4898,7 +4898,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4913,7 +4913,7 @@
             },
             "IsPrepared": {
               "title": "TriStateBooleanDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.TriStateBooleanDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4937,7 +4937,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6157",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "RecipeHandle", "RecipeList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -4958,7 +4958,7 @@
               "items": {
                 "title": "BinaryIdBaseDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                 "required": [ "Id" ],
                 "properties": {
                   "Id": {
@@ -5004,13 +5004,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6172",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5027,13 +5027,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5078,13 +5078,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6148",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "InternalIdIn" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5113,7 +5113,7 @@
             "InternalIdIn": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5143,13 +5143,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6149",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalIdOut", "IsCompleted", "Error" ],
           "properties": {
             "InternalIdOut": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5197,7 +5197,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6160",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeHandle" ],
           "properties": {
             "RecipeHandle": {
@@ -5209,7 +5209,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5231,13 +5231,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6164",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5267,7 +5267,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6165",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5289,13 +5289,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId", "ProductId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5324,7 +5324,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5341,7 +5341,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5363,13 +5363,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5386,13 +5386,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5437,13 +5437,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6152",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "InternalIdIn" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5472,7 +5472,7 @@
             "InternalIdIn": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5502,13 +5502,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6153",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalIdOut", "Error" ],
           "properties": {
             "InternalIdOut": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5564,7 +5564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5578,20 +5578,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "generateOptions" ],
           "properties": {
             "generateOptions": {
               "title": "RecipeTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The InternalId of the recipe to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5623,7 +5623,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6185",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "fileNodeId", "fileHandle", "completionStateMachine" ],
           "properties": {
             "fileNodeId": {
@@ -5650,20 +5650,20 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6583",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "RecipeTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The InternalId of the recipe to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5695,7 +5695,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6584",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -5731,7 +5731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5758,13 +5758,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6209",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5782,7 +5782,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6210",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -5793,14 +5793,14 @@
             "Result": {
               "title": "ResultDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
               "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
               "properties": {
                 "ResultId": {
                   "title": "ResultIdDataType",
                   "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5831,7 +5831,7 @@
                   "title": "MeasIdDataType",
                   "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5848,7 +5848,7 @@
                   "title": "PartIdDataType",
                   "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5865,7 +5865,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5895,7 +5895,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5925,7 +5925,7 @@
                   "title": "ProductIdDataType",
                   "description": "productId which was used to trigger the job which created the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5942,7 +5942,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5972,7 +5972,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -6002,7 +6002,7 @@
                   "title": "JobIdDataType",
                   "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -6020,7 +6020,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Collection of different processing times that were needed to create the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -6074,13 +6074,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6098,7 +6098,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "HasTransferableDataOnFile", "ResultHandle", "IsPartial", "IsSimulated", "ResultState", "MeasId", "PartId", "ExternalRecipeId", "InternalRecipeId", "ProductId", "ExternalConfigurationId", "InternalConfigurationId", "JobId", "CreationTime", "ProcessingTimes", "ResultContent", "Error" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -6123,7 +6123,7 @@
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6139,7 +6139,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6155,7 +6155,7 @@
             "ExternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6184,7 +6184,7 @@
             "InternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6213,7 +6213,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6229,7 +6229,7 @@
             "ExternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6258,7 +6258,7 @@
             "InternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6287,7 +6287,7 @@
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6303,7 +6303,7 @@
             "ProcessingTimes": {
               "title": "ProcessingTimesDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
               "required": [ "StartTime", "EndTime" ],
               "properties": {
                 "StartTime": {
@@ -6353,7 +6353,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultState", "MeasId", "PartId", "ExternalRecipeId", "InternalRecipeId", "ExternalConfigurationId", "InternalConfigurationId", "ProductId", "JobId", "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "ResultState": {
@@ -6364,7 +6364,7 @@
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6380,7 +6380,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6396,7 +6396,7 @@
             "ExternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6425,7 +6425,7 @@
             "InternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6454,7 +6454,7 @@
             "ExternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6483,7 +6483,7 @@
             "InternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6512,7 +6512,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6528,7 +6528,7 @@
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6556,7 +6556,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "ResultHandle", "ResultList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -6577,14 +6577,14 @@
               "items": {
                 "title": "ResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
                 "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
                 "properties": {
                   "ResultId": {
                     "title": "ResultIdDataType",
                     "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6615,7 +6615,7 @@
                     "title": "MeasIdDataType",
                     "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6632,7 +6632,7 @@
                     "title": "PartIdDataType",
                     "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6649,7 +6649,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6679,7 +6679,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6709,7 +6709,7 @@
                     "title": "ProductIdDataType",
                     "description": "productId which was used to trigger the job which created the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6726,7 +6726,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6756,7 +6756,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6786,7 +6786,7 @@
                     "title": "JobIdDataType",
                     "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6804,7 +6804,7 @@
                     "title": "ProcessingTimesDataType",
                     "description": "Collection of different processing times that were needed to create the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
                     "required": [ "StartTime", "EndTime" ],
                     "properties": {
                       "StartTime": {
@@ -6859,7 +6859,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -6871,7 +6871,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -6904,7 +6904,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6918,20 +6918,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ResultTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultTransferOptions",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
                   "title": "ResultIdDataType",
                   "description": "The Id of the result to be transferred to the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -6946,7 +6946,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -6985,7 +6985,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_SafetyStateManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.SafetyStateManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7017,7 +7017,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6222",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SafetyTriggered", "SafetyInformation" ],
           "properties": {
             "SafetyTriggered": {
@@ -7030,7 +7030,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6223",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7123,7 +7123,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionAutomaticModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionAutomaticModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7282,7 +7282,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7297,7 +7297,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6286",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7319,7 +7319,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6289",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Activate", "Cause", "CauseDescription" ],
           "properties": {
             "Activate": {
@@ -7337,7 +7337,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6290",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7359,13 +7359,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MeasId", "PartId", "RecipeId", "ProductId", "Parameters" ],
           "properties": {
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7381,7 +7381,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7397,7 +7397,7 @@
             "RecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7426,7 +7426,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7449,13 +7449,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobId", "Error" ],
           "properties": {
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7483,13 +7483,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6281",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MeasId", "PartId", "RecipeId", "ProductId", "Parameters" ],
           "properties": {
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7505,7 +7505,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7521,7 +7521,7 @@
             "RecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7550,7 +7550,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7573,13 +7573,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6282",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobId", "Error" ],
           "properties": {
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7607,7 +7607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6287",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7622,7 +7622,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6288",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7655,7 +7655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionStepModelStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionStepModelStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7730,7 +7730,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7745,7 +7745,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6320",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7778,7 +7778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7955,7 +7955,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7975,7 +7975,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6254",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7990,7 +7990,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6255",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -8012,7 +8012,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6256",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -8027,7 +8027,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6257",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -8049,7 +8049,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6258",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -8082,7 +8082,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8124,7 +8124,7 @@
     "schemaDefinitions": {
       "SystemStateDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
         "const": {
           "PRD_1": 1,
           "SBY_2": 2,
@@ -8204,13 +8204,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "SystemStateDescriptionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDescriptionDataType",
         "required": [ "State" ],
         "properties": {
           "State": {
             "title": "SystemStateDataType",
             "description": "Denotes one of the basic SEMI E10 states",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -8256,13 +8256,13 @@
         "data": {
           "title": "SystemStateDescriptionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDescriptionDataType",
           "required": [ "State" ],
           "properties": {
             "State": {
               "title": "SystemStateDataType",
               "description": "Denotes one of the basic SEMI E10 states",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8292,7 +8292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8388,7 +8388,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -8492,7 +8492,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -8513,7 +8513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8540,7 +8540,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -8565,7 +8565,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -8671,7 +8671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8698,7 +8698,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -8723,7 +8723,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -8745,7 +8745,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -9004,7 +9004,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9112,7 +9112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9138,7 +9138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9166,7 +9166,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9178,7 +9178,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -9197,7 +9197,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -9207,7 +9207,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -9234,7 +9234,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -9244,7 +9244,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -9292,7 +9292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9411,7 +9411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9553,7 +9553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9638,7 +9638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9664,7 +9664,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9710,7 +9710,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9756,7 +9756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9777,7 +9777,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9798,7 +9798,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9810,7 +9810,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -9831,7 +9831,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -9843,7 +9843,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9864,7 +9864,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -9881,7 +9881,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -9901,7 +9901,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -9927,7 +9927,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {

--- a/wot-codegen/opc-output-integrated/Machinery.Energy.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery.Energy.TM.json
@@ -9,7 +9,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IBaseFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IBaseFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -291,7 +291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IMassFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IMassFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -573,7 +573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IVolumeFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IVolumeFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -854,7 +854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_INonElectricalEnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.INonElectricalEnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -880,7 +880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -906,7 +906,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/Machinery.Jobs.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery.Jobs.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Jobs_JobManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -76,7 +76,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -97,7 +97,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -239,7 +239,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -324,7 +324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -370,7 +370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -416,7 +416,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -558,7 +558,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -576,7 +576,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -599,7 +599,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -617,7 +617,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -640,7 +640,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -658,7 +658,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -681,7 +681,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -699,7 +699,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -722,7 +722,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -740,7 +740,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -763,7 +763,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -781,7 +781,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -804,7 +804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -822,7 +822,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -845,7 +845,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -863,7 +863,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -886,14 +886,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -914,7 +914,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -932,7 +932,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -954,7 +954,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1009,7 +1009,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1031,7 +1031,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1067,7 +1067,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1094,7 +1094,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1120,7 +1120,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1142,7 +1142,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1181,7 +1181,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1208,7 +1208,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1234,7 +1234,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1256,7 +1256,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1295,7 +1295,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1322,7 +1322,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1348,7 +1348,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1370,7 +1370,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1409,7 +1409,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1447,7 +1447,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1473,7 +1473,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1495,7 +1495,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1540,7 +1540,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -1563,14 +1563,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -1591,7 +1591,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1609,7 +1609,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1631,7 +1631,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1686,7 +1686,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1708,7 +1708,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1744,7 +1744,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1771,7 +1771,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1797,7 +1797,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1819,7 +1819,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1858,7 +1858,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1885,7 +1885,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1911,7 +1911,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1933,7 +1933,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1972,7 +1972,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1999,7 +1999,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2025,7 +2025,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2047,7 +2047,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2086,7 +2086,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2124,7 +2124,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2150,7 +2150,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2172,7 +2172,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2217,7 +2217,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2240,14 +2240,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -2268,7 +2268,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2286,7 +2286,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2308,7 +2308,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2363,7 +2363,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -2385,7 +2385,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2421,7 +2421,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2448,7 +2448,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2474,7 +2474,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2496,7 +2496,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2535,7 +2535,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2562,7 +2562,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2588,7 +2588,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2610,7 +2610,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2649,7 +2649,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2676,7 +2676,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2702,7 +2702,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2724,7 +2724,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2763,7 +2763,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2801,7 +2801,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -2827,7 +2827,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2849,7 +2849,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2894,7 +2894,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2939,14 +2939,14 @@
           "title": "ISA95JobOrderAndStateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
           "required": [ "JobOrder", "State" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -2967,7 +2967,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2985,7 +2985,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3007,7 +3007,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3062,7 +3062,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -3084,7 +3084,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3120,7 +3120,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3147,7 +3147,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3173,7 +3173,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3195,7 +3195,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3234,7 +3234,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3261,7 +3261,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3287,7 +3287,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3309,7 +3309,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3348,7 +3348,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3375,7 +3375,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3401,7 +3401,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3423,7 +3423,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3462,7 +3462,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3500,7 +3500,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3526,7 +3526,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3548,7 +3548,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3589,14 +3589,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -3604,7 +3604,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -3734,7 +3734,7 @@
           "title": "ISA95WorkMasterDataType",
           "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -3752,7 +3752,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -3774,7 +3774,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3842,14 +3842,14 @@
             "title": "ISA95JobOrderAndStateDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
             "required": [ "JobOrder", "State" ],
             "properties": {
               "JobOrder": {
                 "title": "ISA95JobOrderDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
                 "required": [ "JobOrderID" ],
                 "properties": {
                   "JobOrderID": {
@@ -3870,7 +3870,7 @@
                       "title": "ISA95WorkMasterDataType",
                       "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -3888,7 +3888,7 @@
                             "title": "ISA95ParameterDataType",
                             "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -3910,7 +3910,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -3965,7 +3965,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3987,7 +3987,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -4023,7 +4023,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -4050,7 +4050,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -4076,7 +4076,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -4098,7 +4098,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -4137,7 +4137,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -4164,7 +4164,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -4190,7 +4190,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -4212,7 +4212,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -4251,7 +4251,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -4278,7 +4278,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -4304,7 +4304,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -4326,7 +4326,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -4365,7 +4365,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -4403,7 +4403,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -4429,7 +4429,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -4451,7 +4451,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -4492,14 +4492,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -4507,7 +4507,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -4628,7 +4628,7 @@
             "title": "ISA95WorkMasterDataType",
             "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
             "required": [ "ID" ],
             "properties": {
               "ID": {
@@ -4646,7 +4646,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -4668,7 +4668,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -4719,7 +4719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobResponseProviderObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseProviderObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4752,7 +4752,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6042",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID" ],
           "properties": {
             "JobOrderID": {
@@ -4763,14 +4763,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponse", "ReturnStatus" ],
           "properties": {
             "JobResponse": {
               "title": "ISA95JobResponseDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
               "required": [ "JobResponseID", "JobOrderID", "JobState" ],
               "properties": {
                 "JobResponseID": {
@@ -4802,14 +4802,14 @@
                     "title": "ISA95StateDataType",
                     "description": "Defines the information needed to schedule and execute a job.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                     "required": [ "BrowsePath", "StateText", "StateNumber" ],
                     "properties": {
                       "BrowsePath": {
                         "title": "RelativePath",
                         "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                         "required": [ "Elements" ],
                         "properties": {
                           "Elements": {
@@ -4817,7 +4817,7 @@
                             "items": {
                               "title": "RelativePathElement",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                              "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                               "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                               "properties": {
                                 "ReferenceTypeId": {
@@ -4857,7 +4857,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -4879,7 +4879,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4915,7 +4915,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4942,7 +4942,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4968,7 +4968,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4990,7 +4990,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5029,7 +5029,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5056,7 +5056,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5082,7 +5082,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5104,7 +5104,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5143,7 +5143,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5170,7 +5170,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5196,7 +5196,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5218,7 +5218,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5257,7 +5257,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -5295,7 +5295,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5321,7 +5321,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5343,7 +5343,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5397,7 +5397,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6016",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderState" ],
           "properties": {
             "JobOrderState": {
@@ -5407,14 +5407,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -5422,7 +5422,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -5459,7 +5459,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6017",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponses", "ReturnStatus" ],
           "properties": {
             "JobResponses": {
@@ -5469,7 +5469,7 @@
                 "title": "ISA95JobResponseDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
                 "required": [ "JobResponseID", "JobOrderID", "JobState" ],
                 "properties": {
                   "JobResponseID": {
@@ -5501,14 +5501,14 @@
                       "title": "ISA95StateDataType",
                       "description": "Defines the information needed to schedule and execute a job.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                       "required": [ "BrowsePath", "StateText", "StateNumber" ],
                       "properties": {
                         "BrowsePath": {
                           "title": "RelativePath",
                           "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                           "required": [ "Elements" ],
                           "properties": {
                             "Elements": {
@@ -5516,7 +5516,7 @@
                               "items": {
                                 "title": "RelativePathElement",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                                "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                                 "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                                 "properties": {
                                   "ReferenceTypeId": {
@@ -5556,7 +5556,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -5578,7 +5578,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5614,7 +5614,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -5641,7 +5641,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5667,7 +5667,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -5689,7 +5689,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -5728,7 +5728,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -5755,7 +5755,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5781,7 +5781,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -5803,7 +5803,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -5842,7 +5842,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -5869,7 +5869,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5895,7 +5895,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -5917,7 +5917,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -5956,7 +5956,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -5994,7 +5994,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6020,7 +6020,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -6042,7 +6042,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -6102,7 +6102,7 @@
           "title": "ISA95JobResponseDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
           "required": [ "JobResponseID", "JobOrderID", "JobState" ],
           "properties": {
             "JobResponseID": {
@@ -6134,14 +6134,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -6149,7 +6149,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -6189,7 +6189,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -6211,7 +6211,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -6247,7 +6247,7 @@
                 "title": "ISA95PersonnelDataType",
                 "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -6274,7 +6274,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -6300,7 +6300,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -6322,7 +6322,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6361,7 +6361,7 @@
                 "title": "ISA95EquipmentDataType",
                 "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -6388,7 +6388,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -6414,7 +6414,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -6436,7 +6436,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6475,7 +6475,7 @@
                 "title": "ISA95PhysicalAssetDataType",
                 "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -6502,7 +6502,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -6528,7 +6528,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -6550,7 +6550,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6589,7 +6589,7 @@
                 "title": "ISA95MaterialDataType",
                 "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                 "properties": {
                   "MaterialClassID": {
                     "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -6627,7 +6627,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -6653,7 +6653,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -6675,7 +6675,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6733,7 +6733,7 @@
             "title": "ISA95JobResponseDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
             "required": [ "JobResponseID", "JobOrderID", "JobState" ],
             "properties": {
               "JobResponseID": {
@@ -6765,14 +6765,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -6780,7 +6780,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -6820,7 +6820,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -6842,7 +6842,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -6878,7 +6878,7 @@
                   "title": "ISA95PersonnelDataType",
                   "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -6905,7 +6905,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -6931,7 +6931,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -6953,7 +6953,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -6992,7 +6992,7 @@
                   "title": "ISA95EquipmentDataType",
                   "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -7019,7 +7019,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -7045,7 +7045,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -7067,7 +7067,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -7106,7 +7106,7 @@
                   "title": "ISA95PhysicalAssetDataType",
                   "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -7133,7 +7133,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -7159,7 +7159,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -7181,7 +7181,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -7220,7 +7220,7 @@
                   "title": "ISA95MaterialDataType",
                   "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                   "properties": {
                     "MaterialClassID": {
                       "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7258,7 +7258,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -7284,7 +7284,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -7306,7 +7306,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {

--- a/wot-codegen/opc-output-integrated/Machinery.ProcessValues.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery.ProcessValues.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ZeroPointAdjustmentEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ZeroPointAdjustmentEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -65,7 +65,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -459,7 +459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -555,7 +555,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -659,7 +659,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -680,7 +680,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -736,7 +736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -804,7 +804,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1046,7 +1046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1085,7 +1085,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -1116,7 +1116,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1144,7 +1144,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1172,7 +1172,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1209,7 +1209,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1237,7 +1237,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1562,7 +1562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1589,7 +1589,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1614,7 +1614,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1720,7 +1720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1747,7 +1747,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1772,7 +1772,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -1794,7 +1794,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -2053,7 +2053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2137,7 +2137,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2156,7 +2156,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -2176,7 +2176,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -2208,7 +2208,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2251,7 +2251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2393,7 +2393,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2478,7 +2478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2524,7 +2524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2570,7 +2570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2596,7 +2596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2622,7 +2622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2696,7 +2696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2792,7 +2792,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Machinery.Result.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery.Result.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -73,14 +73,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -146,7 +146,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -181,7 +181,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -236,14 +236,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -309,7 +309,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -344,7 +344,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -397,7 +397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -421,7 +421,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -450,7 +450,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -546,7 +546,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -560,7 +560,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -592,7 +592,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -605,7 +605,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -618,14 +618,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -691,7 +691,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -726,7 +726,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -781,7 +781,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -798,7 +798,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -811,14 +811,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -884,7 +884,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -919,7 +919,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -973,14 +973,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -988,12 +988,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -1015,7 +1015,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -1023,7 +1023,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -1060,7 +1060,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -1096,7 +1096,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -1109,7 +1109,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -1160,7 +1160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1174,14 +1174,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -1194,7 +1194,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1236,7 +1236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1332,7 +1332,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -1436,7 +1436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1457,7 +1457,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1483,7 +1483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1511,7 +1511,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1523,7 +1523,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1542,7 +1542,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1552,7 +1552,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1579,7 +1579,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1589,7 +1589,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1637,7 +1637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1756,7 +1756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1898,7 +1898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1983,7 +1983,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2009,7 +2009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2055,7 +2055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Machinery.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineTagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineTagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineryEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineryEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineryItemVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineryItemVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -273,7 +273,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -319,7 +319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -571,7 +571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -653,7 +653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryComponentIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -722,7 +722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -835,7 +835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -897,7 +897,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryLifetimeCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryLifetimeCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -990,7 +990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1060,7 +1060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1116,7 +1116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineComponentsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1178,7 +1178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1528,7 +1528,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ITagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15048",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ITagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1585,7 +1585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15035",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1792,7 +1792,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1863,7 +1863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1889,7 +1889,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1910,7 +1910,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1936,7 +1936,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2078,7 +2078,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2163,7 +2163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2209,7 +2209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Machinery_Example.TM.json
+++ b/wot-codegen/opc-output-integrated/Machinery_Example.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Example_ExampleComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery_Example/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery_Example.ExampleComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,7 +40,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Example_ExampleMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery_Example/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery_Example.ExampleMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -72,7 +72,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -93,7 +93,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -119,7 +119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryComponentIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -188,7 +188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -440,7 +440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/MetalForming.TM.json
+++ b/wot-codegen/opc-output-integrated/MetalForming.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_AllowableTiltingExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.AllowableTiltingExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_BreakthroughTonnageExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.BreakthroughTonnageExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CorrectionValueOutOfRangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CorrectionValueOutOfRangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_EccentricLoadExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.EccentricLoadExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_OverloadTriggeredConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.OverloadTriggeredConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_PositionOutOfRangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.PositionOutOfRangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_ProcessForceExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.ProcessForceExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CyclicEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -330,7 +330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingMultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingMultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -395,7 +395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_ProcessWorkingUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.ProcessWorkingUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -440,7 +440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CyclicProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueType",
     "links": [
       {
         "rel": "tm:extends",
@@ -474,7 +474,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MetalForming/",
         "title": "CyclicProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueDataType",
         "required": [ "AnalogSignal", "Setpoint", "CycleCount", "IsActive" ],
         "properties": {
           "AnalogSignal": {
@@ -513,7 +513,7 @@
         "data": {
           "title": "CyclicProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueDataType",
           "required": [ "AnalogSignal", "Setpoint", "CycleCount", "IsActive" ],
           "properties": {
             "AnalogSignal": {
@@ -551,7 +551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingProcessWorkingUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingProcessWorkingUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -584,7 +584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingPositionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingPositionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -640,7 +640,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11164",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -666,7 +666,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -692,7 +692,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -713,7 +713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -809,7 +809,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -913,7 +913,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -969,7 +969,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1037,7 +1037,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1279,7 +1279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1318,7 +1318,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -1349,7 +1349,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1377,7 +1377,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1405,7 +1405,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1442,7 +1442,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1470,7 +1470,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1795,7 +1795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1822,7 +1822,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1847,7 +1847,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -1953,7 +1953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1980,7 +1980,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2005,7 +2005,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -2027,7 +2027,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -2286,7 +2286,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2370,7 +2370,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2389,7 +2389,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -2409,7 +2409,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -2441,7 +2441,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2484,7 +2484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2626,7 +2626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2711,7 +2711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2757,7 +2757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2803,7 +2803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2829,7 +2829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2855,7 +2855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2930,7 +2930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3324,7 +3324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3420,7 +3420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3475,7 +3475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3538,7 +3538,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=51",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3571,7 +3571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3588,7 +3588,7 @@
     "schemaDefinitions": {
       "ToolManagement": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "const": {
           "NumberBased": 0,
           "GroupBased": 1,
@@ -3656,7 +3656,7 @@
       "ControlIdentifierInterpretation": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ToolManagement",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3742,7 +3742,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ToolManagement",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3806,7 +3806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3832,7 +3832,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3877,7 +3877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Mining.DevelopmentSupport.Dozer.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.DevelopmentSupport.Dozer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_DevelopmentSupport_Dozer_DozerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/DevelopmentSupport/Dozer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.DevelopmentSupport.Dozer.DozerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -47,7 +47,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -109,7 +109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -165,7 +165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -236,7 +236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -258,7 +258,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -280,7 +280,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -302,7 +302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -312,7 +312,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -334,7 +334,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -427,7 +427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -448,7 +448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -474,7 +474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -536,7 +536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -606,7 +606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.DevelopmentSupport.RoofSupportSystem.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.DevelopmentSupport.RoofSupportSystem.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_DevelopmentSupport_RoofSupportSystem_RoofSupportSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/DevelopmentSupport/RoofSupportSystem/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.DevelopmentSupport.RoofSupportSystem.RoofSupportSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -41,7 +41,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -159,7 +159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -230,7 +230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -252,7 +252,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -274,7 +274,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -296,7 +296,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -306,7 +306,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -328,7 +328,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -421,7 +421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -468,7 +468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -530,7 +530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -600,7 +600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.ExternalStandards.IREDES.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.ExternalStandards.IREDES.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_DisplayToOperatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DisplayToOperatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "DispFlag": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
         "const": {
           "MachStart": 0,
           "FileLoad": 1
@@ -95,7 +95,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "DispFlag",
         "description": "States under which circumstances the line (message) has to be displayed to the operator.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -152,7 +152,7 @@
         "data": {
           "title": "DispFlag",
           "description": "States under which circumstances the line (message) has to be displayed to the operator.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_EquipmentInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.EquipmentInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -408,7 +408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_GenHeadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.GenHeadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -518,7 +518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_GenTrailerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.GenTrailerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -611,7 +611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IREDESType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IREDESType",
     "links": [
       {
         "rel": "tm:extends",
@@ -702,7 +702,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLHDTruckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLHDTruckType",
     "dov:isComposite": true,
     "links": [
       {
@@ -759,7 +759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTMMonType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTMMonType",
     "links": [
       {
         "rel": "tm:extends",
@@ -850,7 +850,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTPlanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTPlanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -942,7 +942,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTPPerfType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTPPerfType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1033,7 +1033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IROptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IROptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1126,7 +1126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRplanGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRplanGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1325,7 +1325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRpPerfGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRpPerfGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1473,7 +1473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRreplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRreplyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1568,7 +1568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRStatusGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRStatusGenType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1749,7 +1749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRWorkOrderGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRWorkOrderGenType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1785,7 +1785,7 @@
         "title": "JobAssignmentTimeDataType",
         "description": "Time the execution of the job is expected to take.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.JobAssignmentTimeDataType",
         "properties": {
           "ExpectedFinishTime": {
             "description": "Time Machine is expected to finish the job.",
@@ -2034,7 +2034,7 @@
           "title": "JobAssignmentTimeDataType",
           "description": "Time the execution of the job is expected to take.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.JobAssignmentTimeDataType",
           "properties": {
             "ExpectedFinishTime": {
               "description": "Time Machine is expected to finish the job.",
@@ -2197,7 +2197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRWorkOrderReplyGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRWorkOrderReplyGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2208,7 +2208,7 @@
     "schemaDefinitions": {
       "Answer": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
         "const": {
           "Accepted": 0,
           "Delayed": 1,
@@ -2259,7 +2259,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "Answer",
         "description": "See Answer enumeration.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2379,7 +2379,7 @@
         "data": {
           "title": "Answer",
           "description": "See Answer enumeration.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2465,7 +2465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPaccPtsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPaccPtsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2765,7 +2765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPLoadRepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPLoadRepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2970,7 +2970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPMissionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMissionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2981,7 +2981,7 @@
     "schemaDefinitions": {
       "LTPPMaction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
         "const": {
           "Load": 0,
           "Dump": 1,
@@ -3014,7 +3014,7 @@
       },
       "LTPPMptFromType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
         "const": {
           "LoadPt": 0,
           "DumpPt": 1,
@@ -3047,7 +3047,7 @@
       },
       "LTPPMptToType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
         "const": {
           "LoadPt": 0,
           "DumpPt": 1,
@@ -3125,7 +3125,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMaction",
         "description": "Action to be carried out at destination point specified in LTPPMptTo.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3297,7 +3297,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMptFromType",
         "description": "Type of the point where the mission started.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3355,7 +3355,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMptToType",
         "description": "Type of the point where the mission ended.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3476,7 +3476,7 @@
         "data": {
           "title": "LTPPMaction",
           "description": "Action to be carried out at destination point specified in LTPPMptTo.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3582,7 +3582,7 @@
         "data": {
           "title": "LTPPMptFromType",
           "description": "Type of the point where the mission started.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3628,7 +3628,7 @@
         "data": {
           "title": "LTPPMptToType",
           "description": "Type of the point where the mission ended.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3713,7 +3713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPTimeRepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPTimeRepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3807,7 +3807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPwaitProcType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPwaitProcType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4072,7 +4072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_OpPerfLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.OpPerfLogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4336,7 +4336,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_ProjectInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ProjectInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4461,7 +4461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_SiteHeadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.SiteHeadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4516,7 +4516,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/Mining.Extraction.ShearerLoader.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.Extraction.ShearerLoader.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Extraction_ShearerLoader_ShearerLoaderDrumType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Extraction/ShearerLoader/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Extraction.ShearerLoader.ShearerLoaderDrumType",
     "dov:isComposite": true,
     "links": [
       {
@@ -41,7 +41,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Extraction_ShearerLoader_ShearerLoaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Extraction/ShearerLoader/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Extraction.ShearerLoader.ShearerLoaderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -80,7 +80,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -142,7 +142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -198,7 +198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -269,7 +269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -291,7 +291,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -313,7 +313,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -335,7 +335,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -345,7 +345,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -367,7 +367,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -460,7 +460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -481,7 +481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -507,7 +507,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -569,7 +569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -639,7 +639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.General.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -192,7 +192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -274,7 +274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -526,7 +526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -588,7 +588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -658,7 +658,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -714,7 +714,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -785,7 +785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -841,7 +841,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -863,7 +863,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -885,7 +885,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -907,7 +907,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -917,7 +917,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -939,7 +939,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -1032,7 +1032,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1058,7 +1058,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/Mining.Loading.General.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.Loading.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Loading_General_LoadingMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Loading/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Loading.General.LoadingMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -67,7 +67,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -185,7 +185,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -278,7 +278,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -300,7 +300,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -322,7 +322,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -332,7 +332,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -354,7 +354,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -447,7 +447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -468,7 +468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -494,7 +494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -556,7 +556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -626,7 +626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.Loading.HydraulicExcavator.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.Loading.HydraulicExcavator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Loading_HydraulicExcavator_HydraulicExcavatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Loading/HydraulicExcavator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Loading.HydraulicExcavator.HydraulicExcavatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -97,7 +97,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -153,7 +153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -246,7 +246,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -268,7 +268,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -290,7 +290,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -300,7 +300,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -322,7 +322,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -415,7 +415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -436,7 +436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -462,7 +462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -524,7 +524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -594,7 +594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.MineralProcessing.RockCrusher.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.MineralProcessing.RockCrusher.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_MineralProcessing_RockCrusher_RockCrusherControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/MineralProcessing/RockCrusher/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.MineralProcessing.RockCrusher.RockCrusherControlType",
     "dov:isComposite": true,
     "links": [
       {
@@ -47,7 +47,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_MineralProcessing_RockCrusher_RockCrusherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/MineralProcessing/RockCrusher/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.MineralProcessing.RockCrusher.RockCrusherType",
     "dov:isComposite": true,
     "links": [
       {
@@ -74,7 +74,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -136,7 +136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -192,7 +192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -263,7 +263,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -285,7 +285,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -307,7 +307,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -329,7 +329,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -339,7 +339,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -361,7 +361,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -454,7 +454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -475,7 +475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -501,7 +501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -563,7 +563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -633,7 +633,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.PELOServices.FaceAlignmentSystem.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.PELOServices.FaceAlignmentSystem.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_PELOServices_FaceAlignmentSystem_FaceAlignmentSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/PELOServices/FaceAlignmentSystem/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.PELOServices.FaceAlignmentSystem.FaceAlignmentSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -41,7 +41,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -159,7 +159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -230,7 +230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -252,7 +252,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -274,7 +274,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -296,7 +296,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -306,7 +306,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -328,7 +328,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -421,7 +421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -468,7 +468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -530,7 +530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -600,7 +600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.TransportDumping.ArmouredFaceConveyor.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.TransportDumping.ArmouredFaceConveyor.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_ArmouredFaceConveyor_AFCType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/ArmouredFaceConveyor/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.ArmouredFaceConveyor.AFCType",
     "dov:isComposite": true,
     "links": [
       {
@@ -41,7 +41,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -159,7 +159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -230,7 +230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -252,7 +252,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -274,7 +274,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -296,7 +296,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -306,7 +306,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -328,7 +328,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -421,7 +421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -468,7 +468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -530,7 +530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -600,7 +600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.TransportDumping.General.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.TransportDumping.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_General_HaulageMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/General/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.General.HaulageMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -67,7 +67,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -185,7 +185,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -278,7 +278,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -300,7 +300,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -322,7 +322,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -332,7 +332,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -354,7 +354,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -447,7 +447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -468,7 +468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -494,7 +494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -556,7 +556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -626,7 +626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/Mining.TransportDumping.RearDumpTruck.TM.json
+++ b/wot-codegen/opc-output-integrated/Mining.TransportDumping.RearDumpTruck.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_RearDumpTruck_RearDumpTruckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/RearDumpTruck/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.RearDumpTruck.RearDumpTruckType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -97,7 +97,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -153,7 +153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -246,7 +246,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -268,7 +268,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -290,7 +290,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -300,7 +300,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -322,7 +322,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -415,7 +415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -436,7 +436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -462,7 +462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -524,7 +524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -594,7 +594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-integrated/OPENSCS-SER.TM.json
+++ b/wot-codegen/opc-output-integrated/OPENSCS-SER.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSAggregationManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15094",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -99,7 +99,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AggregationElement", "ParentSNFormat", "PackedElementSNFormat", "AggregationContext" ],
           "properties": {
             "AggregationElement": {
@@ -108,14 +108,14 @@
                 "title": "OPENSCSAggregationDataType",
                 "description": "Iidentifies a parent element and a collection of packed elements. This is used in the aggregation packing and unpacking methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationDataType",
                 "required": [ "ParentElement", "ParentElementCollection" ],
                 "properties": {
                   "ParentElement": {
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -128,7 +128,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -148,7 +148,7 @@
                     "title": "OPENSCSLabelCollectionDataType",
                     "description": "Identifies the Serial Number Collection that was added to, or removed from, the parent element.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
                     "required": [ "LabelCollection" ],
                     "properties": {
                       "LabelCollection": {
@@ -158,7 +158,7 @@
                           "title": "OPENSCSLabelDataType",
                           "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                           "required": [ "ID", "LabelProperties" ],
                           "properties": {
                             "ID": {
@@ -171,7 +171,7 @@
                               "items": {
                                 "title": "OPENSCSKeyValueDataType",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -194,7 +194,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -224,7 +224,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -242,13 +242,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -267,7 +267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=6011",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AggregationElement", "ParentSNFormat", "PackedElementSNFormat", "AggregationContext" ],
           "properties": {
             "AggregationElement": {
@@ -276,14 +276,14 @@
                 "title": "OPENSCSAggregationDataType",
                 "description": "Iidentifies a parent element and a collection of packed elements. This is used in the aggregation packing and unpacking methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationDataType",
                 "required": [ "ParentElement", "ParentElementCollection" ],
                 "properties": {
                   "ParentElement": {
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -296,7 +296,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -316,7 +316,7 @@
                     "title": "OPENSCSLabelCollectionDataType",
                     "description": "Identifies the Serial Number Collection that was added to, or removed from, the parent element.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
                     "required": [ "LabelCollection" ],
                     "properties": {
                       "LabelCollection": {
@@ -326,7 +326,7 @@
                           "title": "OPENSCSLabelDataType",
                           "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                           "required": [ "ID", "LabelProperties" ],
                           "properties": {
                             "ID": {
@@ -339,7 +339,7 @@
                               "items": {
                                 "title": "OPENSCSKeyValueDataType",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -362,7 +362,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -392,7 +392,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -410,12 +410,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=6013",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -459,7 +459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSEventManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15062",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSEventManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -477,7 +477,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -545,7 +545,7 @@
       },
       "OPENSCSSerialNumberStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
         "const": {
           "Unassigned0": 0,
           "Unallocated1": 1,
@@ -629,14 +629,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -646,7 +646,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -659,7 +659,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -682,7 +682,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -708,7 +708,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -726,13 +726,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -751,14 +751,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -768,7 +768,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -781,7 +781,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -804,7 +804,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -830,7 +830,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -848,13 +848,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15084",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -873,14 +873,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15080",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -890,7 +890,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -903,7 +903,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -926,7 +926,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -952,7 +952,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -970,13 +970,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15081",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -995,14 +995,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1012,7 +1012,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1025,7 +1025,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1048,7 +1048,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1074,7 +1074,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1092,13 +1092,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1117,14 +1117,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15077",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1134,7 +1134,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1147,7 +1147,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1170,7 +1170,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1196,7 +1196,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1214,13 +1214,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15078",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1239,14 +1239,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1256,7 +1256,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1269,7 +1269,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1292,7 +1292,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1318,7 +1318,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1336,13 +1336,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1361,14 +1361,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15074",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1378,7 +1378,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1391,7 +1391,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1414,7 +1414,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1440,7 +1440,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1458,13 +1458,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15075",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1483,14 +1483,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15068",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1500,7 +1500,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1513,7 +1513,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1536,7 +1536,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1562,7 +1562,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1580,13 +1580,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15069",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1605,14 +1605,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15071",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1622,7 +1622,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1635,7 +1635,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1658,7 +1658,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1684,7 +1684,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1702,13 +1702,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15072",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1727,14 +1727,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15092",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Identifies the Serial Number Collection.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -1748,7 +1748,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1776,7 +1776,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1794,13 +1794,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15093",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1882,7 +1882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSPoolManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15032",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSPoolManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1894,7 +1894,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -1962,7 +1962,7 @@
       },
       "OPENSCSSerialNumberStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
         "const": {
           "Unassigned0": 0,
           "Unallocated1": 1,
@@ -2041,7 +2041,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2064,7 +2064,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2086,13 +2086,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2101,7 +2101,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2115,7 +2115,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2151,7 +2151,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2174,7 +2174,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2196,13 +2196,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2211,7 +2211,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2225,7 +2225,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2261,7 +2261,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15060",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2284,7 +2284,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2306,13 +2306,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15061",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2321,7 +2321,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2335,7 +2335,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2371,14 +2371,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Contains a Serial Number Collection from which Serial Numbers were originally provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2392,7 +2392,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2416,7 +2416,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2438,13 +2438,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2463,14 +2463,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Contains a Serial Number Collection from which Serial Numbers were originally provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2484,7 +2484,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2508,7 +2508,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2530,13 +2530,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2555,13 +2555,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15111",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2575,7 +2575,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2598,7 +2598,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2619,12 +2619,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15112",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2643,13 +2643,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15039",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2663,7 +2663,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2686,7 +2686,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2707,12 +2707,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15040",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2731,13 +2731,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15045",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2751,7 +2751,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2774,7 +2774,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2795,12 +2795,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15046",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2865,7 +2865,7 @@
         "items": {
           "title": "OPENSCSKeyValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -2915,7 +2915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSSIDClassObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15102",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSIDClassObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3007,7 +3007,7 @@
         "items": {
           "title": "OPENSCSSIDClassPropertyDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSIDClassPropertyDataType",
           "required": [ "PropertyID", "PropertyDescription", "PropertyValue", "LabelProperty" ],
           "properties": {
             "PropertyID": {
@@ -3028,7 +3028,7 @@
               "items": {
                 "title": "OPENSCSLabelPropertyDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15007",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelPropertyDataType",
                 "required": [ "PropertyID", "PropertyDescription", "PropertyValue" ],
                 "properties": {
                   "PropertyID": {
@@ -3087,7 +3087,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3108,7 +3108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3136,7 +3136,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3148,7 +3148,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -3167,7 +3167,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3177,7 +3177,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -3204,7 +3204,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3214,7 +3214,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -3262,7 +3262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3381,7 +3381,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3523,7 +3523,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3608,7 +3608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3634,7 +3634,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3680,7 +3680,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Onboarding.TM.json
+++ b/wot-codegen/opc-output-integrated/Onboarding.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrarAdminType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1175",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrarAdminType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35,7 +35,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -48,7 +48,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1178",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -71,7 +71,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -84,7 +84,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -118,7 +118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1259",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrarType",
     "links": [
       {
         "rel": "tm:extends",
@@ -135,7 +135,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -163,7 +163,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1506",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Managers" ],
           "properties": {
             "Managers": {
@@ -171,7 +171,7 @@
               "items": {
                 "title": "ManagerDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1495",
+                "dov:typeRef": "org.opcfoundation.UA.Onboarding.ManagerDescription",
                 "required": [ "Name", "IsRequired", "PurposeUri", "ProtocolUri", "EndpointUrls" ],
                 "properties": {
                   "Name": {
@@ -209,7 +209,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1261",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identities", "Issuers", "Tickets" ],
           "properties": {
             "Identities": {
@@ -236,7 +236,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1262",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SelectedIdentity", "MatchingTicket", "ApplicationId", "SoftwareUpdateManager" ],
           "properties": {
             "SelectedIdentity": {
@@ -246,7 +246,7 @@
             "MatchingTicket": {
               "title": "BaseTicketType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1165",
+              "dov:typeRef": "org.opcfoundation.UA.Onboarding.BaseTicketType",
               "required": [ "ManufacturerName", "ModelName", "ModelVersion", "HardwareRevision", "SoftwareRevision", "SerialNumber", "ManufactureDate", "Authorities" ],
               "properties": {
                 "ManufacturerName": {
@@ -276,7 +276,7 @@
                   "items": {
                     "title": "CertificateAuthorityType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1164",
+                    "dov:typeRef": "org.opcfoundation.UA.Onboarding.CertificateAuthorityType",
                     "required": [ "AuthorityCertificate", "IssuerCertificates" ],
                     "properties": {
                       "AuthorityCertificate": {
@@ -301,7 +301,7 @@
             "SoftwareUpdateManager": {
               "title": "ManagerDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1495",
+              "dov:typeRef": "org.opcfoundation.UA.Onboarding.ManagerDescription",
               "required": [ "Name", "IsRequired", "PurposeUri", "ProtocolUri", "EndpointUrls" ],
               "properties": {
                 "Name": {
@@ -338,13 +338,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1264",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -358,7 +358,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -391,13 +391,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1508",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application", "ProtocolUri" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -408,7 +408,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -443,7 +443,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1509",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -463,7 +463,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1504",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Status", "SoftwareRevision" ],
           "properties": {
             "ProductInstanceUri": {
@@ -500,7 +500,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrationAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1517",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrationAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -546,7 +546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceIdentityAcceptedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1533",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceIdentityAcceptedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -617,7 +617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceSoftwareUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1552",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceSoftwareUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -675,7 +675,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -696,7 +696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12522",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -707,7 +707,7 @@
     "schemaDefinitions": {
       "TrustListValidationOptions": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "const": {
           "SuppressCertificateExpired": 0,
           "SuppressHostNameInvalid": 1,
@@ -760,7 +760,7 @@
       "AddCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12549",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Certificate", "IsTrustedCertificate" ],
           "properties": {
             "Certificate": {
@@ -783,7 +783,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12705",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -795,7 +795,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12547",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyChangesRequired" ],
           "properties": {
             "ApplyChangesRequired": {
@@ -814,7 +814,7 @@
       "OpenWithMasks": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12544",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Masks" ],
           "properties": {
             "Masks": {
@@ -826,7 +826,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12545",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -847,7 +847,7 @@
       "RemoveCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12551",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Thumbprint", "IsTrustedCertificate" ],
           "properties": {
             "Thumbprint": {
@@ -882,7 +882,7 @@
       },
       "DefaultValidationOptions": {
         "title": "TrustListValidationOptions",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -932,7 +932,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -953,7 +953,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -974,7 +974,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -986,7 +986,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -1007,7 +1007,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -1019,7 +1019,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1040,7 +1040,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -1057,7 +1057,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -1077,7 +1077,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -1103,7 +1103,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -1224,7 +1224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1325,7 +1325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1421,7 +1421,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {

--- a/wot-codegen/opc-output-integrated/OpcUaCore.TM.json
+++ b/wot-codegen/opc-output-integrated/OpcUaCore.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -29,7 +29,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -55,7 +55,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=75",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -81,7 +81,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeEncodingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=76",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeEncodingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -107,7 +107,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ModellingRuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=77",
+    "dov:typeRef": "org.opcfoundation.UA.ModellingRuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -133,7 +133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2004",
+    "dov:typeRef": "org.opcfoundation.UA.ServerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -174,7 +174,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -229,7 +229,7 @@
       "GetMonitoredItems": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11490",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -241,7 +241,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11491",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ServerHandles", "ClientHandles" ],
           "properties": {
             "ServerHandles": {
@@ -273,12 +273,12 @@
       "RequestServerStateChange": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12884",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State", "EstimatedReturnTime", "SecondsTillShutdown", "Reason", "Restart" ],
           "properties": {
             "State": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -311,7 +311,7 @@
       "ResendData": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12872",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -332,7 +332,7 @@
       "SetSubscriptionDurable": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "LifetimeInHours" ],
           "properties": {
             "SubscriptionId": {
@@ -349,7 +349,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedLifetimeInHours" ],
           "properties": {
             "RevisedLifetimeInHours": {
@@ -395,7 +395,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -447,7 +447,7 @@
       "ServerStatus": {
         "title": "ServerStatusDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=862",
+        "dov:typeRef": "org.opcfoundation.UA.ServerStatusDataType",
         "required": [ "StartTime", "CurrentTime", "State", "BuildInfo", "SecondsTillShutdown", "ShutdownReason" ],
         "properties": {
           "StartTime": {
@@ -460,7 +460,7 @@
           },
           "State": {
             "title": "ServerState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+            "dov:typeRef": "org.opcfoundation.UA.ServerState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -468,7 +468,7 @@
           "BuildInfo": {
             "title": "BuildInfo",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+            "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
             "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
             "properties": {
               "ProductUri": {
@@ -514,7 +514,7 @@
       "ServerStatus_BuildInfo": {
         "title": "BuildInfo",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+        "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
         "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
         "properties": {
           "ProductUri": {
@@ -675,7 +675,7 @@
       },
       "ServerStatus_State": {
         "title": "ServerState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -721,7 +721,7 @@
         "data": {
           "title": "ServerStatusDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=862",
+          "dov:typeRef": "org.opcfoundation.UA.ServerStatusDataType",
           "required": [ "StartTime", "CurrentTime", "State", "BuildInfo", "SecondsTillShutdown", "ShutdownReason" ],
           "properties": {
             "StartTime": {
@@ -734,7 +734,7 @@
             },
             "State": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -742,7 +742,7 @@
             "BuildInfo": {
               "title": "BuildInfo",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+              "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
               "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
               "properties": {
                 "ProductUri": {
@@ -789,7 +789,7 @@
         "data": {
           "title": "BuildInfo",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+          "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
           "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
           "properties": {
             "ProductUri": {
@@ -961,7 +961,7 @@
       "ServerStatus_State": {
         "data": {
           "title": "ServerState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+          "dov:typeRef": "org.opcfoundation.UA.ServerState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -986,7 +986,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2013",
+    "dov:typeRef": "org.opcfoundation.UA.ServerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1289,7 +1289,7 @@
         "items": {
           "title": "SignedSoftwareCertificate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=344",
+          "dov:typeRef": "org.opcfoundation.UA.SignedSoftwareCertificate",
           "required": [ "CertificateData", "Signature" ],
           "properties": {
             "CertificateData": {
@@ -1351,7 +1351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OperationLimitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11564",
+    "dov:typeRef": "org.opcfoundation.UA.OperationLimitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1540,7 +1540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15607",
+    "dov:typeRef": "org.opcfoundation.UA.RoleSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1560,7 +1560,7 @@
       "AddRole": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15998",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RoleName", "NamespaceUri" ],
           "properties": {
             "RoleName": {
@@ -1573,7 +1573,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15999",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RoleNodeId" ],
           "properties": {
             "RoleNodeId": {
@@ -1592,7 +1592,7 @@
       "RemoveRole": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16001",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RoleNodeId" ],
           "properties": {
             "RoleNodeId": {
@@ -1623,7 +1623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15620",
+    "dov:typeRef": "org.opcfoundation.UA.RoleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1634,7 +1634,7 @@
     "schemaDefinitions": {
       "IdentityCriteriaType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+        "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
         "const": {
           "UserName": 1,
           "Thumbprint": 2,
@@ -1687,7 +1687,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -1726,7 +1726,7 @@
       "AddApplication": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -1745,13 +1745,13 @@
       "AddEndpoint": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16181",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Endpoint" ],
           "properties": {
             "Endpoint": {
               "title": "EndpointType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointType",
               "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
               "properties": {
                 "EndpointUrl": {
@@ -1759,7 +1759,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1785,18 +1785,18 @@
       "AddIdentity": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15625",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Rule" ],
           "properties": {
             "Rule": {
               "title": "IdentityMappingRuleType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
               "required": [ "CriteriaType", "Criteria" ],
               "properties": {
                 "CriteriaType": {
                   "title": "IdentityCriteriaType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+                  "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1819,7 +1819,7 @@
       "RemoveApplication": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16179",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -1838,13 +1838,13 @@
       "RemoveEndpoint": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16183",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Endpoint" ],
           "properties": {
             "Endpoint": {
               "title": "EndpointType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointType",
               "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
               "properties": {
                 "EndpointUrl": {
@@ -1852,7 +1852,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1878,18 +1878,18 @@
       "RemoveIdentity": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15627",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Rule" ],
           "properties": {
             "Rule": {
               "title": "IdentityMappingRuleType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
               "required": [ "CriteriaType", "Criteria" ],
               "properties": {
                 "CriteriaType": {
                   "title": "IdentityCriteriaType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+                  "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1957,7 +1957,7 @@
         "items": {
           "title": "EndpointType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointType",
           "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
           "properties": {
             "EndpointUrl": {
@@ -1965,7 +1965,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2008,12 +2008,12 @@
         "items": {
           "title": "IdentityMappingRuleType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+          "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
           "required": [ "CriteriaType", "Criteria" ],
           "properties": {
             "CriteriaType": {
               "title": "IdentityCriteriaType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2045,7 +2045,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2020",
+    "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2102,7 +2102,7 @@
         "items": {
           "title": "SamplingIntervalDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=856",
+          "dov:typeRef": "org.opcfoundation.UA.SamplingIntervalDiagnosticsDataType",
           "required": [ "SamplingInterval", "MonitoredItemCount", "MaxMonitoredItemCount", "DisabledMonitoredItemCount" ],
           "properties": {
             "SamplingInterval": {
@@ -2138,7 +2138,7 @@
       "ServerDiagnosticsSummary": {
         "title": "ServerDiagnosticsSummaryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=859",
+        "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsSummaryDataType",
         "required": [ "ServerViewCount", "CurrentSessionCount", "CumulatedSessionCount", "SecurityRejectedSessionCount", "RejectedSessionCount", "SessionTimeoutCount", "SessionAbortCount", "CurrentSubscriptionCount", "CumulatedSubscriptionCount", "PublishingIntervalCount", "SecurityRejectedRequestsCount", "RejectedRequestsCount" ],
         "properties": {
           "ServerViewCount": {
@@ -2385,7 +2385,7 @@
         "items": {
           "title": "SubscriptionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+          "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
           "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
           "properties": {
             "SessionId": {
@@ -2557,7 +2557,7 @@
           "items": {
             "title": "SamplingIntervalDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=856",
+            "dov:typeRef": "org.opcfoundation.UA.SamplingIntervalDiagnosticsDataType",
             "required": [ "SamplingInterval", "MonitoredItemCount", "MaxMonitoredItemCount", "DisabledMonitoredItemCount" ],
             "properties": {
               "SamplingInterval": {
@@ -2594,7 +2594,7 @@
         "data": {
           "title": "ServerDiagnosticsSummaryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=859",
+          "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsSummaryDataType",
           "required": [ "ServerViewCount", "CurrentSessionCount", "CumulatedSessionCount", "SecurityRejectedSessionCount", "RejectedSessionCount", "SessionTimeoutCount", "SessionAbortCount", "CurrentSubscriptionCount", "CumulatedSubscriptionCount", "PublishingIntervalCount", "SecurityRejectedRequestsCount", "RejectedRequestsCount" ],
           "properties": {
             "ServerViewCount": {
@@ -2854,7 +2854,7 @@
           "items": {
             "title": "SubscriptionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+            "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
             "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
             "properties": {
               "SessionId": {
@@ -3029,7 +3029,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SessionsDiagnosticsSummaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2026",
+    "dov:typeRef": "org.opcfoundation.UA.SessionsDiagnosticsSummaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3046,7 +3046,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -3070,7 +3070,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -3113,7 +3113,7 @@
         "items": {
           "title": "SessionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+          "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
           "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
           "properties": {
             "SessionId": {
@@ -3125,7 +3125,7 @@
             "ClientDescription": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -3139,7 +3139,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -3205,7 +3205,7 @@
             "TotalRequestCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3228,7 +3228,7 @@
             "ReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3246,7 +3246,7 @@
             "HistoryReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3264,7 +3264,7 @@
             "WriteCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3282,7 +3282,7 @@
             "HistoryUpdateCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3300,7 +3300,7 @@
             "CallCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3318,7 +3318,7 @@
             "CreateMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3336,7 +3336,7 @@
             "ModifyMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3354,7 +3354,7 @@
             "SetMonitoringModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3372,7 +3372,7 @@
             "SetTriggeringCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3390,7 +3390,7 @@
             "DeleteMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3408,7 +3408,7 @@
             "CreateSubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3426,7 +3426,7 @@
             "ModifySubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3444,7 +3444,7 @@
             "SetPublishingModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3462,7 +3462,7 @@
             "PublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3480,7 +3480,7 @@
             "RepublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3498,7 +3498,7 @@
             "TransferSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3516,7 +3516,7 @@
             "DeleteSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3534,7 +3534,7 @@
             "AddNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3552,7 +3552,7 @@
             "AddReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3570,7 +3570,7 @@
             "DeleteNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3588,7 +3588,7 @@
             "DeleteReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3606,7 +3606,7 @@
             "BrowseCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3624,7 +3624,7 @@
             "BrowseNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3642,7 +3642,7 @@
             "TranslateBrowsePathsToNodeIdsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3660,7 +3660,7 @@
             "QueryFirstCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3678,7 +3678,7 @@
             "QueryNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3696,7 +3696,7 @@
             "RegisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3714,7 +3714,7 @@
             "UnregisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3745,7 +3745,7 @@
         "items": {
           "title": "SessionSecurityDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+          "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
           "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
           "properties": {
             "SessionId": {
@@ -3771,7 +3771,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3802,7 +3802,7 @@
           "items": {
             "title": "SessionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+            "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
             "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
             "properties": {
               "SessionId": {
@@ -3814,7 +3814,7 @@
               "ClientDescription": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -3828,7 +3828,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3894,7 +3894,7 @@
               "TotalRequestCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3917,7 +3917,7 @@
               "ReadCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3935,7 +3935,7 @@
               "HistoryReadCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3953,7 +3953,7 @@
               "WriteCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3971,7 +3971,7 @@
               "HistoryUpdateCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3989,7 +3989,7 @@
               "CallCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4007,7 +4007,7 @@
               "CreateMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4025,7 +4025,7 @@
               "ModifyMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4043,7 +4043,7 @@
               "SetMonitoringModeCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4061,7 +4061,7 @@
               "SetTriggeringCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4079,7 +4079,7 @@
               "DeleteMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4097,7 +4097,7 @@
               "CreateSubscriptionCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4115,7 +4115,7 @@
               "ModifySubscriptionCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4133,7 +4133,7 @@
               "SetPublishingModeCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4151,7 +4151,7 @@
               "PublishCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4169,7 +4169,7 @@
               "RepublishCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4187,7 +4187,7 @@
               "TransferSubscriptionsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4205,7 +4205,7 @@
               "DeleteSubscriptionsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4223,7 +4223,7 @@
               "AddNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4241,7 +4241,7 @@
               "AddReferencesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4259,7 +4259,7 @@
               "DeleteNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4277,7 +4277,7 @@
               "DeleteReferencesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4295,7 +4295,7 @@
               "BrowseCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4313,7 +4313,7 @@
               "BrowseNextCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4331,7 +4331,7 @@
               "TranslateBrowsePathsToNodeIdsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4349,7 +4349,7 @@
               "QueryFirstCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4367,7 +4367,7 @@
               "QueryNextCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4385,7 +4385,7 @@
               "RegisterNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4403,7 +4403,7 @@
               "UnregisterNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -4435,7 +4435,7 @@
           "items": {
             "title": "SessionSecurityDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+            "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
             "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
             "properties": {
               "SessionId": {
@@ -4461,7 +4461,7 @@
               },
               "SecurityMode": {
                 "title": "MessageSecurityMode",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4495,7 +4495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SessionDiagnosticsObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2029",
+    "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4506,7 +4506,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -4530,7 +4530,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -4585,7 +4585,7 @@
       "SessionDiagnostics": {
         "title": "SessionDiagnosticsDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+        "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
         "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
         "properties": {
           "SessionId": {
@@ -4597,7 +4597,7 @@
           "ClientDescription": {
             "title": "ApplicationDescription",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+            "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
             "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
             "properties": {
               "ApplicationUri": {
@@ -4611,7 +4611,7 @@
               },
               "ApplicationType": {
                 "title": "ApplicationType",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4677,7 +4677,7 @@
           "TotalRequestCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4700,7 +4700,7 @@
           "ReadCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4718,7 +4718,7 @@
           "HistoryReadCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4736,7 +4736,7 @@
           "WriteCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4754,7 +4754,7 @@
           "HistoryUpdateCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4772,7 +4772,7 @@
           "CallCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4790,7 +4790,7 @@
           "CreateMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4808,7 +4808,7 @@
           "ModifyMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4826,7 +4826,7 @@
           "SetMonitoringModeCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4844,7 +4844,7 @@
           "SetTriggeringCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4862,7 +4862,7 @@
           "DeleteMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4880,7 +4880,7 @@
           "CreateSubscriptionCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4898,7 +4898,7 @@
           "ModifySubscriptionCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4916,7 +4916,7 @@
           "SetPublishingModeCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4934,7 +4934,7 @@
           "PublishCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4952,7 +4952,7 @@
           "RepublishCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4970,7 +4970,7 @@
           "TransferSubscriptionsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4988,7 +4988,7 @@
           "DeleteSubscriptionsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5006,7 +5006,7 @@
           "AddNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5024,7 +5024,7 @@
           "AddReferencesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5042,7 +5042,7 @@
           "DeleteNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5060,7 +5060,7 @@
           "DeleteReferencesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5078,7 +5078,7 @@
           "BrowseCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5096,7 +5096,7 @@
           "BrowseNextCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5114,7 +5114,7 @@
           "TranslateBrowsePathsToNodeIdsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5132,7 +5132,7 @@
           "QueryFirstCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5150,7 +5150,7 @@
           "QueryNextCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5168,7 +5168,7 @@
           "RegisterNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5186,7 +5186,7 @@
           "UnregisterNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -5228,7 +5228,7 @@
       "SessionDiagnostics_AddNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5255,7 +5255,7 @@
       "SessionDiagnostics_AddReferencesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5282,7 +5282,7 @@
       "SessionDiagnostics_BrowseCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5309,7 +5309,7 @@
       "SessionDiagnostics_BrowseNextCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5336,7 +5336,7 @@
       "SessionDiagnostics_CallCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5376,7 +5376,7 @@
       "SessionDiagnostics_ClientDescription": {
         "title": "ApplicationDescription",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
         "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
         "properties": {
           "ApplicationUri": {
@@ -5390,7 +5390,7 @@
           },
           "ApplicationType": {
             "title": "ApplicationType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+            "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5434,7 +5434,7 @@
       "SessionDiagnostics_CreateMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5461,7 +5461,7 @@
       "SessionDiagnostics_CreateSubscriptionCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5530,7 +5530,7 @@
       "SessionDiagnostics_DeleteMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5557,7 +5557,7 @@
       "SessionDiagnostics_DeleteNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5584,7 +5584,7 @@
       "SessionDiagnostics_DeleteReferencesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5611,7 +5611,7 @@
       "SessionDiagnostics_DeleteSubscriptionsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5650,7 +5650,7 @@
       "SessionDiagnostics_HistoryReadCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5677,7 +5677,7 @@
       "SessionDiagnostics_HistoryUpdateCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5733,7 +5733,7 @@
       "SessionDiagnostics_ModifyMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5760,7 +5760,7 @@
       "SessionDiagnostics_ModifySubscriptionCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5787,7 +5787,7 @@
       "SessionDiagnostics_PublishCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5814,7 +5814,7 @@
       "SessionDiagnostics_QueryFirstCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5841,7 +5841,7 @@
       "SessionDiagnostics_QueryNextCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5868,7 +5868,7 @@
       "SessionDiagnostics_ReadCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5895,7 +5895,7 @@
       "SessionDiagnostics_RegisterNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5922,7 +5922,7 @@
       "SessionDiagnostics_RepublishCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5985,7 +5985,7 @@
       "SessionDiagnostics_SetMonitoringModeCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6012,7 +6012,7 @@
       "SessionDiagnostics_SetPublishingModeCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6039,7 +6039,7 @@
       "SessionDiagnostics_SetTriggeringCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6066,7 +6066,7 @@
       "SessionDiagnostics_TotalRequestCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6093,7 +6093,7 @@
       "SessionDiagnostics_TransferSubscriptionsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6120,7 +6120,7 @@
       "SessionDiagnostics_TranslateBrowsePathsToNodeIdsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6161,7 +6161,7 @@
       "SessionDiagnostics_UnregisterNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6188,7 +6188,7 @@
       "SessionDiagnostics_WriteCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -6215,7 +6215,7 @@
       "SessionSecurityDiagnostics": {
         "title": "SessionSecurityDiagnosticsDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+        "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
         "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
         "properties": {
           "SessionId": {
@@ -6241,7 +6241,7 @@
           },
           "SecurityMode": {
             "title": "MessageSecurityMode",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+            "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -6330,7 +6330,7 @@
       },
       "SessionSecurityDiagnostics_SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6385,7 +6385,7 @@
         "items": {
           "title": "SubscriptionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+          "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
           "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
           "properties": {
             "SessionId": {
@@ -6555,7 +6555,7 @@
         "data": {
           "title": "SessionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+          "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
           "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
           "properties": {
             "SessionId": {
@@ -6567,7 +6567,7 @@
             "ClientDescription": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -6581,7 +6581,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -6647,7 +6647,7 @@
             "TotalRequestCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6670,7 +6670,7 @@
             "ReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6688,7 +6688,7 @@
             "HistoryReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6706,7 +6706,7 @@
             "WriteCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6724,7 +6724,7 @@
             "HistoryUpdateCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6742,7 +6742,7 @@
             "CallCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6760,7 +6760,7 @@
             "CreateMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6778,7 +6778,7 @@
             "ModifyMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6796,7 +6796,7 @@
             "SetMonitoringModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6814,7 +6814,7 @@
             "SetTriggeringCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6832,7 +6832,7 @@
             "DeleteMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6850,7 +6850,7 @@
             "CreateSubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6868,7 +6868,7 @@
             "ModifySubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6886,7 +6886,7 @@
             "SetPublishingModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6904,7 +6904,7 @@
             "PublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6922,7 +6922,7 @@
             "RepublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6940,7 +6940,7 @@
             "TransferSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6958,7 +6958,7 @@
             "DeleteSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6976,7 +6976,7 @@
             "AddNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6994,7 +6994,7 @@
             "AddReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7012,7 +7012,7 @@
             "DeleteNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7030,7 +7030,7 @@
             "DeleteReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7048,7 +7048,7 @@
             "BrowseCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7066,7 +7066,7 @@
             "BrowseNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7084,7 +7084,7 @@
             "TranslateBrowsePathsToNodeIdsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7102,7 +7102,7 @@
             "QueryFirstCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7120,7 +7120,7 @@
             "QueryNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7138,7 +7138,7 @@
             "RegisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7156,7 +7156,7 @@
             "UnregisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -7200,7 +7200,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7228,7 +7228,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7256,7 +7256,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7284,7 +7284,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7312,7 +7312,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7354,7 +7354,7 @@
         "data": {
           "title": "ApplicationDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+          "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
           "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
           "properties": {
             "ApplicationUri": {
@@ -7368,7 +7368,7 @@
             },
             "ApplicationType": {
               "title": "ApplicationType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7414,7 +7414,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7442,7 +7442,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7515,7 +7515,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7543,7 +7543,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7571,7 +7571,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7599,7 +7599,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7640,7 +7640,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7668,7 +7668,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7727,7 +7727,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7755,7 +7755,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7783,7 +7783,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7811,7 +7811,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7839,7 +7839,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7867,7 +7867,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7895,7 +7895,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7923,7 +7923,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7990,7 +7990,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8018,7 +8018,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8046,7 +8046,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8074,7 +8074,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8102,7 +8102,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8130,7 +8130,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8173,7 +8173,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8201,7 +8201,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -8229,7 +8229,7 @@
         "data": {
           "title": "SessionSecurityDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+          "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
           "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
           "properties": {
             "SessionId": {
@@ -8255,7 +8255,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8350,7 +8350,7 @@
       "SessionSecurityDiagnostics_SecurityMode": {
         "data": {
           "title": "MessageSecurityMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+          "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8409,7 +8409,7 @@
           "items": {
             "title": "SubscriptionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+            "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
             "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
             "properties": {
               "SessionId": {
@@ -8584,7 +8584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_VendorServerInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2033",
+    "dov:typeRef": "org.opcfoundation.UA.VendorServerInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8610,7 +8610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2034",
+    "dov:typeRef": "org.opcfoundation.UA.ServerRedundancyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8621,7 +8621,7 @@
     "schemaDefinitions": {
       "RedundancySupport": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=851",
+        "dov:typeRef": "org.opcfoundation.UA.RedundancySupport",
         "const": {
           "None": 0,
           "Cold": 1,
@@ -8653,7 +8653,7 @@
       },
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -8704,7 +8704,7 @@
     "properties": {
       "RedundancySupport": {
         "title": "RedundancySupport",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=851",
+        "dov:typeRef": "org.opcfoundation.UA.RedundancySupport",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8722,7 +8722,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -8735,7 +8735,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8764,7 +8764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NamespacesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11645",
+    "dov:typeRef": "org.opcfoundation.UA.NamespacesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8796,7 +8796,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NamespaceMetadataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11616",
+    "dov:typeRef": "org.opcfoundation.UA.NamespaceMetadataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8813,7 +8813,7 @@
     "schemaDefinitions": {
       "IdType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=256",
+        "dov:typeRef": "org.opcfoundation.UA.IdType",
         "const": {
           "Numeric": 0,
           "String": 1,
@@ -8837,7 +8837,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -8913,7 +8913,7 @@
       },
       "AccessRestrictionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=95",
+        "dov:typeRef": "org.opcfoundation.UA.AccessRestrictionType",
         "const": {
           "SigningRequired": 0,
           "EncryptionRequired": 1,
@@ -8961,7 +8961,7 @@
       },
       "DefaultAccessRestrictions": {
         "title": "AccessRestrictionType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=95",
+        "dov:typeRef": "org.opcfoundation.UA.AccessRestrictionType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8979,7 +8979,7 @@
         "items": {
           "title": "RolePermissionType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+          "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
           "required": [ "RoleId", "Permissions" ],
           "properties": {
             "RoleId": {
@@ -8987,7 +8987,7 @@
             },
             "Permissions": {
               "title": "PermissionType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+              "dov:typeRef": "org.opcfoundation.UA.PermissionType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9008,7 +9008,7 @@
         "items": {
           "title": "RolePermissionType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+          "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
           "required": [ "RoleId", "Permissions" ],
           "properties": {
             "RoleId": {
@@ -9016,7 +9016,7 @@
             },
             "Permissions": {
               "title": "PermissionType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+              "dov:typeRef": "org.opcfoundation.UA.PermissionType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9092,7 +9092,7 @@
         "type": "array",
         "items": {
           "title": "IdType",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=256",
+          "dov:typeRef": "org.opcfoundation.UA.IdType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9144,7 +9144,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AddressSpaceFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11595",
+    "dov:typeRef": "org.opcfoundation.UA.AddressSpaceFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9179,7 +9179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9200,7 +9200,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9221,7 +9221,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9233,7 +9233,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -9254,7 +9254,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -9266,7 +9266,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -9287,7 +9287,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -9304,7 +9304,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -9324,7 +9324,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -9350,7 +9350,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -9471,7 +9471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransparentRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2036",
+    "dov:typeRef": "org.opcfoundation.UA.TransparentRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9483,7 +9483,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -9548,7 +9548,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -9561,7 +9561,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9590,7 +9590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2039",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9638,7 +9638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentNetworkRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11945",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentNetworkRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9664,7 +9664,7 @@
         "items": {
           "title": "NetworkGroupDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11944",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkGroupDataType",
           "required": [ "ServerUri", "NetworkPaths" ],
           "properties": {
             "ServerUri": {
@@ -9675,7 +9675,7 @@
               "items": {
                 "title": "EndpointUrlListDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11943",
+                "dov:typeRef": "org.opcfoundation.UA.EndpointUrlListDataType",
                 "required": [ "EndpointUrlList" ],
                 "properties": {
                   "EndpointUrlList": {
@@ -9711,7 +9711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentBackupRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32411",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentBackupRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9723,7 +9723,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -9763,7 +9763,7 @@
       },
       "RedundantServerMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32417",
+        "dov:typeRef": "org.opcfoundation.UA.RedundantServerMode",
         "const": {
           "PrimaryWithBackup": 0,
           "PrimaryOnly": 1,
@@ -9807,7 +9807,7 @@
     "properties": {
       "Mode": {
         "title": "RedundantServerMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32417",
+        "dov:typeRef": "org.opcfoundation.UA.RedundantServerMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9825,7 +9825,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -9838,7 +9838,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9867,7 +9867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9963,7 +9963,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -10067,7 +10067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10168,7 +10168,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditSecurityEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2058",
+    "dov:typeRef": "org.opcfoundation.UA.AuditSecurityEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10213,7 +10213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditChannelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2059",
+    "dov:typeRef": "org.opcfoundation.UA.AuditChannelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10258,7 +10258,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditOpenSecureChannelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2060",
+    "dov:typeRef": "org.opcfoundation.UA.AuditOpenSecureChannelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10270,7 +10270,7 @@
     "schemaDefinitions": {
       "SecurityTokenRequestType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=315",
+        "dov:typeRef": "org.opcfoundation.UA.SecurityTokenRequestType",
         "const": {
           "Issue": 0,
           "Renew": 1
@@ -10286,7 +10286,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -10368,7 +10368,7 @@
       },
       "RequestType": {
         "title": "SecurityTokenRequestType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=315",
+        "dov:typeRef": "org.opcfoundation.UA.SecurityTokenRequestType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10383,7 +10383,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10420,7 +10420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2069",
+    "dov:typeRef": "org.opcfoundation.UA.AuditSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10465,7 +10465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCreateSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2071",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCreateSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10545,7 +10545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUrlMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2748",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUrlMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10590,7 +10590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditActivateSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2075",
+    "dov:typeRef": "org.opcfoundation.UA.AuditActivateSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10616,7 +10616,7 @@
         "items": {
           "title": "SignedSoftwareCertificate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=344",
+          "dov:typeRef": "org.opcfoundation.UA.SignedSoftwareCertificate",
           "required": [ "CertificateData", "Signature" ],
           "properties": {
             "CertificateData": {
@@ -10666,7 +10666,7 @@
       "UserIdentityToken": {
         "title": "UserIdentityToken",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=316",
+        "dov:typeRef": "org.opcfoundation.UA.UserIdentityToken",
         "required": [ "PolicyId" ],
         "properties": {
           "PolicyId": {
@@ -10695,7 +10695,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCancelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2078",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCancelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10742,7 +10742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2080",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10788,7 +10788,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateDataMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2082",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateDataMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10844,7 +10844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateExpiredEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2085",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateExpiredEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10871,7 +10871,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateInvalidEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2086",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateInvalidEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10898,7 +10898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateUntrustedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2087",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateUntrustedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10925,7 +10925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateRevokedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2088",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateRevokedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10952,7 +10952,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2089",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10979,7 +10979,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditNodeManagementEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2090",
+    "dov:typeRef": "org.opcfoundation.UA.AuditNodeManagementEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11006,7 +11006,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditAddNodesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2091",
+    "dov:typeRef": "org.opcfoundation.UA.AuditAddNodesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11018,7 +11018,7 @@
     "schemaDefinitions": {
       "NodeClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+        "dov:typeRef": "org.opcfoundation.UA.NodeClass",
         "const": {
           "Unspecified": 0,
           "Object": 1,
@@ -11085,7 +11085,7 @@
         "items": {
           "title": "AddNodesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=376",
+          "dov:typeRef": "org.opcfoundation.UA.AddNodesItem",
           "required": [ "ParentNodeId", "ReferenceTypeId", "RequestedNewNodeId", "BrowseName", "NodeClass", "NodeAttributes", "TypeDefinition" ],
           "properties": {
             "ParentNodeId": {
@@ -11102,7 +11102,7 @@
             },
             "NodeClass": {
               "title": "NodeClass",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+              "dov:typeRef": "org.opcfoundation.UA.NodeClass",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -11137,7 +11137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditDeleteNodesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2093",
+    "dov:typeRef": "org.opcfoundation.UA.AuditDeleteNodesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11163,7 +11163,7 @@
         "items": {
           "title": "DeleteNodesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=382",
+          "dov:typeRef": "org.opcfoundation.UA.DeleteNodesItem",
           "required": [ "NodeId", "DeleteTargetReferences" ],
           "properties": {
             "NodeId": {
@@ -11196,7 +11196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditAddReferencesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2095",
+    "dov:typeRef": "org.opcfoundation.UA.AuditAddReferencesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11208,7 +11208,7 @@
     "schemaDefinitions": {
       "NodeClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+        "dov:typeRef": "org.opcfoundation.UA.NodeClass",
         "const": {
           "Unspecified": 0,
           "Object": 1,
@@ -11275,7 +11275,7 @@
         "items": {
           "title": "AddReferencesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=379",
+          "dov:typeRef": "org.opcfoundation.UA.AddReferencesItem",
           "required": [ "SourceNodeId", "ReferenceTypeId", "IsForward", "TargetServerUri", "TargetNodeId", "TargetNodeClass" ],
           "properties": {
             "SourceNodeId": {
@@ -11295,7 +11295,7 @@
             },
             "TargetNodeClass": {
               "title": "NodeClass",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+              "dov:typeRef": "org.opcfoundation.UA.NodeClass",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -11324,7 +11324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditDeleteReferencesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2097",
+    "dov:typeRef": "org.opcfoundation.UA.AuditDeleteReferencesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11350,7 +11350,7 @@
         "items": {
           "title": "DeleteReferencesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=385",
+          "dov:typeRef": "org.opcfoundation.UA.DeleteReferencesItem",
           "required": [ "SourceNodeId", "ReferenceTypeId", "IsForward", "TargetNodeId", "DeleteBidirectional" ],
           "properties": {
             "SourceNodeId": {
@@ -11392,7 +11392,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2099",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11419,7 +11419,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditWriteUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2100",
+    "dov:typeRef": "org.opcfoundation.UA.AuditWriteUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11501,7 +11501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2104",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11546,7 +11546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateMethodEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2127",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateMethodEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11632,7 +11632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2130",
+    "dov:typeRef": "org.opcfoundation.UA.SystemEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11659,7 +11659,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DeviceFailureEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2131",
+    "dov:typeRef": "org.opcfoundation.UA.DeviceFailureEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11686,7 +11686,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemStatusChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11446",
+    "dov:typeRef": "org.opcfoundation.UA.SystemStatusChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11698,7 +11698,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -11749,7 +11749,7 @@
     "properties": {
       "SystemState": {
         "title": "ServerState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -11775,7 +11775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseModelChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2132",
+    "dov:typeRef": "org.opcfoundation.UA.BaseModelChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11802,7 +11802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_GeneralModelChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2133",
+    "dov:typeRef": "org.opcfoundation.UA.GeneralModelChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11828,7 +11828,7 @@
         "items": {
           "title": "ModelChangeStructureDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=877",
+          "dov:typeRef": "org.opcfoundation.UA.ModelChangeStructureDataType",
           "required": [ "Affected", "AffectedType", "Verb" ],
           "properties": {
             "Affected": {
@@ -11866,7 +11866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SemanticChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2738",
+    "dov:typeRef": "org.opcfoundation.UA.SemanticChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11892,7 +11892,7 @@
         "items": {
           "title": "SemanticChangeStructureDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=897",
+          "dov:typeRef": "org.opcfoundation.UA.SemanticChangeStructureDataType",
           "required": [ "Affected", "AffectedType" ],
           "properties": {
             "Affected": {
@@ -11925,7 +11925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EventQueueOverflowEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3035",
+    "dov:typeRef": "org.opcfoundation.UA.EventQueueOverflowEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11952,7 +11952,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgressEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11436",
+    "dov:typeRef": "org.opcfoundation.UA.ProgressEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12011,7 +12011,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditClientEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23606",
+    "dov:typeRef": "org.opcfoundation.UA.AuditClientEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12056,7 +12056,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditClientUpdateMethodResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23926",
+    "dov:typeRef": "org.opcfoundation.UA.AuditClientUpdateMethodResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12153,7 +12153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AggregateFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2340",
+    "dov:typeRef": "org.opcfoundation.UA.AggregateFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12179,7 +12179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeRefinementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19820",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeRefinementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12206,7 +12206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubtypeRestrictionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19822",
+    "dov:typeRef": "org.opcfoundation.UA.SubtypeRestrictionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12233,7 +12233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12318,7 +12318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12460,7 +12460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12506,7 +12506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12532,7 +12532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12578,7 +12578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ChoiceStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15109",
+    "dov:typeRef": "org.opcfoundation.UA.ChoiceStateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12605,7 +12605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12713,7 +12713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateStateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2315",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateStateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12771,7 +12771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12785,7 +12785,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -12795,7 +12795,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -12814,7 +12814,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -12827,7 +12827,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -12851,7 +12851,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -12870,7 +12870,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -12889,7 +12889,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -12920,7 +12920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12948,7 +12948,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -12960,7 +12960,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -12979,7 +12979,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -12989,7 +12989,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -13016,7 +13016,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -13026,7 +13026,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -13074,7 +13074,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13193,7 +13193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleMappingRuleChangedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17641",
+    "dov:typeRef": "org.opcfoundation.UA.RoleMappingRuleChangedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -13220,7 +13220,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17589",
+    "dov:typeRef": "org.opcfoundation.UA.DictionaryEntryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13252,7 +13252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DictionaryFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17591",
+    "dov:typeRef": "org.opcfoundation.UA.DictionaryFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13290,7 +13290,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IrdiDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17598",
+    "dov:typeRef": "org.opcfoundation.UA.IrdiDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13317,7 +13317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UriDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17600",
+    "dov:typeRef": "org.opcfoundation.UA.UriDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13344,7 +13344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13370,7 +13370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IOrderedObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23513",
+    "dov:typeRef": "org.opcfoundation.UA.IOrderedObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13414,7 +13414,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13459,7 +13459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SyntaxReferenceEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32439",
+    "dov:typeRef": "org.opcfoundation.UA.SyntaxReferenceEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13504,7 +13504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32442",
+    "dov:typeRef": "org.opcfoundation.UA.UnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13570,7 +13570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32447",
+    "dov:typeRef": "org.opcfoundation.UA.ServerUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13593,7 +13593,7 @@
     "schemaDefinitions": {
       "ConversionLimitEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32436",
+        "dov:typeRef": "org.opcfoundation.UA.ConversionLimitEnum",
         "const": {
           "NoConversion": 0,
           "Limited": 1,
@@ -13624,7 +13624,7 @@
     "properties": {
       "ConversionLimit": {
         "title": "ConversionLimitEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32436",
+        "dov:typeRef": "org.opcfoundation.UA.ConversionLimitEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13650,7 +13650,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlternativeUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32467",
+    "dov:typeRef": "org.opcfoundation.UA.AlternativeUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13673,7 +13673,7 @@
       "LinearConversion": {
         "title": "LinearConversionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32435",
+        "dov:typeRef": "org.opcfoundation.UA.LinearConversionDataType",
         "required": [ "InitialAddend", "Multiplicand", "Divisor", "FinalAddend" ],
         "properties": {
           "InitialAddend": {
@@ -13741,7 +13741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_QuantityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32475",
+    "dov:typeRef": "org.opcfoundation.UA.QuantityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13773,7 +13773,7 @@
         "items": {
           "title": "AnnotationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32434",
+          "dov:typeRef": "org.opcfoundation.UA.AnnotationDataType",
           "required": [ "Annotation", "Discipline", "Uri" ],
           "properties": {
             "Annotation": {
@@ -13810,7 +13810,7 @@
       "Dimension": {
         "title": "QuantityDimension",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32438",
+        "dov:typeRef": "org.opcfoundation.UA.QuantityDimension",
         "required": [ "MassExponent", "LengthExponent", "TimeExponent", "ElectricCurrentExponent", "AmountOfSubstanceExponent", "LuminousIntensityExponent", "AbsoluteTemperatureExponent", "DimensionlessExponent" ],
         "properties": {
           "MassExponent": {
@@ -13887,7 +13887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -13914,7 +13914,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -13939,7 +13939,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -13961,7 +13961,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -14220,7 +14220,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DialogConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2830",
+    "dov:typeRef": "org.opcfoundation.UA.DialogConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14247,7 +14247,7 @@
       "Respond": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9070",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SelectedResponse" ],
           "properties": {
             "SelectedResponse": {
@@ -14268,7 +14268,7 @@
       "Respond2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24313",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SelectedResponse", "Comment" ],
           "properties": {
             "SelectedResponse": {
@@ -14427,7 +14427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14454,7 +14454,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -14479,7 +14479,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -14585,7 +14585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14624,7 +14624,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -14655,7 +14655,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14683,7 +14683,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14711,7 +14711,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14748,7 +14748,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14776,7 +14776,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15101,7 +15101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15185,7 +15185,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15204,7 +15204,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -15224,7 +15224,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -15256,7 +15256,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15299,7 +15299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15325,7 +15325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmSuppressionGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32064",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmSuppressionGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15352,7 +15352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15594,7 +15594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15668,7 +15668,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15736,7 +15736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9906",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15890,7 +15890,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLevelAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10060",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLevelAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15917,7 +15917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLevelAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9482",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLevelAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15944,7 +15944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10368",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16000,7 +16000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveRateOfChangeAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10214",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveRateOfChangeAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16024,7 +16024,7 @@
       "EngineeringUnits": {
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -16064,7 +16064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16120,7 +16120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveRateOfChangeAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9623",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveRateOfChangeAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16144,7 +16144,7 @@
       "EngineeringUnits": {
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -16184,7 +16184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16211,7 +16211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16256,7 +16256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11753",
+    "dov:typeRef": "org.opcfoundation.UA.SystemOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16283,7 +16283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TripAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10751",
+    "dov:typeRef": "org.opcfoundation.UA.TripAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16310,7 +16310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InstrumentDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18347",
+    "dov:typeRef": "org.opcfoundation.UA.InstrumentDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16337,7 +16337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18496",
+    "dov:typeRef": "org.opcfoundation.UA.SystemDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16364,7 +16364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateExpirationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13225",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateExpirationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16445,7 +16445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscrepancyAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17080",
+    "dov:typeRef": "org.opcfoundation.UA.DiscrepancyAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16515,7 +16515,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16541,7 +16541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11164",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16567,7 +16567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_MaintenanceConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11165",
+    "dov:typeRef": "org.opcfoundation.UA.MaintenanceConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16593,7 +16593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11166",
+    "dov:typeRef": "org.opcfoundation.UA.SystemConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16619,7 +16619,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SafetyConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17218",
+    "dov:typeRef": "org.opcfoundation.UA.SafetyConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16645,7 +16645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HighlyManagedAlarmConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17219",
+    "dov:typeRef": "org.opcfoundation.UA.HighlyManagedAlarmConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16671,7 +16671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrainingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17220",
+    "dov:typeRef": "org.opcfoundation.UA.TrainingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16697,7 +16697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StatisticalConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18665",
+    "dov:typeRef": "org.opcfoundation.UA.StatisticalConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16723,7 +16723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TestingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17221",
+    "dov:typeRef": "org.opcfoundation.UA.TestingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16749,7 +16749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2790",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16776,7 +16776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionEnableEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2803",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionEnableEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16803,7 +16803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionCommentEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2829",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionCommentEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16860,7 +16860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionRespondEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8927",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionRespondEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16907,7 +16907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionAcknowledgeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8944",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionAcknowledgeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16964,7 +16964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionConfirmEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8961",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionConfirmEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17021,7 +17021,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionShelvingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11093",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionShelvingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17067,7 +17067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionSuppressionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17225",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionSuppressionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17094,7 +17094,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionSilenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17242",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionSilenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17121,7 +17121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionResetEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15013",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionResetEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17148,7 +17148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionOutOfServiceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17259",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionOutOfServiceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17175,7 +17175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshStartEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2787",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshStartEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17202,7 +17202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2788",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17229,7 +17229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshRequiredEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2789",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshRequiredEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17256,7 +17256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmMetricsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17279",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmMetricsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17514,7 +17514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2391",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17766,7 +17766,7 @@
       "ProgramDiagnostic": {
         "title": "ProgramDiagnostic2DataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24033",
+        "dov:typeRef": "org.opcfoundation.UA.ProgramDiagnostic2DataType",
         "required": [ "CreateSessionId", "CreateClientName", "InvocationCreationTime", "LastTransitionTime", "LastMethodCall", "LastMethodSessionId", "LastMethodInputArguments", "LastMethodOutputArguments", "LastMethodInputValues", "LastMethodOutputValues", "LastMethodCallTime", "LastMethodReturnStatus" ],
         "properties": {
           "CreateSessionId": {
@@ -17794,7 +17794,7 @@
             "items": {
               "title": "Argument",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+              "dov:typeRef": "org.opcfoundation.UA.Argument",
               "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
               "properties": {
                 "Name": {
@@ -17827,7 +17827,7 @@
             "items": {
               "title": "Argument",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+              "dov:typeRef": "org.opcfoundation.UA.Argument",
               "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
               "properties": {
                 "Name": {
@@ -17954,7 +17954,7 @@
         "items": {
           "title": "Argument",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+          "dov:typeRef": "org.opcfoundation.UA.Argument",
           "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
           "properties": {
             "Name": {
@@ -18012,7 +18012,7 @@
         "items": {
           "title": "Argument",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+          "dov:typeRef": "org.opcfoundation.UA.Argument",
           "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
           "properties": {
             "Name": {
@@ -18132,7 +18132,7 @@
         "data": {
           "title": "ProgramDiagnostic2DataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24033",
+          "dov:typeRef": "org.opcfoundation.UA.ProgramDiagnostic2DataType",
           "required": [ "CreateSessionId", "CreateClientName", "InvocationCreationTime", "LastTransitionTime", "LastMethodCall", "LastMethodSessionId", "LastMethodInputArguments", "LastMethodOutputArguments", "LastMethodInputValues", "LastMethodOutputValues", "LastMethodCallTime", "LastMethodReturnStatus" ],
           "properties": {
             "CreateSessionId": {
@@ -18160,7 +18160,7 @@
               "items": {
                 "title": "Argument",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+                "dov:typeRef": "org.opcfoundation.UA.Argument",
                 "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
                 "properties": {
                   "Name": {
@@ -18193,7 +18193,7 @@
               "items": {
                 "title": "Argument",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+                "dov:typeRef": "org.opcfoundation.UA.Argument",
                 "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
                 "properties": {
                   "Name": {
@@ -18326,7 +18326,7 @@
           "items": {
             "title": "Argument",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+            "dov:typeRef": "org.opcfoundation.UA.Argument",
             "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
             "properties": {
               "Name": {
@@ -18386,7 +18386,7 @@
           "items": {
             "title": "Argument",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+            "dov:typeRef": "org.opcfoundation.UA.Argument",
             "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
             "properties": {
               "Name": {
@@ -18477,7 +18477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2378",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18541,7 +18541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11856",
+    "dov:typeRef": "org.opcfoundation.UA.AuditProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18588,7 +18588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramTransitionAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3806",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramTransitionAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18650,7 +18650,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalDataConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2318",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalDataConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18673,7 +18673,7 @@
     "schemaDefinitions": {
       "ExceptionDeviationFormat": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "const": {
           "AbsoluteValue": 0,
           "PercentOfValue": 1,
@@ -18736,7 +18736,7 @@
       },
       "ExceptionDeviationFormat": {
         "title": "ExceptionDeviationFormat",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18857,7 +18857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AggregateConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11187",
+    "dov:typeRef": "org.opcfoundation.UA.AggregateConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18938,7 +18938,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalEventConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32621",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalEventConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18969,7 +18969,7 @@
         "items": {
           "title": "SimpleAttributeOperand",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+          "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
           "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
           "properties": {
             "TypeDefinitionId": {
@@ -19037,7 +19037,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalExternalEventSourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32625",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalExternalEventSourceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19049,7 +19049,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -19073,7 +19073,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -19097,7 +19097,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -19200,7 +19200,7 @@
       "HistoricalEventFilter": {
         "title": "EventFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=725",
+        "dov:typeRef": "org.opcfoundation.UA.EventFilter",
         "required": [ "SelectClauses", "WhereClause" ],
         "properties": {
           "SelectClauses": {
@@ -19208,7 +19208,7 @@
             "items": {
               "title": "SimpleAttributeOperand",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+              "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
               "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
               "properties": {
                 "TypeDefinitionId": {
@@ -19234,7 +19234,7 @@
           "WhereClause": {
             "title": "ContentFilter",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+            "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -19242,12 +19242,12 @@
                 "items": {
                   "title": "ContentFilterElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                  "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                   "required": [ "FilterOperator", "FilterOperands" ],
                   "properties": {
                     "FilterOperator": {
                       "title": "FilterOperator",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                      "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -19276,7 +19276,7 @@
       "IdentityTokenPolicy": {
         "title": "UserTokenPolicy",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
         "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
         "properties": {
           "PolicyId": {
@@ -19284,7 +19284,7 @@
           },
           "TokenType": {
             "title": "UserTokenType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+            "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -19310,7 +19310,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19369,7 +19369,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoryServerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2330",
+    "dov:typeRef": "org.opcfoundation.UA.HistoryServerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19577,7 +19577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryEventUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2999",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryEventUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19589,7 +19589,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -19617,7 +19617,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -19709,7 +19709,7 @@
       "Filter": {
         "title": "EventFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=725",
+        "dov:typeRef": "org.opcfoundation.UA.EventFilter",
         "required": [ "SelectClauses", "WhereClause" ],
         "properties": {
           "SelectClauses": {
@@ -19717,7 +19717,7 @@
             "items": {
               "title": "SimpleAttributeOperand",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+              "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
               "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
               "properties": {
                 "TypeDefinitionId": {
@@ -19743,7 +19743,7 @@
           "WhereClause": {
             "title": "ContentFilter",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+            "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -19751,12 +19751,12 @@
                 "items": {
                   "title": "ContentFilterElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                  "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                   "required": [ "FilterOperator", "FilterOperands" ],
                   "properties": {
                     "FilterOperator": {
                       "title": "FilterOperator",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                      "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -19812,7 +19812,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19849,7 +19849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryValueUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3006",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryValueUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19861,7 +19861,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -19928,7 +19928,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19965,7 +19965,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryAnnotationUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19095",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryAnnotationUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19977,7 +19977,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -20019,7 +20019,7 @@
         "items": {
           "title": "Annotation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=891",
+          "dov:typeRef": "org.opcfoundation.UA.Annotation",
           "required": [ "Message", "UserName", "AnnotationTime" ],
           "properties": {
             "Message": {
@@ -20048,7 +20048,7 @@
         "items": {
           "title": "Annotation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=891",
+          "dov:typeRef": "org.opcfoundation.UA.Annotation",
           "required": [ "Message", "UserName", "AnnotationTime" ],
           "properties": {
             "Message": {
@@ -20074,7 +20074,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20100,7 +20100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3012",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20145,7 +20145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryRawModifyDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3014",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryRawModifyDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20228,7 +20228,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryAtTimeDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3019",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryAtTimeDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20291,7 +20291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryEventDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3022",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryEventDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20351,7 +20351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryConfigurationChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32758",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryConfigurationChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20378,7 +20378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryBulkInsertEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32803",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryBulkInsertEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20447,7 +20447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12522",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20458,7 +20458,7 @@
     "schemaDefinitions": {
       "TrustListValidationOptions": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "const": {
           "SuppressCertificateExpired": 0,
           "SuppressHostNameInvalid": 1,
@@ -20511,7 +20511,7 @@
       "AddCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12549",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Certificate", "IsTrustedCertificate" ],
           "properties": {
             "Certificate": {
@@ -20534,7 +20534,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12705",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -20546,7 +20546,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12547",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyChangesRequired" ],
           "properties": {
             "ApplyChangesRequired": {
@@ -20565,7 +20565,7 @@
       "OpenWithMasks": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12544",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Masks" ],
           "properties": {
             "Masks": {
@@ -20577,7 +20577,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12545",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -20598,7 +20598,7 @@
       "RemoveCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12551",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Thumbprint", "IsTrustedCertificate" ],
           "properties": {
             "Thumbprint": {
@@ -20633,7 +20633,7 @@
       },
       "DefaultValidationOptions": {
         "title": "TrustListValidationOptions",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20683,7 +20683,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListOutOfDateAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19297",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListOutOfDateAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20752,7 +20752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12555",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20791,7 +20791,7 @@
       "GetRejectedList": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23527",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificates" ],
           "properties": {
             "Certificates": {
@@ -20851,7 +20851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateGroupFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13813",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateGroupFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20895,7 +20895,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12556",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20921,7 +20921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12557",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20947,7 +20947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HttpsCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12558",
+    "dov:typeRef": "org.opcfoundation.UA.HttpsCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20974,7 +20974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UserCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19323",
+    "dov:typeRef": "org.opcfoundation.UA.UserCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21000,7 +21000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19324",
+    "dov:typeRef": "org.opcfoundation.UA.TlsCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21026,7 +21026,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsServerCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19325",
+    "dov:typeRef": "org.opcfoundation.UA.TlsServerCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21053,7 +21053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsClientCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19326",
+    "dov:typeRef": "org.opcfoundation.UA.TlsClientCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21080,7 +21080,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RsaMinApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12559",
+    "dov:typeRef": "org.opcfoundation.UA.RsaMinApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21107,7 +21107,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RsaSha256ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12560",
+    "dov:typeRef": "org.opcfoundation.UA.RsaSha256ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21134,7 +21134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23537",
+    "dov:typeRef": "org.opcfoundation.UA.EccApplicationCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21160,7 +21160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccNistP256ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23538",
+    "dov:typeRef": "org.opcfoundation.UA.EccNistP256ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21187,7 +21187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccNistP384ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23539",
+    "dov:typeRef": "org.opcfoundation.UA.EccNistP384ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21214,7 +21214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccBrainpoolP256r1ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23540",
+    "dov:typeRef": "org.opcfoundation.UA.EccBrainpoolP256r1ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21241,7 +21241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccBrainpoolP384r1ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23541",
+    "dov:typeRef": "org.opcfoundation.UA.EccBrainpoolP384r1ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21268,7 +21268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccCurve25519ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23542",
+    "dov:typeRef": "org.opcfoundation.UA.EccCurve25519ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21295,7 +21295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccCurve448ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23543",
+    "dov:typeRef": "org.opcfoundation.UA.EccCurve448ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21322,7 +21322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConfigurationFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15437",
+    "dov:typeRef": "org.opcfoundation.UA.ConfigurationFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21334,7 +21334,7 @@
     "schemaDefinitions": {
       "ConfigurationUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15539",
+        "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -21372,7 +21372,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15506",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "VersionToUpdate", "Targets", "RevertAfterTime", "RestartDelayTime" ],
           "properties": {
             "FileHandle": {
@@ -21390,7 +21390,7 @@
               "items": {
                 "title": "ConfigurationUpdateTargetType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15538",
+                "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateTargetType",
                 "required": [ "Path", "UpdateType" ],
                 "properties": {
                   "Path": {
@@ -21398,7 +21398,7 @@
                   },
                   "UpdateType": {
                     "title": "ConfigurationUpdateType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15539",
+                    "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -21418,7 +21418,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15507",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateResults", "NewVersion", "UpdateId" ],
           "properties": {
             "UpdateResults": {
@@ -21449,7 +21449,7 @@
       "ConfirmUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15511",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UpdateId" ],
           "properties": {
             "UpdateId": {
@@ -21529,7 +21529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConfigurationUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15541",
+    "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21589,7 +21589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListUpdateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32260",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListUpdateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21616,7 +21616,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12561",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21661,7 +21661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransactionDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32286",
+    "dov:typeRef": "org.opcfoundation.UA.TransactionDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21726,7 +21726,7 @@
         "items": {
           "title": "TransactionErrorType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32285",
+          "dov:typeRef": "org.opcfoundation.UA.TransactionErrorType",
           "required": [ "TargetId", "Error", "Message" ],
           "properties": {
             "TargetId": {
@@ -21785,7 +21785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16662",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21811,7 +21811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15550",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21822,7 +21822,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -21953,7 +21953,7 @@
         "items": {
           "title": "UserTokenPolicy",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
           "properties": {
             "PolicyId": {
@@ -21961,7 +21961,7 @@
             },
             "TokenType": {
               "title": "UserTokenType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -21999,7 +21999,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12581",
+    "dov:typeRef": "org.opcfoundation.UA.ServerConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22028,7 +22028,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -22080,7 +22080,7 @@
       "CreateSelfSignedCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19338",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "SubjectName", "DnsNames", "IpAddresses", "LifetimeInDays", "KeySizeInBits" ],
           "properties": {
             "CertificateGroupId": {
@@ -22118,7 +22118,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19339",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificate" ],
           "properties": {
             "Certificate": {
@@ -22138,7 +22138,7 @@
       "CreateSigningRequest": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12732",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "SubjectName", "RegeneratePrivateKey", "Nonce" ],
           "properties": {
             "CertificateGroupId": {
@@ -22161,7 +22161,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12733",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateRequest" ],
           "properties": {
             "CertificateRequest": {
@@ -22181,7 +22181,7 @@
       "DeleteCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19341",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId" ],
           "properties": {
             "CertificateGroupId": {
@@ -22203,7 +22203,7 @@
       "GetCertificates": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId" ],
           "properties": {
             "CertificateGroupId": {
@@ -22213,7 +22213,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32298",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateTypeIds", "Certificates" ],
           "properties": {
             "CertificateTypeIds": {
@@ -22242,7 +22242,7 @@
       "GetRejectedList": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12776",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificates" ],
           "properties": {
             "Certificates": {
@@ -22274,7 +22274,7 @@
       "UpdateCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12617",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "Certificate", "IssuerCertificates", "PrivateKeyFormat", "PrivateKey" ],
           "properties": {
             "CertificateGroupId": {
@@ -22305,7 +22305,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12618",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyChangesRequired" ],
           "properties": {
             "ApplyChangesRequired": {
@@ -22339,7 +22339,7 @@
       },
       "ApplicationType": {
         "title": "ApplicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22472,7 +22472,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25731",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22495,7 +22495,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -22530,7 +22530,7 @@
     "properties": {
       "ApplicationType": {
         "title": "ApplicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22600,7 +22600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17496",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22620,7 +22620,7 @@
       "CreateCredential": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17523",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "ResourceUri", "ProfileUri", "EndpointUrls" ],
           "properties": {
             "Name": {
@@ -22642,7 +22642,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17524",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CredentialNodeId" ],
           "properties": {
             "CredentialNodeId": {
@@ -22673,7 +22673,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18001",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22703,7 +22703,7 @@
       "GetEncryptingKey": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17535",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId", "RequestedSecurityPolicyUri" ],
           "properties": {
             "CredentialId": {
@@ -22716,7 +22716,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17536",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PublicKey", "RevisedSecurityPolicyUri" ],
           "properties": {
             "PublicKey": {
@@ -22739,7 +22739,7 @@
       "UpdateCredential": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18007",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId", "CredentialSecret", "CertificateThumbprint", "SecurityPolicyUri" ],
           "properties": {
             "CredentialId": {
@@ -22838,7 +22838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuthorizationServicesConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23556",
+    "dov:typeRef": "org.opcfoundation.UA.AuthorizationServicesConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22870,7 +22870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuthorizationServiceConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17852",
+    "dov:typeRef": "org.opcfoundation.UA.AuthorizationServiceConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22937,7 +22937,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateUpdateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32306",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateUpdateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22964,7 +22964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12620",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -23020,7 +23020,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18011",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -23065,7 +23065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18029",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -23092,7 +23092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialDeletedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18047",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialDeletedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -23137,7 +23137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15906",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyServiceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23164,7 +23164,7 @@
       "GetSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15911",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId" ],
           "properties": {
             "SecurityGroupId": {
@@ -23174,7 +23174,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15912",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupNodeId": {
@@ -23193,7 +23193,7 @@
       "GetSecurityKeys": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15908",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId", "StartingTokenId", "RequestedKeyCount" ],
           "properties": {
             "SecurityGroupId": {
@@ -23213,7 +23213,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15909",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityPolicyUri", "FirstTokenId", "Keys", "TimeToNextKey", "KeyLifetime" ],
           "properties": {
             "SecurityPolicyUri": {
@@ -23264,7 +23264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SecurityGroupFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15452",
+    "dov:typeRef": "org.opcfoundation.UA.SecurityGroupFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23291,7 +23291,7 @@
       "AddSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15462",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupName", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount" ],
           "properties": {
             "SecurityGroupName": {
@@ -23318,7 +23318,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15463",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupId", "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupId": {
@@ -23340,7 +23340,7 @@
       "AddSecurityGroupFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25313",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -23350,7 +23350,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25314",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupFolderNodeId" ],
           "properties": {
             "SecurityGroupFolderNodeId": {
@@ -23369,7 +23369,7 @@
       "RemoveSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15465",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupNodeId": {
@@ -23388,7 +23388,7 @@
       "RemoveSecurityGroupFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25316",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupFolderNodeId" ],
           "properties": {
             "SecurityGroupFolderNodeId": {
@@ -23433,7 +23433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SecurityGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15471",
+    "dov:typeRef": "org.opcfoundation.UA.SecurityGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23544,7 +23544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyPushTargetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25346",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23561,7 +23561,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -23588,7 +23588,7 @@
       "AddPushTarget": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25367",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval" ],
           "properties": {
             "ApplicationUri": {
@@ -23603,7 +23603,7 @@
             "UserTokenType": {
               "title": "UserTokenPolicy",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
               "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
               "properties": {
                 "PolicyId": {
@@ -23611,7 +23611,7 @@
                 },
                 "TokenType": {
                   "title": "UserTokenType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -23640,7 +23640,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25368",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PushTargetId" ],
           "properties": {
             "PushTargetId": {
@@ -23659,7 +23659,7 @@
       "AddPushTargetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25372",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -23669,7 +23669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25373",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PushTargetFolderNodeId" ],
           "properties": {
             "PushTargetFolderNodeId": {
@@ -23688,7 +23688,7 @@
       "RemovePushTarget": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25370",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PushTargetId" ],
           "properties": {
             "PushTargetId": {
@@ -23707,7 +23707,7 @@
       "RemovePushTargetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25375",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PushTargetFolderNodeId" ],
           "properties": {
             "PushTargetFolderNodeId": {
@@ -23738,7 +23738,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyPushTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25337",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23749,7 +23749,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -23783,7 +23783,7 @@
       "ConnectSecurityGroups": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25642",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupIds" ],
           "properties": {
             "SecurityGroupIds": {
@@ -23796,7 +23796,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25643",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConnectResults" ],
           "properties": {
             "ConnectResults": {
@@ -23818,7 +23818,7 @@
       "DisconnectSecurityGroups": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25645",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupIds" ],
           "properties": {
             "SecurityGroupIds": {
@@ -23831,7 +23831,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25646",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DisconnectResults" ],
           "properties": {
             "DisconnectResults": {
@@ -23946,7 +23946,7 @@
       "UserTokenType": {
         "title": "UserTokenPolicy",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
         "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
         "properties": {
           "PolicyId": {
@@ -23954,7 +23954,7 @@
           },
           "TokenType": {
             "title": "UserTokenType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+            "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -23991,7 +23991,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishSubscribeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14416",
+    "dov:typeRef": "org.opcfoundation.UA.PublishSubscribeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24044,7 +24044,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -24068,7 +24068,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -24092,7 +24092,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -24116,7 +24116,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -24148,7 +24148,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -24170,13 +24170,13 @@
       "AddConnection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16599",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "PubSubConnectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15617",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConnectionDataType",
               "required": [ "Name", "Enabled", "PublisherId", "TransportProfileUri", "Address", "ConnectionProperties", "TransportSettings", "WriterGroups", "ReaderGroups" ],
               "properties": {
                 "Name": {
@@ -24195,7 +24195,7 @@
                 "Address": {
                   "title": "NetworkAddressDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+                  "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
                   "required": [ "NetworkInterface" ],
                   "properties": {
                     "NetworkInterface": {
@@ -24208,7 +24208,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -24229,7 +24229,7 @@
                   "items": {
                     "title": "WriterGroupDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15480",
+                    "dov:typeRef": "org.opcfoundation.UA.WriterGroupDataType",
                     "required": [ "WriterGroupId", "PublishingInterval", "KeepAliveTime", "Priority", "LocaleIds", "HeaderLayoutUri", "TransportSettings", "MessageSettings", "DataSetWriters" ],
                     "properties": {
                       "WriterGroupId": {
@@ -24270,7 +24270,7 @@
                         "items": {
                           "title": "DataSetWriterDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
                           "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
                           "properties": {
                             "Name": {
@@ -24286,7 +24286,7 @@
                             },
                             "DataSetFieldContentMask": {
                               "title": "DataSetFieldContentMask",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24304,7 +24304,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -24334,7 +24334,7 @@
                   "items": {
                     "title": "ReaderGroupDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15520",
+                    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupDataType",
                     "required": [ "TransportSettings", "MessageSettings", "DataSetReaders" ],
                     "properties": {
                       "TransportSettings": {
@@ -24348,7 +24348,7 @@
                         "items": {
                           "title": "DataSetReaderDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
                           "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
                           "properties": {
                             "Name": {
@@ -24374,7 +24374,7 @@
                             "DataSetMetaData": {
                               "title": "DataSetMetaDataType",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                               "properties": {
                                 "Name": {
@@ -24388,7 +24388,7 @@
                                   "items": {
                                     "title": "FieldMetaData",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                                     "properties": {
                                       "Name": {
@@ -24399,7 +24399,7 @@
                                       },
                                       "FieldFlags": {
                                         "title": "DataSetFieldFlags",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                                         "type": "integer",
                                         "minimum": -2147483648,
                                         "maximum": 2147483647
@@ -24439,7 +24439,7 @@
                                         "items": {
                                           "title": "KeyValuePair",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                           "required": [ "Key", "Value" ],
                                           "properties": {
                                             "Key": {
@@ -24462,7 +24462,7 @@
                                 "ConfigurationVersion": {
                                   "title": "ConfigurationVersionDataType",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                                   "required": [ "MajorVersion", "MinorVersion" ],
                                   "properties": {
                                     "MajorVersion": {
@@ -24481,7 +24481,7 @@
                             },
                             "DataSetFieldContentMask": {
                               "title": "DataSetFieldContentMask",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24500,7 +24500,7 @@
                             },
                             "SecurityMode": {
                               "title": "MessageSecurityMode",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24513,7 +24513,7 @@
                               "items": {
                                 "title": "EndpointDescription",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                                "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                                 "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                                 "properties": {
                                   "EndpointUrl": {
@@ -24522,7 +24522,7 @@
                                   "Server": {
                                     "title": "ApplicationDescription",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                                    "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                                     "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                                     "properties": {
                                       "ApplicationUri": {
@@ -24536,7 +24536,7 @@
                                       },
                                       "ApplicationType": {
                                         "title": "ApplicationType",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                                        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                                         "type": "integer",
                                         "minimum": -2147483648,
                                         "maximum": 2147483647
@@ -24561,7 +24561,7 @@
                                   },
                                   "SecurityMode": {
                                     "title": "MessageSecurityMode",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                                    "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -24574,7 +24574,7 @@
                                     "items": {
                                       "title": "UserTokenPolicy",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                                      "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                                       "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                                       "properties": {
                                         "PolicyId": {
@@ -24582,7 +24582,7 @@
                                         },
                                         "TokenType": {
                                           "title": "UserTokenType",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                                          "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                                           "type": "integer",
                                           "minimum": -2147483648,
                                           "maximum": 2147483647
@@ -24615,7 +24615,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -24649,7 +24649,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16600",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConnectionId" ],
           "properties": {
             "ConnectionId": {
@@ -24668,7 +24668,7 @@
       "RemoveConnection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14433",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConnectionId" ],
           "properties": {
             "ConnectionId": {
@@ -24687,7 +24687,7 @@
       "SetSecurityKeys": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId", "SecurityPolicyUri", "CurrentTokenId", "CurrentKey", "FutureKeys", "TimeToNextKey", "KeyLifetime" ],
           "properties": {
             "SecurityGroupId": {
@@ -24737,7 +24737,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -24789,7 +24789,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -24798,7 +24798,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -24812,7 +24812,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -24837,7 +24837,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -24850,7 +24850,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -24858,7 +24858,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -24921,7 +24921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14477",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24938,7 +24938,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -24950,7 +24950,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -25033,7 +25033,7 @@
       "AddDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16995",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -25043,7 +25043,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16996",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -25062,7 +25062,7 @@
       "AddPublishedDataItems": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14494",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "FieldNameAliases", "FieldFlags", "VariablesToAdd" ],
           "properties": {
             "Name": {
@@ -25078,7 +25078,7 @@
               "type": "array",
               "items": {
                 "title": "DataSetFieldFlags",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -25089,7 +25089,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -25134,7 +25134,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14495",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId", "ConfigurationVersion", "AddResults" ],
           "properties": {
             "DataSetNodeId": {
@@ -25143,7 +25143,7 @@
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25177,7 +25177,7 @@
       "AddPublishedDataItemsTemplate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16958",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "DataSetMetaData", "VariablesToAdd" ],
           "properties": {
             "Name": {
@@ -25186,7 +25186,7 @@
             "DataSetMetaData": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -25200,7 +25200,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -25211,7 +25211,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -25251,7 +25251,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -25274,7 +25274,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -25296,7 +25296,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -25341,7 +25341,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16959",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId", "AddResults" ],
           "properties": {
             "DataSetNodeId": {
@@ -25366,7 +25366,7 @@
       "AddPublishedEvents": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14497",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "EventNotifier", "FieldNameAliases", "FieldFlags", "SelectedFields", "Filter" ],
           "properties": {
             "Name": {
@@ -25385,7 +25385,7 @@
               "type": "array",
               "items": {
                 "title": "DataSetFieldFlags",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -25396,7 +25396,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -25422,7 +25422,7 @@
             "Filter": {
               "title": "ContentFilter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -25430,12 +25430,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -25455,13 +25455,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14498",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConfigurationVersion", "DataSetNodeId" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25492,7 +25492,7 @@
       "AddPublishedEventsTemplate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16961",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "DataSetMetaData", "EventNotifier", "SelectedFields", "Filter" ],
           "properties": {
             "Name": {
@@ -25501,7 +25501,7 @@
             "DataSetMetaData": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -25515,7 +25515,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -25526,7 +25526,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -25566,7 +25566,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -25589,7 +25589,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -25614,7 +25614,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -25640,7 +25640,7 @@
             "Filter": {
               "title": "ContentFilter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -25648,12 +25648,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -25673,7 +25673,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16971",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId" ],
           "properties": {
             "DataSetNodeId": {
@@ -25692,7 +25692,7 @@
       "RemoveDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17007",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -25711,7 +25711,7 @@
       "RemovePublishedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14500",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetNodeId" ],
           "properties": {
             "DataSetNodeId": {
@@ -25742,7 +25742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14509",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25759,7 +25759,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -25783,7 +25783,7 @@
       "ConfigurationVersion": {
         "title": "ConfigurationVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+        "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
         "required": [ "MajorVersion", "MinorVersion" ],
         "properties": {
           "MajorVersion": {
@@ -25832,7 +25832,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -25846,7 +25846,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -25857,7 +25857,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -25897,7 +25897,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -25920,7 +25920,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -25958,7 +25958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExtensionFieldsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15489",
+    "dov:typeRef": "org.opcfoundation.UA.ExtensionFieldsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25979,7 +25979,7 @@
       "AddExtensionField": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15492",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FieldName", "FieldValue" ],
           "properties": {
             "FieldName": {
@@ -25992,7 +25992,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15493",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FieldId" ],
           "properties": {
             "FieldId": {
@@ -26011,7 +26011,7 @@
       "RemoveExtensionField": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15495",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FieldId" ],
           "properties": {
             "FieldId": {
@@ -26055,7 +26055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23795",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26072,7 +26072,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -26087,7 +26087,7 @@
       "AddDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23817",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -26097,7 +26097,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23818",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -26116,13 +26116,13 @@
       "AddSubscribedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23812",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscribedDataSet" ],
           "properties": {
             "SubscribedDataSet": {
               "title": "StandaloneSubscribedDataSetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+              "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
               "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -26137,7 +26137,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -26151,7 +26151,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -26162,7 +26162,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -26202,7 +26202,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -26225,7 +26225,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -26251,7 +26251,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23813",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SubscribedDataSetNodeId" ],
           "properties": {
             "SubscribedDataSetNodeId": {
@@ -26270,7 +26270,7 @@
       "RemoveDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23820",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -26289,7 +26289,7 @@
       "RemoveSubscribedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23815",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscribedDataSetNodeId" ],
           "properties": {
             "SubscribedDataSetNodeId": {
@@ -26320,7 +26320,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StandaloneSubscribedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23828",
+    "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26337,7 +26337,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -26361,7 +26361,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -26375,7 +26375,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -26386,7 +26386,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -26426,7 +26426,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -26449,7 +26449,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -26498,7 +26498,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15108",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26524,7 +26524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25482",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26535,7 +26535,7 @@
     "schemaDefinitions": {
       "PubSubConfigurationRefMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
         "const": {
           "ElementAdd": 0,
           "ElementMatch": 1,
@@ -26598,7 +26598,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25509",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "RequireCompleteUpdate", "ConfigurationReferences" ],
           "properties": {
             "FileHandle": {
@@ -26614,12 +26614,12 @@
               "items": {
                 "title": "PubSubConfigurationRefDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                 "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                 "properties": {
                   "ConfigurationMask": {
                     "title": "PubSubConfigurationRefMask",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -26646,7 +26646,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25510",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ChangesApplied", "ReferencesResults", "ConfigurationValues", "ConfigurationObjects" ],
           "properties": {
             "ChangesApplied": {
@@ -26663,18 +26663,18 @@
               "items": {
                 "title": "PubSubConfigurationValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
                 "required": [ "ConfigurationElement", "Name", "Identifier" ],
                 "properties": {
                   "ConfigurationElement": {
                     "title": "PubSubConfigurationRefDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                     "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                     "properties": {
                       "ConfigurationMask": {
                         "title": "PubSubConfigurationRefMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -26725,7 +26725,7 @@
       "ReserveIds": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25506",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TransportProfileUri", "NumReqWriterGroupIds", "NumReqDataSetWriterIds" ],
           "properties": {
             "TransportProfileUri": {
@@ -26745,7 +26745,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25507",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DefaultPublisherId", "WriterGroupIds", "DataSetWriterIds" ],
           "properties": {
             "DefaultPublisherId": {
@@ -26792,7 +26792,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14643",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26803,7 +26803,7 @@
     "schemaDefinitions": {
       "PubSubState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "const": {
           "Disabled": 0,
           "Paused": 1,
@@ -26865,7 +26865,7 @@
     "properties": {
       "State": {
         "title": "PubSubState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -26883,7 +26883,7 @@
       "State": {
         "data": {
           "title": "PubSubState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -26907,7 +26907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsRootType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19732",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsRootType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26939,7 +26939,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19677",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26962,7 +26962,7 @@
     "schemaDefinitions": {
       "DiagnosticsLevel": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+        "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
         "const": {
           "Basic": 0,
           "Advanced": 1,
@@ -27015,7 +27015,7 @@
     "properties": {
       "DiagnosticsLevel": {
         "title": "DiagnosticsLevel",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+        "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -27070,7 +27070,7 @@
       "DiagnosticsLevel": {
         "data": {
           "title": "DiagnosticsLevel",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+          "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -27134,7 +27134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23832",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27369,7 +27369,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedDataItemsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14534",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedDataItemsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -27391,13 +27391,13 @@
       "AddVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14556",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "FieldNameAliases", "PromotedFields", "VariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27429,7 +27429,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -27474,13 +27474,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14557",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion", "AddResults" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27514,13 +27514,13 @@
       "RemoveVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14559",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "VariablesToRemove" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27547,13 +27547,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14560",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion", "RemoveResults" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27591,7 +27591,7 @@
         "items": {
           "title": "PublishedVariableDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+          "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
           "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
           "properties": {
             "PublishedVariable": {
@@ -27653,7 +27653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedEventsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14572",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedEventsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -27665,7 +27665,7 @@
     "schemaDefinitions": {
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -27755,13 +27755,13 @@
       "ModifyFieldSelection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "FieldNameAliases", "PromotedFields", "SelectedFields" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27793,7 +27793,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -27820,13 +27820,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15517",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -27856,7 +27856,7 @@
       "Filter": {
         "title": "ContentFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+        "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
         "required": [ "Elements" ],
         "properties": {
           "Elements": {
@@ -27864,12 +27864,12 @@
             "items": {
               "title": "ContentFilterElement",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
               "required": [ "FilterOperator", "FilterOperands" ],
               "properties": {
                 "FilterOperator": {
                   "title": "FilterOperator",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                  "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -27909,7 +27909,7 @@
         "items": {
           "title": "SimpleAttributeOperand",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+          "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
           "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
           "properties": {
             "TypeDefinitionId": {
@@ -27953,7 +27953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14209",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27988,7 +27988,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -28020,7 +28020,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -28032,7 +28032,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -28056,7 +28056,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -28080,7 +28080,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -28119,13 +28119,13 @@
       "AddReaderGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17507",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "ReaderGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15520",
+              "dov:typeRef": "org.opcfoundation.UA.ReaderGroupDataType",
               "required": [ "TransportSettings", "MessageSettings", "DataSetReaders" ],
               "properties": {
                 "TransportSettings": {
@@ -28139,7 +28139,7 @@
                   "items": {
                     "title": "DataSetReaderDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
                     "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
                     "properties": {
                       "Name": {
@@ -28165,7 +28165,7 @@
                       "DataSetMetaData": {
                         "title": "DataSetMetaDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                         "properties": {
                           "Name": {
@@ -28179,7 +28179,7 @@
                             "items": {
                               "title": "FieldMetaData",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                               "properties": {
                                 "Name": {
@@ -28190,7 +28190,7 @@
                                 },
                                 "FieldFlags": {
                                   "title": "DataSetFieldFlags",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -28230,7 +28230,7 @@
                                   "items": {
                                     "title": "KeyValuePair",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                     "required": [ "Key", "Value" ],
                                     "properties": {
                                       "Key": {
@@ -28253,7 +28253,7 @@
                           "ConfigurationVersion": {
                             "title": "ConfigurationVersionDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                             "required": [ "MajorVersion", "MinorVersion" ],
                             "properties": {
                               "MajorVersion": {
@@ -28272,7 +28272,7 @@
                       },
                       "DataSetFieldContentMask": {
                         "title": "DataSetFieldContentMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -28291,7 +28291,7 @@
                       },
                       "SecurityMode": {
                         "title": "MessageSecurityMode",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -28304,7 +28304,7 @@
                         "items": {
                           "title": "EndpointDescription",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                           "properties": {
                             "EndpointUrl": {
@@ -28313,7 +28313,7 @@
                             "Server": {
                               "title": "ApplicationDescription",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                               "properties": {
                                 "ApplicationUri": {
@@ -28327,7 +28327,7 @@
                                 },
                                 "ApplicationType": {
                                   "title": "ApplicationType",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -28352,7 +28352,7 @@
                             },
                             "SecurityMode": {
                               "title": "MessageSecurityMode",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -28365,7 +28365,7 @@
                               "items": {
                                 "title": "UserTokenPolicy",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                                 "properties": {
                                   "PolicyId": {
@@ -28373,7 +28373,7 @@
                                   },
                                   "TokenType": {
                                     "title": "UserTokenType",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -28406,7 +28406,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -28437,7 +28437,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17508",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -28456,13 +28456,13 @@
       "AddWriterGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17428",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "WriterGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15480",
+              "dov:typeRef": "org.opcfoundation.UA.WriterGroupDataType",
               "required": [ "WriterGroupId", "PublishingInterval", "KeepAliveTime", "Priority", "LocaleIds", "HeaderLayoutUri", "TransportSettings", "MessageSettings", "DataSetWriters" ],
               "properties": {
                 "WriterGroupId": {
@@ -28503,7 +28503,7 @@
                   "items": {
                     "title": "DataSetWriterDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
                     "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
                     "properties": {
                       "Name": {
@@ -28519,7 +28519,7 @@
                       },
                       "DataSetFieldContentMask": {
                         "title": "DataSetFieldContentMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -28537,7 +28537,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -28565,7 +28565,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17456",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -28584,7 +28584,7 @@
       "RemoveGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14226",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -28607,7 +28607,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -28676,7 +28676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NetworkAddressType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21145",
+    "dov:typeRef": "org.opcfoundation.UA.NetworkAddressType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28737,7 +28737,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17721",
+    "dov:typeRef": "org.opcfoundation.UA.ConnectionTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28763,7 +28763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19786",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28795,7 +28795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14232",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28812,7 +28812,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -28836,7 +28836,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -28860,7 +28860,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -28898,7 +28898,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -28948,7 +28948,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -28957,7 +28957,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -28971,7 +28971,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -28996,7 +28996,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -29009,7 +29009,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -29017,7 +29017,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -29055,7 +29055,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -29081,7 +29081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17725",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29110,7 +29110,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -29152,13 +29152,13 @@
       "AddDataSetWriter": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17976",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "DataSetWriterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
               "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
               "properties": {
                 "Name": {
@@ -29174,7 +29174,7 @@
                 },
                 "DataSetFieldContentMask": {
                   "title": "DataSetFieldContentMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -29192,7 +29192,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -29217,7 +29217,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17987",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetWriterNodeId" ],
           "properties": {
             "DataSetWriterNodeId": {
@@ -29236,7 +29236,7 @@
       "RemoveDataSetWriter": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17993",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetWriterNodeId" ],
           "properties": {
             "DataSetWriterNodeId": {
@@ -29342,7 +29342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17997",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29368,7 +29368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17998",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29394,7 +29394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsWriterGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19834",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsWriterGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29432,7 +29432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17999",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29461,7 +29461,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -29473,7 +29473,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -29505,7 +29505,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -29529,7 +29529,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -29553,7 +29553,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -29580,13 +29580,13 @@
       "AddDataSetReader": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "DataSetReaderDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
               "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -29612,7 +29612,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -29626,7 +29626,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -29637,7 +29637,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -29677,7 +29677,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -29700,7 +29700,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -29719,7 +29719,7 @@
                 },
                 "DataSetFieldContentMask": {
                   "title": "DataSetFieldContentMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -29738,7 +29738,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -29751,7 +29751,7 @@
                   "items": {
                     "title": "EndpointDescription",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                    "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                     "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                     "properties": {
                       "EndpointUrl": {
@@ -29760,7 +29760,7 @@
                       "Server": {
                         "title": "ApplicationDescription",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                        "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                         "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                         "properties": {
                           "ApplicationUri": {
@@ -29774,7 +29774,7 @@
                           },
                           "ApplicationType": {
                             "title": "ApplicationType",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                            "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -29799,7 +29799,7 @@
                       },
                       "SecurityMode": {
                         "title": "MessageSecurityMode",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -29812,7 +29812,7 @@
                         "items": {
                           "title": "UserTokenPolicy",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                           "properties": {
                             "PolicyId": {
@@ -29820,7 +29820,7 @@
                             },
                             "TokenType": {
                               "title": "UserTokenType",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -29853,7 +29853,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -29881,7 +29881,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21084",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetReaderNodeId" ],
           "properties": {
             "DataSetReaderNodeId": {
@@ -29900,7 +29900,7 @@
       "RemoveDataSetReader": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetReaderNodeId" ],
           "properties": {
             "DataSetReaderNodeId": {
@@ -29931,7 +29931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsReaderGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19903",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsReaderGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29969,7 +29969,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21090",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29995,7 +29995,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21091",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30021,7 +30021,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15298",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30056,7 +30056,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -30099,7 +30099,7 @@
     "properties": {
       "DataSetFieldContentMask": {
         "title": "DataSetFieldContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -30130,7 +30130,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -30177,7 +30177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15305",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30203,7 +30203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21096",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30229,7 +30229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsDataSetWriterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19968",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsDataSetWriterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30267,7 +30267,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15306",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30308,7 +30308,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -30320,7 +30320,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -30352,7 +30352,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -30376,7 +30376,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -30400,7 +30400,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -30424,7 +30424,7 @@
       },
       "OverrideValueHandling": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+        "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
         "const": {
           "Disabled": 0,
           "LastUsableValue": 1,
@@ -30444,7 +30444,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -30530,7 +30530,7 @@
       "CreateDataSetMirror": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17390",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ParentNodeName", "RolePermissions" ],
           "properties": {
             "ParentNodeName": {
@@ -30541,7 +30541,7 @@
               "items": {
                 "title": "RolePermissionType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                 "required": [ "RoleId", "Permissions" ],
                 "properties": {
                   "RoleId": {
@@ -30549,7 +30549,7 @@
                   },
                   "Permissions": {
                     "title": "PermissionType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                    "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -30561,7 +30561,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17391",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ParentNodeId" ],
           "properties": {
             "ParentNodeId": {
@@ -30580,13 +30580,13 @@
       "CreateTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17387",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetVariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -30606,7 +30606,7 @@
               "items": {
                 "title": "FieldTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+                "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
                 "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
                 "properties": {
                   "DataSetFieldId": {
@@ -30629,7 +30629,7 @@
                   },
                   "OverrideValueHandling": {
                     "title": "OverrideValueHandling",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+                    "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -30645,7 +30645,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17388",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AddResults" ],
           "properties": {
             "AddResults": {
@@ -30668,7 +30668,7 @@
     "properties": {
       "DataSetFieldContentMask": {
         "title": "DataSetFieldContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -30684,7 +30684,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -30698,7 +30698,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -30709,7 +30709,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -30749,7 +30749,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -30772,7 +30772,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -30802,7 +30802,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -30900,7 +30900,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -30909,7 +30909,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -30923,7 +30923,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -30948,7 +30948,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -30961,7 +30961,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -30969,7 +30969,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -31007,7 +31007,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31046,7 +31046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15319",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31072,7 +31072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21104",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31098,7 +31098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsDataSetReaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20027",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsDataSetReaderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31136,7 +31136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TargetVariablesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15111",
+    "dov:typeRef": "org.opcfoundation.UA.TargetVariablesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31148,7 +31148,7 @@
     "schemaDefinitions": {
       "OverrideValueHandling": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+        "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
         "const": {
           "Disabled": 0,
           "LastUsableValue": 1,
@@ -31178,13 +31178,13 @@
       "AddTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15116",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetVariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -31204,7 +31204,7 @@
               "items": {
                 "title": "FieldTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+                "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
                 "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
                 "properties": {
                   "DataSetFieldId": {
@@ -31227,7 +31227,7 @@
                   },
                   "OverrideValueHandling": {
                     "title": "OverrideValueHandling",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+                    "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -31243,7 +31243,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15117",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AddResults" ],
           "properties": {
             "AddResults": {
@@ -31265,13 +31265,13 @@
       "RemoveTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15119",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetsToRemove" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -31298,7 +31298,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15120",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RemoveResults" ],
           "properties": {
             "RemoveResults": {
@@ -31324,7 +31324,7 @@
         "items": {
           "title": "FieldTargetDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+          "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
           "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
           "properties": {
             "DataSetFieldId": {
@@ -31347,7 +31347,7 @@
             },
             "OverrideValueHandling": {
               "title": "OverrideValueHandling",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+              "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -31380,7 +31380,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetMirrorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15127",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetMirrorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31407,7 +31407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubStatusEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15535",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubStatusEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31419,7 +31419,7 @@
     "schemaDefinitions": {
       "PubSubState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "const": {
           "Disabled": 0,
           "Paused": 1,
@@ -31480,7 +31480,7 @@
       },
       "State": {
         "title": "PubSubState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31506,7 +31506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubTransportLimitsExceedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15548",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubTransportLimitsExceedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31566,7 +31566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubCommunicationFailureEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15563",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubCommunicationFailureEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31611,7 +31611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpWriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21105",
+    "dov:typeRef": "org.opcfoundation.UA.UadpWriterGroupMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31623,7 +31623,7 @@
     "schemaDefinitions": {
       "DataSetOrderingType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20408",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetOrderingType",
         "const": {
           "Undefined": 0,
           "AscendingWriterId": 1,
@@ -31643,7 +31643,7 @@
       },
       "UadpNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "const": {
           "PublisherId": 0,
           "GroupHeader": 1,
@@ -31706,7 +31706,7 @@
     "properties": {
       "DataSetOrdering": {
         "title": "DataSetOrderingType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20408",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetOrderingType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31734,7 +31734,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "UadpNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31787,7 +31787,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpDataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21111",
+    "dov:typeRef": "org.opcfoundation.UA.UadpDataSetWriterMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31799,7 +31799,7 @@
     "schemaDefinitions": {
       "UadpDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "const": {
           "Timestamp": 0,
           "PicoSeconds": 1,
@@ -31855,7 +31855,7 @@
       },
       "DataSetMessageContentMask": {
         "title": "UadpDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31907,7 +31907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpDataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21116",
+    "dov:typeRef": "org.opcfoundation.UA.UadpDataSetReaderMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31919,7 +31919,7 @@
     "schemaDefinitions": {
       "UadpNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "const": {
           "PublisherId": 0,
           "GroupHeader": 1,
@@ -31971,7 +31971,7 @@
       },
       "UadpDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "const": {
           "Timestamp": 0,
           "PicoSeconds": 1,
@@ -32026,7 +32026,7 @@
       },
       "DataSetMessageContentMask": {
         "title": "UadpDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32067,7 +32067,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "UadpNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32142,7 +32142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonWriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21126",
+    "dov:typeRef": "org.opcfoundation.UA.JsonWriterGroupMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32154,7 +32154,7 @@
     "schemaDefinitions": {
       "JsonNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "const": {
           "NetworkMessageHeader": 0,
           "DataSetMessageHeader": 1,
@@ -32201,7 +32201,7 @@
     "properties": {
       "NetworkMessageContentMask": {
         "title": "JsonNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32227,7 +32227,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonDataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21128",
+    "dov:typeRef": "org.opcfoundation.UA.JsonDataSetWriterMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32239,7 +32239,7 @@
     "schemaDefinitions": {
       "JsonDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "const": {
           "DataSetWriterId": 0,
           "MetaDataVersion": 1,
@@ -32306,7 +32306,7 @@
     "properties": {
       "DataSetMessageContentMask": {
         "title": "JsonDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32332,7 +32332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonDataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21130",
+    "dov:typeRef": "org.opcfoundation.UA.JsonDataSetReaderMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32344,7 +32344,7 @@
     "schemaDefinitions": {
       "JsonNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "const": {
           "NetworkMessageHeader": 0,
           "DataSetMessageHeader": 1,
@@ -32380,7 +32380,7 @@
       },
       "JsonDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "const": {
           "DataSetWriterId": 0,
           "MetaDataVersion": 1,
@@ -32447,7 +32447,7 @@
     "properties": {
       "DataSetMessageContentMask": {
         "title": "JsonDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32462,7 +32462,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "JsonNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32488,7 +32488,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15064",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramConnectionTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32579,7 +32579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramWriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21133",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramWriterGroupTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32693,7 +32693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramDataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24016",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramDataSetReaderTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32769,7 +32769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15155",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerConnectionTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32825,7 +32825,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerWriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21136",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerWriterGroupTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32837,7 +32837,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -32898,7 +32898,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32935,7 +32935,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerDataSetWriterTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21138",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerDataSetWriterTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32947,7 +32947,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -33031,7 +33031,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33068,7 +33068,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerDataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21142",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerDataSetReaderTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33080,7 +33080,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -33152,7 +33152,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33189,7 +33189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NetworkAddressUrlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21147",
+    "dov:typeRef": "org.opcfoundation.UA.NetworkAddressUrlType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33251,7 +33251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AliasNameType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23455",
+    "dov:typeRef": "org.opcfoundation.UA.AliasNameType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33277,7 +33277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AliasNameCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23456",
+    "dov:typeRef": "org.opcfoundation.UA.AliasNameCategoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33298,7 +33298,7 @@
       "FindAlias": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23463",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AliasNameSearchPattern", "ReferenceTypeFilter" ],
           "properties": {
             "AliasNameSearchPattern": {
@@ -33311,7 +33311,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23464",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AliasNodeList" ],
           "properties": {
             "AliasNodeList": {
@@ -33319,7 +33319,7 @@
               "items": {
                 "title": "AliasNameDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23468",
+                "dov:typeRef": "org.opcfoundation.UA.AliasNameDataType",
                 "required": [ "AliasName", "ReferencedNodes" ],
                 "properties": {
                   "AliasName": {
@@ -33372,7 +33372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UserManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24264",
+    "dov:typeRef": "org.opcfoundation.UA.UserManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33383,7 +33383,7 @@
     "schemaDefinitions": {
       "UserConfigurationMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+        "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
         "const": {
           "NoDelete": 0,
           "Disabled": 1,
@@ -33411,7 +33411,7 @@
       },
       "PasswordOptionsMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24277",
+        "dov:typeRef": "org.opcfoundation.UA.PasswordOptionsMask",
         "const": {
           "SupportInitialPasswordChange": 0,
           "SupportDisableUser": 1,
@@ -33474,7 +33474,7 @@
       "AddUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24270",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName", "Password", "UserConfiguration", "Description" ],
           "properties": {
             "UserName": {
@@ -33485,7 +33485,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33506,7 +33506,7 @@
       "ChangePassword": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24276",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OldPassword", "NewPassword" ],
           "properties": {
             "OldPassword": {
@@ -33528,7 +33528,7 @@
       "ModifyUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24272",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName", "ModifyPassword", "Password", "ModifyUserConfiguration", "UserConfiguration", "ModifyDescription", "Description" ],
           "properties": {
             "UserName": {
@@ -33545,7 +33545,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33569,7 +33569,7 @@
       "RemoveUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24274",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName" ],
           "properties": {
             "UserName": {
@@ -33590,7 +33590,7 @@
       "PasswordLength": {
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -33615,7 +33615,7 @@
       },
       "PasswordOptions": {
         "title": "PasswordOptionsMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24277",
+        "dov:typeRef": "org.opcfoundation.UA.PasswordOptionsMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33644,7 +33644,7 @@
         "items": {
           "title": "UserManagementDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24281",
+          "dov:typeRef": "org.opcfoundation.UA.UserManagementDataType",
           "required": [ "UserName", "UserConfiguration", "Description" ],
           "properties": {
             "UserName": {
@@ -33652,7 +33652,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33684,7 +33684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProvisionableDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26871",
+    "dov:typeRef": "org.opcfoundation.UA.ProvisionableDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33701,7 +33701,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -33735,7 +33735,7 @@
       "RequestTickets": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26874",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -33757,7 +33757,7 @@
       "SetRegistrarEndpoints": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Registrars" ],
           "properties": {
             "Registrars": {
@@ -33765,7 +33765,7 @@
               "items": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -33779,7 +33779,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -33835,7 +33835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIetfBaseNetworkInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24148",
+    "dov:typeRef": "org.opcfoundation.UA.IIetfBaseNetworkInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33846,7 +33846,7 @@
     "schemaDefinitions": {
       "InterfaceAdminStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -33869,7 +33869,7 @@
       },
       "InterfaceOperStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -33928,7 +33928,7 @@
     "properties": {
       "AdminStatus": {
         "title": "InterfaceAdminStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33943,7 +33943,7 @@
       },
       "OperStatus": {
         "title": "InterfaceOperStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33985,7 +33985,7 @@
       "AdminStatus": {
         "data": {
           "title": "InterfaceAdminStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34001,7 +34001,7 @@
       "OperStatus": {
         "data": {
           "title": "InterfaceOperStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34051,7 +34051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseEthernetPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24158",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseEthernetPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34062,7 +34062,7 @@
     "schemaDefinitions": {
       "Duplex": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+        "dov:typeRef": "org.opcfoundation.UA.Duplex",
         "const": {
           "Full": 0,
           "Half": 1,
@@ -34101,7 +34101,7 @@
     "properties": {
       "Duplex": {
         "title": "Duplex",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+        "dov:typeRef": "org.opcfoundation.UA.Duplex",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34145,7 +34145,7 @@
       "Duplex": {
         "data": {
           "title": "Duplex",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+          "dov:typeRef": "org.opcfoundation.UA.Duplex",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34197,7 +34197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeAutoNegotiationStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24233",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeAutoNegotiationStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34208,7 +34208,7 @@
     "schemaDefinitions": {
       "NegotiationStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+        "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
         "const": {
           "InProgress": 0,
           "Complete": 1,
@@ -34257,7 +34257,7 @@
     "properties": {
       "NegotiationStatus": {
         "title": "NegotiationStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+        "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34275,7 +34275,7 @@
       "NegotiationStatus": {
         "data": {
           "title": "NegotiationStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+          "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34299,7 +34299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IBaseEthernetCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24167",
+    "dov:typeRef": "org.opcfoundation.UA.IBaseEthernetCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34360,7 +34360,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IVlanIdType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25218",
+    "dov:typeRef": "org.opcfoundation.UA.IVlanIdType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34425,7 +34425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ISrClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24169",
+    "dov:typeRef": "org.opcfoundation.UA.ISrClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34544,7 +34544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24173",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnStreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34555,7 +34555,7 @@
     "schemaDefinitions": {
       "TsnStreamState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+        "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
         "const": {
           "Disabled": 0,
           "Configuring": 1,
@@ -34630,7 +34630,7 @@
       },
       "State": {
         "title": "TsnStreamState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+        "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34703,7 +34703,7 @@
       "State": {
         "data": {
           "title": "TsnStreamState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+          "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34756,7 +34756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnTrafficSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24179",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnTrafficSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34784,7 +34784,7 @@
       "Interval": {
         "title": "UnsignedRationalNumber",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24107",
+        "dov:typeRef": "org.opcfoundation.UA.UnsignedRationalNumber",
         "required": [ "Numerator", "Denominator" ],
         "properties": {
           "Numerator": {
@@ -34839,7 +34839,7 @@
         "data": {
           "title": "UnsignedRationalNumber",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24107",
+          "dov:typeRef": "org.opcfoundation.UA.UnsignedRationalNumber",
           "required": [ "Numerator", "Denominator" ],
           "properties": {
             "Numerator": {
@@ -34901,7 +34901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnStatusStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24183",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnStatusStreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34912,7 +34912,7 @@
     "schemaDefinitions": {
       "TsnTalkerStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+        "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
         "const": {
           "None": 0,
           "Ready": 1,
@@ -34935,7 +34935,7 @@
       },
       "TsnListenerStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+        "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
         "const": {
           "None": 0,
           "Ready": 1,
@@ -34963,7 +34963,7 @@
       },
       "TsnFailureCode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+        "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
         "const": {
           "NoFailure": 0,
           "InsufficientBandwidth": 1,
@@ -35117,7 +35117,7 @@
     "properties": {
       "FailureCode": {
         "title": "TsnFailureCode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+        "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35151,7 +35151,7 @@
       },
       "ListenerStatus": {
         "title": "TsnListenerStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+        "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35166,7 +35166,7 @@
       },
       "TalkerStatus": {
         "title": "TsnTalkerStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+        "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35184,7 +35184,7 @@
       "FailureCode": {
         "data": {
           "title": "TsnFailureCode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+          "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35220,7 +35220,7 @@
       "ListenerStatus": {
         "data": {
           "title": "TsnListenerStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+          "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35236,7 +35236,7 @@
       "TalkerStatus": {
         "data": {
           "title": "TsnTalkerStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+          "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35260,7 +35260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24188",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35344,7 +35344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationTalkerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24191",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationTalkerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35409,7 +35409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationListenerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24195",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationListenerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35474,7 +35474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnMacAddressType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24199",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnMacAddressType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35578,7 +35578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnVlanTagType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24202",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnVlanTagType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35670,7 +35670,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IPriorityMappingEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24205",
+    "dov:typeRef": "org.opcfoundation.UA.IPriorityMappingEntryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35808,7 +35808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IetfBaseNetworkInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25221",
+    "dov:typeRef": "org.opcfoundation.UA.IetfBaseNetworkInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35820,7 +35820,7 @@
     "schemaDefinitions": {
       "InterfaceAdminStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -35843,7 +35843,7 @@
       },
       "InterfaceOperStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -35902,7 +35902,7 @@
     "properties": {
       "AdminStatus": {
         "title": "InterfaceAdminStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35917,7 +35917,7 @@
       },
       "OperStatus": {
         "title": "InterfaceOperStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35959,7 +35959,7 @@
       "AdminStatus": {
         "data": {
           "title": "InterfaceAdminStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35975,7 +35975,7 @@
       "OperStatus": {
         "data": {
           "title": "InterfaceOperStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -36025,7 +36025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PriorityMappingTableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25227",
+    "dov:typeRef": "org.opcfoundation.UA.PriorityMappingTableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -36047,7 +36047,7 @@
       "AddPriorityMappingEntry": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25230",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MappingUri", "PriorityLabel", "PriorityValue_PCP", "PriorityValue_DSCP" ],
           "properties": {
             "MappingUri": {
@@ -36079,7 +36079,7 @@
       "DeletePriorityMappingEntry": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MappingUri", "PriorityLabel" ],
           "properties": {
             "MappingUri": {
@@ -36105,7 +36105,7 @@
         "items": {
           "title": "PriorityMappingEntryType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25220",
+          "dov:typeRef": "org.opcfoundation.UA.PriorityMappingEntryType",
           "required": [ "MappingUri", "PriorityLabel", "PriorityValue_PCP", "PriorityValue_DSCP" ],
           "properties": {
             "MappingUri": {
@@ -36148,7 +36148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18973",
+    "dov:typeRef": "org.opcfoundation.UA.LldpInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36192,7 +36192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpRemoteStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18996",
+    "dov:typeRef": "org.opcfoundation.UA.LldpRemoteStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36365,7 +36365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpLocalSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19002",
+    "dov:typeRef": "org.opcfoundation.UA.LldpLocalSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36376,7 +36376,7 @@
     "schemaDefinitions": {
       "ChassisIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "const": {
           "ChassisComponent": 1,
           "InterfaceAlias": 2,
@@ -36419,7 +36419,7 @@
       },
       "LldpSystemCapabilitiesMap": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "const": {
           "Other": 0,
           "Repeater": 1,
@@ -36504,7 +36504,7 @@
       },
       "ChassisIdSubtype": {
         "title": "ChassisIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36519,7 +36519,7 @@
       },
       "SystemCapabilitiesEnabled": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36534,7 +36534,7 @@
       },
       "SystemCapabilitiesSupported": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36582,7 +36582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpPortInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19009",
+    "dov:typeRef": "org.opcfoundation.UA.LldpPortInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36599,7 +36599,7 @@
     "schemaDefinitions": {
       "PortIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "const": {
           "InterfaceAlias": 1,
           "PortComponent": 2,
@@ -36642,7 +36642,7 @@
       },
       "ManAddrIfSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+        "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
         "const": {
           "None": 0,
           "Unknown": 1,
@@ -36711,7 +36711,7 @@
         "items": {
           "title": "LldpManagementAddressTxPortType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18953",
+          "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressTxPortType",
           "required": [ "AddressSubtype", "ManAddress", "TxEnable", "AddrLen", "IfSubtype", "IfId" ],
           "properties": {
             "AddressSubtype": {
@@ -36732,7 +36732,7 @@
             },
             "IfSubtype": {
               "title": "ManAddrIfSubtype",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+              "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -36777,7 +36777,7 @@
       },
       "PortIdSubtype": {
         "title": "PortIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36803,7 +36803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpRemoteSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19033",
+    "dov:typeRef": "org.opcfoundation.UA.LldpRemoteSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36814,7 +36814,7 @@
     "schemaDefinitions": {
       "ChassisIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "const": {
           "ChassisComponent": 1,
           "InterfaceAlias": 2,
@@ -36857,7 +36857,7 @@
       },
       "PortIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "const": {
           "InterfaceAlias": 1,
           "PortComponent": 2,
@@ -36900,7 +36900,7 @@
       },
       "LldpSystemCapabilitiesMap": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "const": {
           "Other": 0,
           "Repeater": 1,
@@ -36963,7 +36963,7 @@
       },
       "ManAddrIfSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+        "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
         "const": {
           "None": 0,
           "Unknown": 1,
@@ -37018,7 +37018,7 @@
       },
       "ChassisIdSubtype": {
         "title": "ChassisIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37036,7 +37036,7 @@
         "items": {
           "title": "LldpManagementAddressType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18954",
+          "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressType",
           "required": [ "AddressSubtype", "Address", "IfSubtype", "IfId" ],
           "properties": {
             "AddressSubtype": {
@@ -37049,7 +37049,7 @@
             },
             "IfSubtype": {
               "title": "ManAddrIfSubtype",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+              "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -37094,7 +37094,7 @@
       },
       "PortIdSubtype": {
         "title": "PortIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37147,7 +37147,7 @@
         "items": {
           "title": "LldpTlvType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18955",
+          "dov:typeRef": "org.opcfoundation.UA.LldpTlvType",
           "required": [ "TlvType", "TlvInfo" ],
           "properties": {
             "TlvType": {
@@ -37172,7 +37172,7 @@
       },
       "SystemCapabilitiesEnabled": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37187,7 +37187,7 @@
       },
       "SystemCapabilitiesSupported": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37252,7 +37252,7 @@
       "ChassisIdSubtype": {
         "data": {
           "title": "ChassisIdSubtype",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+          "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37271,7 +37271,7 @@
           "items": {
             "title": "LldpManagementAddressType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18954",
+            "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressType",
             "required": [ "AddressSubtype", "Address", "IfSubtype", "IfId" ],
             "properties": {
               "AddressSubtype": {
@@ -37284,7 +37284,7 @@
               },
               "IfSubtype": {
                 "title": "ManAddrIfSubtype",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+                "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -37332,7 +37332,7 @@
       "PortIdSubtype": {
         "data": {
           "title": "PortIdSubtype",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+          "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37389,7 +37389,7 @@
           "items": {
             "title": "LldpTlvType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18955",
+            "dov:typeRef": "org.opcfoundation.UA.LldpTlvType",
             "required": [ "TlvType", "TlvInfo" ],
             "properties": {
               "TlvType": {
@@ -37415,7 +37415,7 @@
       "SystemCapabilitiesEnabled": {
         "data": {
           "title": "LldpSystemCapabilitiesMap",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+          "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37431,7 +37431,7 @@
       "SystemCapabilitiesSupported": {
         "data": {
           "title": "LldpSystemCapabilitiesMap",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+          "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37493,7 +37493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SerializationEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19824",
+    "dov:typeRef": "org.opcfoundation.UA.SerializationEntityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -37520,7 +37520,7 @@
       "ConfigureSerialization": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19840",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SerializationFilterProperties" ],
           "properties": {
             "SerializationFilterProperties": {
@@ -37528,7 +37528,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -37545,7 +37545,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19841",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -37584,7 +37584,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -37726,7 +37726,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19352",
+    "dov:typeRef": "org.opcfoundation.UA.LogObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -37737,7 +37737,7 @@
     "schemaDefinitions": {
       "LogRecordMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+        "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
         "const": {
           "EventType": 0,
           "SourceNode": 1,
@@ -37775,7 +37775,7 @@
       "GetRecords": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartTime", "EndTime", "MaxReturnRecords", "MinimumSeverity", "RequestMask", "ContinuationPointIn" ],
           "properties": {
             "StartTime": {
@@ -37798,7 +37798,7 @@
             },
             "RequestMask": {
               "title": "LogRecordMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -37811,13 +37811,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "ContinuationPointOut" ],
           "properties": {
             "Results": {
               "title": "LogRecordsDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19745",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordsDataType",
               "required": [ "LogRecordArray" ],
               "properties": {
                 "LogRecordArray": {
@@ -37825,7 +37825,7 @@
                   "items": {
                     "title": "LogRecord",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19361",
+                    "dov:typeRef": "org.opcfoundation.UA.LogRecord",
                     "required": [ "Time", "Severity", "Message" ],
                     "properties": {
                       "Time": {
@@ -37852,7 +37852,7 @@
                       "TraceContext": {
                         "title": "TraceContextDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19747",
+                        "dov:typeRef": "org.opcfoundation.UA.TraceContextDataType",
                         "required": [ "ParentSpanId", "ParentIdentifier" ],
                         "properties": {
                           "ParentSpanId": {
@@ -37870,7 +37870,7 @@
                         "items": {
                           "title": "NameValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19748",
+                          "dov:typeRef": "org.opcfoundation.UA.NameValuePair",
                           "required": [ "Name", "Value" ],
                           "properties": {
                             "Name": {
@@ -37955,7 +37955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseLogEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19362",
+    "dov:typeRef": "org.opcfoundation.UA.BaseLogEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38033,7 +38033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogOverflowEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19369",
+    "dov:typeRef": "org.opcfoundation.UA.LogOverflowEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38060,7 +38060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogEntryConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19370",
+    "dov:typeRef": "org.opcfoundation.UA.LogEntryConditionClassType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PADIM.TM.json
+++ b/wot-codegen/opc-output-integrated/PADIM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PADIMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PADIMType",
     "dov:isComposite": true,
     "links": [
       {
@@ -44,7 +44,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -77,7 +77,7 @@
       },
       "ResetModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
         "const": {
           "Application": 1,
           "Communication": 2712,
@@ -118,12 +118,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResetMode" ],
           "properties": {
             "ResetMode": {
               "title": "ResetModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -184,7 +184,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -356,7 +356,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -393,7 +393,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -425,7 +425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -480,7 +480,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAdministrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAdministrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -491,7 +491,7 @@
     "schemaDefinitions": {
       "ResetModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
         "const": {
           "Application": 1,
           "Communication": 2712,
@@ -532,12 +532,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1080",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResetMode" ],
           "properties": {
             "ResetMode": {
               "title": "ResetModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -624,7 +624,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ISignalSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ISignalSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -656,7 +656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -752,7 +752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -764,7 +764,7 @@
     "schemaDefinitions": {
       "ExecutionModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1158",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ExecutionModeEnum",
         "const": {
           "Start": 2,
           "Abort": 255
@@ -801,12 +801,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1119",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExecutionMode" ],
           "properties": {
             "ExecutionMode": {
               "title": "ExecutionModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1158",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ExecutionModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_DiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.DiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1056,7 +1056,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TwoStateDiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TwoStateDiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1130,7 +1130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_MultiStateDiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.MultiStateDiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1208,7 +1208,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TwoStateDiscreteControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1223",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TwoStateDiscreteControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1352,7 +1352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_MultiStateDiscreteControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1239",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.MultiStateDiscreteControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1468,7 +1468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_CalibrationPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.CalibrationPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_CalibrationPointSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.CalibrationPointSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1596,7 +1596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_GeneralDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.GeneralDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1719,7 +1719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IGeneralDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IGeneralDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1757,7 +1757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ICalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ICalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1858,7 +1858,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IPhCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IPhCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1968,7 +1968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IConductivityCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IConductivityCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2035,7 +2035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAmperometricCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAmperometricCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2174,7 +2174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IOpticalFluorescenseQuenchingCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IOpticalFluorescenseQuenchingCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2313,7 +2313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITocDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITocDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2554,7 +2554,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IFlameIonisationDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IFlameIonisationDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2708,7 +2708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_INonDispersiveInfraredSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.INonDispersiveInfraredSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2847,7 +2847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITocSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITocSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3073,7 +3073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IParamagneticSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IParamagneticSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3169,7 +3169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IThermalConductivitySignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IThermalConductivitySignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3236,7 +3236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITunableDiodeLaserSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITunableDiodeLaserSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3458,7 +3458,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IZirconiumDioxideSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IZirconiumDioxideSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3583,7 +3583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IPhSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IPhSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3794,7 +3794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IConductivitySignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IConductivitySignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3947,7 +3947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IOpticalFluorescenseQuenchingSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IOpticalFluorescenseQuenchingSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4071,7 +4071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAmperometricSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAmperometricSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4195,7 +4195,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalyticalSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalyticalSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4273,7 +4273,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AmperometricSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AmperometricSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4312,7 +4312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ConductivitySignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1067",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ConductivitySignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4351,7 +4351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_FlameIonisationSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.FlameIonisationSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4378,7 +4378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_NonDispersiveInfraredSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1071",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.NonDispersiveInfraredSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4411,7 +4411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_OpticalFluorescenseQuenchingSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1073",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.OpticalFluorescenseQuenchingSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4450,7 +4450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ParamagneticSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ParamagneticSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4483,7 +4483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PhSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1076",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PhSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4522,7 +4522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ThermalConductivitySignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1077",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ThermalConductivitySignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4555,7 +4555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TocSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TocSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4588,7 +4588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TunableDiodeLaserSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TunableDiodeLaserSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4621,7 +4621,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ZirconiumDioxideSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ZirconiumDioxideSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4654,7 +4654,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ProcessAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1082",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ProcessAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4681,7 +4681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AmperometricAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1083",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AmperometricAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4708,7 +4708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ConductivityMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ConductivityMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4735,7 +4735,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_FlameIonisationDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1085",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.FlameIonisationDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4768,7 +4768,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_NonDispersiveInfraredGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1086",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.NonDispersiveInfraredGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4795,7 +4795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_OpticalFluorescenseQuenchingSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.OpticalFluorescenseQuenchingSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4822,7 +4822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ParamagneticGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1088",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ParamagneticGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4849,7 +4849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PhMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1089",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PhMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4876,7 +4876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ThermalConductivityGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ThermalConductivityGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4903,7 +4903,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TocAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1091",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TocAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4936,7 +4936,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TunableDiodeLaserSpectrometerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1092",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TunableDiodeLaserSpectrometerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4963,7 +4963,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ZirconiumDioxideAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1093",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ZirconiumDioxideAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4990,7 +4990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5193,7 +5193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5249,7 +5249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5320,7 +5320,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5342,7 +5342,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5364,7 +5364,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5386,7 +5386,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5396,7 +5396,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5418,7 +5418,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -5511,7 +5511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfigurableObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfigurableObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5550,7 +5550,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -5571,7 +5571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5597,7 +5597,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PAEFS.TM.json
+++ b/wot-codegen/opc-output-integrated/PAEFS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AirConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -49,7 +49,7 @@
     "schemaDefinitions": {
       "AirConnectionOpenEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "const": {
           "Open": 0,
           "Closed": 1,
@@ -109,7 +109,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AirConnectionOpenEnum",
         "description": "Indicates the connections status (open, closed, or a state in between)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -148,7 +148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -171,7 +171,7 @@
     "schemaDefinitions": {
       "AnalogDigitalEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AnalogDigitalEnum",
         "const": {
           "Analog": 0,
           "Digital": 1
@@ -201,7 +201,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AnalogDigitalEnum",
         "description": "Specifies whether the sensor is an analog or a digital sensor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AnalogDigitalEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -227,7 +227,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CompressedAirSupplyInterruptedAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CompressedAirSupplyInterruptedAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -254,7 +254,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_EndOfFilterRollAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.EndOfFilterRollAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -281,7 +281,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -308,7 +308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SafetySystemTriggeredAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SafetySystemTriggeredAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -335,7 +335,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentDrainMalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentDrainMalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentInflowMalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentInflowMalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -389,7 +389,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningRecommendedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningRecommendedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -436,7 +436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MaintenanceRequestedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MaintenanceRequestedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -483,7 +483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AirConnectionStatusChangedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionStatusChangedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -495,7 +495,7 @@
     "schemaDefinitions": {
       "AirConnectionOpenEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "const": {
           "Open": 0,
           "Closed": 1,
@@ -533,7 +533,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AirConnectionOpenEnum",
         "description": "Reflects the value of the ConnectionOpen property at the time the event is triggered",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -559,7 +559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitActiveConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitActiveConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -606,7 +606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ContainerOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ContainerOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -653,7 +653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_DischargeContainerInstalledConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.DischargeContainerInstalledConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -700,7 +700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterAidDeviceStatusChangedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusChangedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -712,7 +712,7 @@
     "schemaDefinitions": {
       "FilterAidDeviceStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "const": {
           "DeviceActive": 0,
           "DeviceInactive": 1,
@@ -750,7 +750,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "FilterAidDeviceStatusEnum",
         "description": "Reflects the value of the FilterAidDeviceStatus property at the time the condition was triggered",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -776,7 +776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MaintenanceSwitchConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MaintenanceSwitchConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -823,7 +823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentDrainOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentDrainOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -870,7 +870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentInflowOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentInflowOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -917,7 +917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_HighVoltageUnitSupplyActiveEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.HighVoltageUnitSupplyActiveEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -964,7 +964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1121,7 +1121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitValveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1180,7 +1180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ConsumptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ConsumptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1255,7 +1255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorSetpointWriteType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorSetpointWriteType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1287,7 +1287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorSetpointReadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorSetpointReadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1339,7 +1339,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CollectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CollectorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1371,7 +1371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_DischargeSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.DischargeSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1484,7 +1484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1561,7 +1561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterAidDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1602,7 +1602,7 @@
     "schemaDefinitions": {
       "FilterAidDeviceStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "const": {
           "DeviceActive": 0,
           "DeviceInactive": 1,
@@ -1724,7 +1724,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "FilterAidDeviceStatusEnum",
         "description": "Describes the action performed by the dosage unit (see FilterAidDeviceStatusEnum).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1763,7 +1763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1841,7 +1841,7 @@
     "schemaDefinitions": {
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.ControlModeEnum",
         "const": {
           "Automatic": 0,
           "Manual": 1,
@@ -1897,7 +1897,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "ControlModeEnum",
         "description": "Operating mode that describes whether the system can be controlled externally. Possible values are manual, auto and other.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1988,7 +1988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2105,7 +2105,7 @@
         "description": "The Method SetAirflowSetpoint sets a setpoint for the airflow. The value’s unit is the same as the one specified in object Airflow. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for pressure and rotational speed to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6277",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -2128,7 +2128,7 @@
         "description": "The Method SetPressureSetpoint sets a setpoint for the pressure. The value’s unit is the same as the one specified in object Pressure. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for airflow and rotational speed to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6278",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -2151,7 +2151,7 @@
         "description": "The Method SetRotationalSpeedSetpoint sets a setpoint for the rotational speed. The value’s unit is the same as the one specified in object RotationalSpeed. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for airflow and pressure to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6279",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -2249,7 +2249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SeparatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2321,7 +2321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SafetySystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SafetySystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2386,7 +2386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_TemperatureRegulatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.TemperatureRegulatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2450,7 +2450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterMachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2579,7 +2579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_HighVoltageUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.HighVoltageUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2738,7 +2738,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_IonizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.IonizerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2770,7 +2770,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AutomaticRollFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AutomaticRollFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2817,7 +2817,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CartridgeFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CartridgeFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2844,7 +2844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ElectrostaticPrecipitatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ElectrostaticPrecipitatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2877,7 +2877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WetSeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WetSeparatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2963,7 +2963,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2984,7 +2984,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3010,7 +3010,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3066,7 +3066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3134,7 +3134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3376,7 +3376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3415,7 +3415,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3446,7 +3446,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3474,7 +3474,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3502,7 +3502,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3539,7 +3539,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3567,7 +3567,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3892,7 +3892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3919,7 +3919,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3944,7 +3944,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4050,7 +4050,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4077,7 +4077,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4102,7 +4102,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4124,7 +4124,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4383,7 +4383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4479,7 +4479,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4583,7 +4583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4667,7 +4667,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4686,7 +4686,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -4706,7 +4706,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -4738,7 +4738,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4781,7 +4781,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4923,7 +4923,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5008,7 +5008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5054,7 +5054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5100,7 +5100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5126,7 +5126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5200,7 +5200,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5245,7 +5245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5273,7 +5273,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5667,7 +5667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5763,7 +5763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5818,7 +5818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5900,7 +5900,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6152,7 +6152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PDRV.TM.json
+++ b/wot-codegen/opc-output-integrated/PDRV.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_DriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.DriveAxisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -90,7 +90,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PDRV/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=6038",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -147,7 +147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_SafetyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.SafetyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -221,7 +221,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_SafetyFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.SafetyFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -331,7 +331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_VelocityDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.VelocityDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -376,7 +376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_FrequencyDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.FrequencyDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -421,7 +421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_PositioningDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.PositioningDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -490,7 +490,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_TraversingTaskType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.TraversingTaskType",
     "links": [
       {
         "rel": "tm:extends",
@@ -702,7 +702,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_VelocityServoDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.VelocityServoDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -765,7 +765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_PositionServoDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.PositionServoDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -840,7 +840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_DiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.DiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -852,7 +852,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -888,7 +888,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PDRV/",
         "title": "LogEntryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
         "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
         "properties": {
           "FaultSituationNumber": {
@@ -906,7 +906,7 @@
           "EventType": {
             "title": "EventTypeEnumeration",
             "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -959,7 +959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisSwOvertravelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisSwOvertravelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1005,7 +1005,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1250,7 +1250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisHwOvertravelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisHwOvertravelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1296,7 +1296,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_TorqueLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.TorqueLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1358,7 +1358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_MotorCurrentLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.MotorCurrentLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1420,7 +1420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_ForceLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.ForceLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1482,7 +1482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1503,7 +1503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1529,7 +1529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1550,7 +1550,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1571,7 +1571,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1583,7 +1583,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -1604,7 +1604,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -1616,7 +1616,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1637,7 +1637,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -1654,7 +1654,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -1674,7 +1674,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -1700,7 +1700,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -1821,7 +1821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1860,7 +1860,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -1891,7 +1891,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1919,7 +1919,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1947,7 +1947,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -1984,7 +1984,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2012,7 +2012,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2337,7 +2337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2364,7 +2364,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2389,7 +2389,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2495,7 +2495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2522,7 +2522,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2547,7 +2547,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -2569,7 +2569,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -2828,7 +2828,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2924,7 +2924,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3028,7 +3028,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3112,7 +3112,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3131,7 +3131,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -3151,7 +3151,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -3183,7 +3183,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3226,7 +3226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3368,7 +3368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3453,7 +3453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3499,7 +3499,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3545,7 +3545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3571,7 +3571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3593,7 +3593,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -3615,7 +3615,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -3637,7 +3637,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -3647,7 +3647,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -3669,7 +3669,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -3762,7 +3762,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_LogbookType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.LogbookType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3773,7 +3773,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -3822,7 +3822,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6074",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ActiveDiagnosis" ],
           "properties": {
             "ActiveDiagnosis": {
@@ -3830,7 +3830,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -3848,7 +3848,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3895,7 +3895,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6071",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentLogEntries" ],
           "properties": {
             "CurrentLogEntries": {
@@ -3903,7 +3903,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -3921,7 +3921,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3968,7 +3968,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LogbookFilterOptions", "FaultSituationNumber", "EventType", "EventCode", "EventAppearanceInterval" ],
           "properties": {
             "LogbookFilterOptions": {
@@ -3983,7 +3983,7 @@
             },
             "EventType": {
               "title": "EventTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4001,7 +4001,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6033",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FilteredLogEntries" ],
           "properties": {
             "FilteredLogEntries": {
@@ -4009,7 +4009,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -4027,7 +4027,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4074,7 +4074,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FaultSituationNumber" ],
           "properties": {
             "FaultSituationNumber": {
@@ -4086,7 +4086,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6073",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "HistoricLogEntries" ],
           "properties": {
             "HistoricLogEntries": {
@@ -4094,7 +4094,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -4112,7 +4112,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4177,7 +4177,7 @@
         "items": {
           "title": "LogEntryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
           "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
           "properties": {
             "FaultSituationNumber": {
@@ -4195,7 +4195,7 @@
             "EventType": {
               "title": "EventTypeEnumeration",
               "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4245,7 +4245,7 @@
           "items": {
             "title": "LogEntryDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
             "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
             "properties": {
               "FaultSituationNumber": {
@@ -4263,7 +4263,7 @@
               "EventType": {
                 "title": "EventTypeEnumeration",
                 "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4315,7 +4315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4369,7 +4369,7 @@
     "schemaDefinitions": {
       "EncoderChannelStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "const": {
           "NORMAL_OPERATION": 0,
           "ERROR_ACKNOWLEDGEMENT": 1,
@@ -4448,7 +4448,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6002",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -4495,7 +4495,7 @@
       "EncoderChannelState": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderChannelStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4795,7 +4795,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "data": {
           "title": "EncoderChannelStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5091,7 +5091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderAxisConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5102,7 +5102,7 @@
     "schemaDefinitions": {
       "EncoderAxisTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "const": {
           "ROTARY": 0,
           "LINEAR": 1
@@ -5120,7 +5120,7 @@
       },
       "EncoderCodeSequenceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "const": {
           "INCREASING_CLOCKWISE": 0,
           "INCREASING_COUNTERCLOCKWISE": 1
@@ -5154,7 +5154,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AxisConfigParameters" ],
           "properties": {
             "AxisConfigParameters": {
@@ -5162,7 +5162,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5179,7 +5179,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AxisConfigParametersResult" ],
           "properties": {
             "AxisConfigParametersResult": {
@@ -5187,7 +5187,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5229,7 +5229,7 @@
       "AxisType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAxisTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5245,7 +5245,7 @@
       "CodeSequence": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderCodeSequenceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5372,7 +5372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderControlConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderControlConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5383,7 +5383,7 @@
     "schemaDefinitions": {
       "EncoderAlarmChannelControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "const": {
           "ALARM_CHANNEL_DISABLED": 0,
           "ALARM_CHANNEL_ENABLED": 1
@@ -5401,7 +5401,7 @@
       },
       "EncoderPresetControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "const": {
           "ENABLE_PRESET_CONTROL": 0,
           "DISABLE_PRESET_CONTROL": 1
@@ -5430,7 +5430,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlConfigParameters" ],
           "properties": {
             "ControlConfigParameters": {
@@ -5438,7 +5438,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5455,7 +5455,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ControlConfigParametersResult" ],
           "properties": {
             "ControlConfigParametersResult": {
@@ -5463,7 +5463,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5491,7 +5491,7 @@
       "AlarmChannelControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAlarmChannelControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5521,7 +5521,7 @@
       "XIST1PresetControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderPresetControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5547,7 +5547,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5579,7 +5579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5683,7 +5683,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5710,7 +5710,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PresetValue" ],
           "properties": {
             "PresetValue": {
@@ -5826,7 +5826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5837,7 +5837,7 @@
     "schemaDefinitions": {
       "EncoderConfigTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "const": {
           "STATIC": 0,
           "DYNAMIC": 1
@@ -5855,7 +5855,7 @@
       },
       "EncoderSensorAbsoluteTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "const": {
           "SINGLETURN": 0,
           "MULTITURN": 1
@@ -5884,7 +5884,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SensorConfigParameters" ],
           "properties": {
             "SensorConfigParameters": {
@@ -5892,7 +5892,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5909,7 +5909,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SensorConfigParametersResult" ],
           "properties": {
             "SensorConfigParametersResult": {
@@ -5917,7 +5917,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -5969,7 +5969,7 @@
       "ConfigType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderConfigTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5985,7 +5985,7 @@
       "SensorAbsoluteType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderSensorAbsoluteTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,

--- a/wot-codegen/opc-output-integrated/PNEM.TM.json
+++ b/wot-codegen/opc-output-integrated/PNEM.TM.json
@@ -9,7 +9,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileD0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileD0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -137,7 +137,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -191,7 +191,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -233,7 +233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -327,7 +327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE2Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE2Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -521,7 +521,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE3Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE3Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -597,7 +597,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -636,7 +636,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -675,7 +675,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -750,7 +750,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -789,7 +789,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -828,7 +828,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPpDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPpDataType",
         "required": [ "A_b", "B_c", "C_a" ],
         "properties": {
           "A_b": {
@@ -988,7 +988,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1023,7 +1023,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1058,7 +1058,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1121,7 +1121,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1156,7 +1156,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1191,7 +1191,7 @@
         "data": {
           "title": "AcPpDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPpDataType",
           "required": [ "A_b", "B_c", "C_a" ],
           "properties": {
             "A_b": {
@@ -1232,7 +1232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyDevicePowerOffType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyDevicePowerOffType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1260,7 +1260,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6110",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -1411,7 +1411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyMeasurementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1501,7 +1501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModesContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModesContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1533,7 +1533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1819,7 +1819,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModeStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModeStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1848,7 +1848,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "StandbyModeTransitionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.StandbyModeTransitionDataType",
         "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
         "properties": {
           "IDDestination": {
@@ -1887,7 +1887,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "EnergyStateInformationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStateInformationDataType",
         "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
         "properties": {
           "IDSource": {
@@ -1930,7 +1930,7 @@
         "data": {
           "title": "StandbyModeTransitionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.StandbyModeTransitionDataType",
           "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
           "properties": {
             "IDDestination": {
@@ -1970,7 +1970,7 @@
         "data": {
           "title": "EnergyStateInformationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStateInformationDataType",
           "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
           "properties": {
             "IDSource": {
@@ -2017,7 +2017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyStandbyManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStandbyManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2063,7 +2063,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentTimeToOperate", "ReturnCode" ],
           "properties": {
             "CurrentTimeToOperate": {
@@ -2091,7 +2091,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PauseTime" ],
           "properties": {
             "PauseTime": {
@@ -2103,7 +2103,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthToStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -2147,7 +2147,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ModeID" ],
           "properties": {
             "ModeID": {
@@ -2160,7 +2160,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EffectiveModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "EffectiveModeID": {
@@ -2271,7 +2271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_PeServiceAccessPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.PeServiceAccessPointType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2283,7 +2283,7 @@
     "schemaDefinitions": {
       "PeClassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeClassEnumeration",
         "const": {
           "PE_CLASS1": 0,
           "PE_CLASS2": 1,
@@ -2306,7 +2306,7 @@
       },
       "PeSubclassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeSubclassEnumeration",
         "const": {
           "PE_SUBCLASS1": 0,
           "PE_SUBCLASS2": 1
@@ -2341,7 +2341,7 @@
       "PeClass": {
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeClassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeClassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2362,7 +2362,7 @@
       "PeSubclass": {
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeSubclassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeSubclassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2384,7 +2384,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeVersionDataType",
         "required": [ "MajorVersion", "MinorVersion", "Revision" ],
         "properties": {
           "MajorVersion": {
@@ -2430,7 +2430,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2456,7 +2456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2477,7 +2477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2499,7 +2499,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -2521,7 +2521,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -2543,7 +2543,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -2553,7 +2553,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -2575,7 +2575,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PNENC.TM.json
+++ b/wot-codegen/opc-output-integrated/PNENC.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderDiagnosisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -43,7 +43,7 @@
       },
       "EncoderDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -83,7 +83,7 @@
       "DiagnosisType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EventTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -123,7 +123,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -149,7 +149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbeLatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbeLatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -219,7 +219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderRefLatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderRefLatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -277,7 +277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -289,7 +289,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -325,7 +325,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "LogEntryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
         "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
         "properties": {
           "FaultSituationNumber": {
@@ -343,7 +343,7 @@
           "EventType": {
             "title": "EventTypeEnumeration",
             "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -396,7 +396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderAxisConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -407,7 +407,7 @@
     "schemaDefinitions": {
       "EncoderAxisTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "const": {
           "ROTARY": 0,
           "LINEAR": 1
@@ -425,7 +425,7 @@
       },
       "EncoderCodeSequenceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "const": {
           "INCREASING_CLOCKWISE": 0,
           "INCREASING_COUNTERCLOCKWISE": 1
@@ -459,7 +459,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AxisConfigParameters" ],
           "properties": {
             "AxisConfigParameters": {
@@ -467,7 +467,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -484,7 +484,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AxisConfigParametersResult" ],
           "properties": {
             "AxisConfigParametersResult": {
@@ -492,7 +492,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -534,7 +534,7 @@
       "AxisType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAxisTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -550,7 +550,7 @@
       "CodeSequence": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderCodeSequenceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -677,7 +677,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -731,7 +731,7 @@
     "schemaDefinitions": {
       "EncoderChannelStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "const": {
           "NORMAL_OPERATION": 0,
           "ERROR_ACKNOWLEDGEMENT": 1,
@@ -810,7 +810,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6002",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -857,7 +857,7 @@
       "EncoderChannelState": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderChannelStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1157,7 +1157,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "data": {
           "title": "EncoderChannelStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1453,7 +1453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderControlConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderControlConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1464,7 +1464,7 @@
     "schemaDefinitions": {
       "EncoderAlarmChannelControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "const": {
           "ALARM_CHANNEL_DISABLED": 0,
           "ALARM_CHANNEL_ENABLED": 1
@@ -1482,7 +1482,7 @@
       },
       "EncoderPresetControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "const": {
           "ENABLE_PRESET_CONTROL": 0,
           "DISABLE_PRESET_CONTROL": 1
@@ -1511,7 +1511,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlConfigParameters" ],
           "properties": {
             "ControlConfigParameters": {
@@ -1519,7 +1519,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1536,7 +1536,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ControlConfigParametersResult" ],
           "properties": {
             "ControlConfigParametersResult": {
@@ -1544,7 +1544,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1572,7 +1572,7 @@
       "AlarmChannelControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAlarmChannelControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1602,7 +1602,7 @@
       "XIST1PresetControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderPresetControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1628,7 +1628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_LogbookType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.LogbookType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1639,7 +1639,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -1688,7 +1688,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6074",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ActiveDiagnosis" ],
           "properties": {
             "ActiveDiagnosis": {
@@ -1696,7 +1696,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -1714,7 +1714,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1761,7 +1761,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6071",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentLogEntries" ],
           "properties": {
             "CurrentLogEntries": {
@@ -1769,7 +1769,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -1787,7 +1787,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1834,7 +1834,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LogbookFilterOptions", "FaultSituationNumber", "EventType", "EventCode", "EventAppearanceInterval" ],
           "properties": {
             "LogbookFilterOptions": {
@@ -1849,7 +1849,7 @@
             },
             "EventType": {
               "title": "EventTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1867,7 +1867,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6033",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FilteredLogEntries" ],
           "properties": {
             "FilteredLogEntries": {
@@ -1875,7 +1875,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -1893,7 +1893,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1940,7 +1940,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FaultSituationNumber" ],
           "properties": {
             "FaultSituationNumber": {
@@ -1952,7 +1952,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6073",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "HistoricLogEntries" ],
           "properties": {
             "HistoricLogEntries": {
@@ -1960,7 +1960,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -1978,7 +1978,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2043,7 +2043,7 @@
         "items": {
           "title": "LogEntryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
           "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
           "properties": {
             "FaultSituationNumber": {
@@ -2061,7 +2061,7 @@
             "EventType": {
               "title": "EventTypeEnumeration",
               "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2111,7 +2111,7 @@
           "items": {
             "title": "LogEntryDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
             "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
             "properties": {
               "FaultSituationNumber": {
@@ -2129,7 +2129,7 @@
               "EventType": {
                 "title": "EventTypeEnumeration",
                 "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2181,7 +2181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2213,7 +2213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2317,7 +2317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2344,7 +2344,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PresetValue" ],
           "properties": {
             "PresetValue": {
@@ -2460,7 +2460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2471,7 +2471,7 @@
     "schemaDefinitions": {
       "EncoderConfigTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "const": {
           "STATIC": 0,
           "DYNAMIC": 1
@@ -2489,7 +2489,7 @@
       },
       "EncoderSensorAbsoluteTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "const": {
           "SINGLETURN": 0,
           "MULTITURN": 1
@@ -2518,7 +2518,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SensorConfigParameters" ],
           "properties": {
             "SensorConfigParameters": {
@@ -2526,7 +2526,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2543,7 +2543,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SensorConfigParametersResult" ],
           "properties": {
             "SensorConfigParametersResult": {
@@ -2551,7 +2551,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2603,7 +2603,7 @@
       "ConfigType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderConfigTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2619,7 +2619,7 @@
       "SensorAbsoluteType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderSensorAbsoluteTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2693,7 +2693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2789,7 +2789,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2893,7 +2893,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2914,7 +2914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2936,7 +2936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -2958,7 +2958,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -2980,7 +2980,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -2990,7 +2990,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -3012,7 +3012,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PNGSDGM.TM.json
+++ b/wot-codegen/opc-output-integrated/PNGSDGM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenAlarmEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenAlarmEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "GsdGenChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -38,7 +38,7 @@
       },
       "GsdGenChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -66,7 +66,7 @@
       },
       "GsdGenChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -94,7 +94,7 @@
       },
       "GsdGenChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -134,7 +134,7 @@
       "Accumulative": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelAccumulativeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelAccumulativeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -192,7 +192,7 @@
       "Direction": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelDirectionEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -248,7 +248,7 @@
       "Maintenance": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelMaintenanceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelMaintenanceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -305,7 +305,7 @@
       "Specifier": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelSpecifierEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelSpecifierEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -359,7 +359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -420,7 +420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelQualityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelQualityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -431,7 +431,7 @@
     "schemaDefinitions": {
       "GsdGenIoQualityFormatEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoQualityFormatEnumeration",
         "const": {
           "QUALIFIER": 0,
           "EMBEDDED_STATUS": 1,
@@ -480,7 +480,7 @@
       "Format": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoQualityFormatEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoQualityFormatEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -506,7 +506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -565,7 +565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -588,7 +588,7 @@
     "schemaDefinitions": {
       "GsdGenIoConsistencyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConsistencyEnumeration",
         "const": {
           "ITEM_CONSISTENCY": 0,
           "ALL_ITEMS_CONSISTENCY": 1
@@ -623,7 +623,7 @@
       "Consistency": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoConsistencyEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConsistencyEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -678,7 +678,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenSubmoduleApplicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenSubmoduleApplicationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -726,7 +726,7 @@
     "schemaDefinitions": {
       "GsdGenIoCommunicationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoCommunicationStatusEnumeration",
         "const": {
           "INDATA": 0,
           "OFFLINE": 1
@@ -744,7 +744,7 @@
       },
       "GsdGenIoConfigurationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConfigurationStatusEnumeration",
         "const": {
           "OK": 0,
           "SUBSTITUTE": 1,
@@ -788,7 +788,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=6074",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -834,7 +834,7 @@
       "CommunicationStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoCommunicationStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoCommunicationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -850,7 +850,7 @@
       "ConfigurationStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoConfigurationStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConfigurationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1041,7 +1041,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1137,7 +1137,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -1241,7 +1241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1262,7 +1262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1288,7 +1288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1359,7 +1359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1381,7 +1381,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -1403,7 +1403,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -1425,7 +1425,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -1435,7 +1435,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -1457,7 +1457,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PNRIO.TM.json
+++ b/wot-codegen/opc-output-integrated/PNRIO.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelDiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "RioChannelDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -48,7 +48,7 @@
       },
       "RioChannelDiagnosisStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "const": {
           "HI_LIM_EXCEEDED": 0,
           "LO_LIM_EXCEEDED": 1,
@@ -154,7 +154,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -184,7 +184,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -210,7 +210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelDiagnosisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -222,7 +222,7 @@
     "schemaDefinitions": {
       "RioChannelDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -250,7 +250,7 @@
       },
       "RioChannelDiagnosisStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "const": {
           "HI_LIM_EXCEEDED": 0,
           "LO_LIM_EXCEEDED": 1,
@@ -356,7 +356,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -386,7 +386,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -412,7 +412,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnIoSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoSignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnIoTelegramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -490,7 +490,7 @@
     "schemaDefinitions": {
       "PnIoTelegramStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "const": {
           "GOOD": 0,
           "BAD_BY_SUBSLOT": 1,
@@ -535,7 +535,7 @@
       "ConsumerStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "PnIoTelegramStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -578,7 +578,7 @@
       "ProviderStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "PnIoTelegramStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -604,7 +604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnTelegramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnTelegramType",
     "dov:isComposite": true,
     "links": [
       {
@@ -643,7 +643,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelGroupConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelGroupConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -654,7 +654,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -702,7 +702,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -764,7 +764,7 @@
         "items": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -806,7 +806,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioBitFieldDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
         "required": [ "BitData", "BitUsed" ],
         "properties": {
           "BitData": {
@@ -833,7 +833,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -898,7 +898,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -941,7 +941,7 @@
         "items": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -983,7 +983,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioBitFieldDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
         "required": [ "BitData", "BitUsed" ],
         "properties": {
           "BitData": {
@@ -1021,7 +1021,7 @@
       "SignalType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioSignalTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1037,7 +1037,7 @@
       "SubstitutePolicy": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioSubstitutePolicyEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1095,7 +1095,7 @@
         "data": {
           "title": "RioBitFieldDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
           "required": [ "BitData", "BitUsed" ],
           "properties": {
             "BitData": {
@@ -1123,7 +1123,7 @@
         "data": {
           "title": "RioBitFieldDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
           "required": [ "BitData", "BitUsed" ],
           "properties": {
             "BitData": {
@@ -1157,7 +1157,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1206,7 +1206,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -1279,7 +1279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1307,7 +1307,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -1377,7 +1377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1404,7 +1404,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1431,7 +1431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1459,7 +1459,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6133",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled", "Index" ],
           "properties": {
             "SimulationEnabled": {
@@ -1486,14 +1486,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6292",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier", "Index" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Value used to set the Value member of the array element.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -1567,14 +1567,14 @@
         "items": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -1649,7 +1649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1677,7 +1677,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled", "Index" ],
           "properties": {
             "SimulationEnabled": {
@@ -1704,7 +1704,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier", "Index" ],
           "properties": {
             "Value": {
@@ -1756,7 +1756,7 @@
         "items": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -1809,7 +1809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1821,7 +1821,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -1869,7 +1869,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -1915,7 +1915,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputConfigDataType",
         "required": [ "Damping", "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "Damping": {
@@ -1925,7 +1925,7 @@
           },
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1938,7 +1938,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1946,7 +1946,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -1989,7 +1989,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2043,7 +2043,7 @@
         "data": {
           "title": "RioFaAnalogInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputConfigDataType",
           "required": [ "Damping", "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "Damping": {
@@ -2053,7 +2053,7 @@
             },
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2066,7 +2066,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2074,7 +2074,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -2118,7 +2118,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2178,7 +2178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2190,7 +2190,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2238,7 +2238,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -2284,12 +2284,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2305,7 +2305,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2313,7 +2313,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -2361,7 +2361,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2398,7 +2398,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2466,12 +2466,12 @@
         "data": {
           "title": "RioFaAnalogOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2487,7 +2487,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2495,7 +2495,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -2544,7 +2544,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2583,7 +2583,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2658,7 +2658,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2670,7 +2670,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2718,7 +2718,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -2764,12 +2764,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2782,7 +2782,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2804,7 +2804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2844,12 +2844,12 @@
         "data": {
           "title": "RioFaDigitalInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2862,7 +2862,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2885,7 +2885,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2930,7 +2930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2942,7 +2942,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2990,7 +2990,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -3036,12 +3036,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3057,7 +3057,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3084,7 +3084,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -3107,7 +3107,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -3161,12 +3161,12 @@
         "data": {
           "title": "RioFaDigitalOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3182,7 +3182,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3210,7 +3210,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -3234,7 +3234,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -3294,7 +3294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3306,7 +3306,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -3354,7 +3354,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -3382,7 +3382,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -3421,14 +3421,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6294",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualProcessValue" ],
           "properties": {
             "ManualProcessValue": {
               "title": "RioAnalogDataType",
               "description": "Desired Value of the ManualProcessValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3471,13 +3471,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6293",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3496,7 +3496,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6295",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -3517,14 +3517,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6296",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Desired content of the Value struct member of the SimulationValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3575,7 +3575,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputConfigDataType",
         "required": [ "Damping", "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "HighLimit", "LowLimit" ],
         "properties": {
           "Damping": {
@@ -3585,7 +3585,7 @@
           },
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3595,7 +3595,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3603,7 +3603,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3635,7 +3635,7 @@
           "HighLimit": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3667,7 +3667,7 @@
           "LowLimit": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3710,7 +3710,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -3750,7 +3750,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3767,7 +3767,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -3828,14 +3828,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
             "title": "RioAnalogDataType",
             "description": "Current value.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3887,7 +3887,7 @@
         "data": {
           "title": "RioPaAnalogInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputConfigDataType",
           "required": [ "Damping", "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "HighLimit", "LowLimit" ],
           "properties": {
             "Damping": {
@@ -3897,7 +3897,7 @@
             },
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3907,7 +3907,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3915,7 +3915,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3947,7 +3947,7 @@
             "HighLimit": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3979,7 +3979,7 @@
             "LowLimit": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4023,7 +4023,7 @@
         "data": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -4064,7 +4064,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4082,7 +4082,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -4146,14 +4146,14 @@
         "data": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4209,7 +4209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4221,7 +4221,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -4269,7 +4269,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -4297,7 +4297,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -4336,14 +4336,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6298",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualOutValue" ],
           "properties": {
             "ManualOutValue": {
               "title": "RioAnalogDataType",
               "description": "Desired Value of the ManualOutValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4386,13 +4386,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4411,7 +4411,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6299",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -4432,14 +4432,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6300",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Desired content of the SimulationEnabled Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4490,12 +4490,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -4505,7 +4505,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -4513,7 +4513,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -4561,7 +4561,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -4601,7 +4601,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4618,7 +4618,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -4653,7 +4653,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -4728,14 +4728,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
             "title": "RioAnalogDataType",
             "description": "Current value.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -4787,12 +4787,12 @@
         "data": {
           "title": "RioPaAnalogOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4802,7 +4802,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4810,7 +4810,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4859,7 +4859,7 @@
         "data": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -4900,7 +4900,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4918,7 +4918,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -4954,7 +4954,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -5033,14 +5033,14 @@
         "data": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -5096,7 +5096,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5108,7 +5108,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -5156,7 +5156,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -5184,7 +5184,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -5223,7 +5223,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6302",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualProcessValue" ],
           "properties": {
             "ManualProcessValue": {
@@ -5244,13 +5244,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6301",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5269,7 +5269,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6303",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -5290,7 +5290,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6304",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5319,12 +5319,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5337,7 +5337,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5370,7 +5370,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5387,7 +5387,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -5448,7 +5448,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
@@ -5478,12 +5478,12 @@
         "data": {
           "title": "RioPaDigitalInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5496,7 +5496,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5531,7 +5531,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5549,7 +5549,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -5613,7 +5613,7 @@
         "data": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5647,7 +5647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5659,7 +5659,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -5707,7 +5707,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -5735,7 +5735,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -5774,7 +5774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6071",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualOutValue" ],
           "properties": {
             "ManualOutValue": {
@@ -5795,13 +5795,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5820,7 +5820,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -5841,7 +5841,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5870,12 +5870,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5888,7 +5888,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5926,7 +5926,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5943,7 +5943,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -5978,7 +5978,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -6053,7 +6053,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
@@ -6083,12 +6083,12 @@
         "data": {
           "title": "RioPaDigitalOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6101,7 +6101,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6141,7 +6141,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6159,7 +6159,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -6195,7 +6195,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -6274,7 +6274,7 @@
         "data": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -6308,7 +6308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6347,7 +6347,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -6378,7 +6378,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6406,7 +6406,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6434,7 +6434,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6471,7 +6471,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6499,7 +6499,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6824,7 +6824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -6851,7 +6851,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6876,7 +6876,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -6982,7 +6982,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -7009,7 +7009,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -7034,7 +7034,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -7056,7 +7056,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -7315,7 +7315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7411,7 +7411,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -7515,7 +7515,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -7536,7 +7536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7620,7 +7620,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7639,7 +7639,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -7659,7 +7659,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -7691,7 +7691,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7734,7 +7734,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7876,7 +7876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7961,7 +7961,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8007,7 +8007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8053,7 +8053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8079,7 +8079,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8105,7 +8105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8127,7 +8127,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -8149,7 +8149,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -8171,7 +8171,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -8181,7 +8181,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -8203,7 +8203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/POWERLINK.TM.json
+++ b/wot-codegen/opc-output-integrated/POWERLINK.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -120,7 +120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkCnConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkCnConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkDeviceProfileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkDeviceProfileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -231,7 +231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkMnConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkMnConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -275,7 +275,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -340,7 +340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -385,7 +385,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -441,7 +441,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -512,7 +512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -534,7 +534,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -556,7 +556,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -578,7 +578,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -588,7 +588,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -610,7 +610,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -703,7 +703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -748,7 +748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -795,7 +795,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -857,7 +857,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1010,7 +1010,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1034,7 +1034,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1237,7 +1237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1258,7 +1258,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PROFINET.TM.json
+++ b/wot-codegen/opc-output-integrated/PROFINET.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnDiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -38,7 +38,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -66,7 +66,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -94,7 +94,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -122,7 +122,7 @@
       },
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -182,7 +182,7 @@
       "Accumulative": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelAccumulativeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -240,7 +240,7 @@
       "Direction": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelDirectionEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -296,7 +296,7 @@
       "Maintenance": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelMaintenanceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -353,7 +353,7 @@
       "Specifier": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelSpecifierEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -383,7 +383,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -423,7 +423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -435,7 +435,7 @@
     "schemaDefinitions": {
       "PnAssetChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangeEnumeration",
         "const": {
           "INSERTED": 0,
           "REMOVED": 1,
@@ -458,7 +458,7 @@
       },
       "PnAssetTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetTypeEnumeration",
         "const": {
           "DEVICE": 0,
           "MODULE": 1,
@@ -498,7 +498,7 @@
       "AssetChange": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnAssetChangeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -514,7 +514,7 @@
       "AssetType": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnAssetTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -540,7 +540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnTopologyChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnTopologyChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -567,7 +567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnDomainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnDomainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -599,7 +599,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnEquipmentContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnEquipmentContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -631,7 +631,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -672,7 +672,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -720,7 +720,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -738,7 +738,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -766,7 +766,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -794,7 +794,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -852,7 +852,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -877,35 +877,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -980,7 +980,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -1005,35 +1005,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1098,7 +1098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1131,7 +1131,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1319,7 +1319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1330,7 +1330,7 @@
     "schemaDefinitions": {
       "IMTagSelectorEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.IMTagSelectorEnumeration",
         "const": {
           "FUNCTION": 0,
           "LOCATION": 1,
@@ -1361,7 +1361,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Date" ],
           "properties": {
             "Date": {
@@ -1383,7 +1383,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Descriptor" ],
           "properties": {
             "Descriptor": {
@@ -1404,13 +1404,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tag_Selector", "Tag_Function", "Tag_Location" ],
           "properties": {
             "Tag_Selector": {
               "title": "IMTagSelectorEnumeration",
               "description": "If 1, Tag_Function shall be written, If 2, Tag_Location shall be written, if 3 both.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.IMTagSelectorEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1479,7 +1479,7 @@
           "title": "PnIM5DataType",
           "description": "Contains the fields of the APDU element I&M5 | I&M5Data",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnIM5DataType",
           "required": [ "Annotation", "OrderId", "VendorId", "SerialNumber", "HardwareRevision", "SoftwareRevision" ],
           "properties": {
             "Annotation": {
@@ -1687,7 +1687,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnInterfaceContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnInterfaceContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1720,7 +1720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnRealModuleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnRealModuleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1753,7 +1753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1785,7 +1785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnApplicationRelationContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnApplicationRelationContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1818,7 +1818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnApplicationRelationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnApplicationRelationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1835,7 +1835,7 @@
     "schemaDefinitions": {
       "PnARStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
         "const": {
           "CONNECTED": 0,
           "UNCONNECTED": 1,
@@ -1868,7 +1868,7 @@
       },
       "PnARTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARTypeEnumeration",
         "const": {
           "IOCARSingle": 0,
           "IOSAR": 6,
@@ -1972,7 +1972,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnARStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1993,7 +1993,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnARTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2012,7 +2012,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnARStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2036,7 +2036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnExpectedModuleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnExpectedModuleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2069,7 +2069,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2080,7 +2080,7 @@
     "schemaDefinitions": {
       "PnDeviceStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
         "const": {
           "OFFLINE": 0,
           "OFFLINE_DOCKING": 1,
@@ -2137,7 +2137,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnDeviceStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2156,7 +2156,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnDeviceStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2180,7 +2180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2210,7 +2210,7 @@
     "schemaDefinitions": {
       "PnDeviceRoleOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceRoleOptionSet",
         "const": {
           "IO_DEVICE": 0,
           "IO_CONTROLLER": 1,
@@ -2254,7 +2254,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6095",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameOfStation" ],
           "properties": {
             "NameOfStation": {
@@ -2304,7 +2304,7 @@
       "DeviceRole": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnDeviceRoleOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceRoleOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2396,7 +2396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_EthernetInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.EthernetInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2476,7 +2476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_NetworkComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.NetworkComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2552,7 +2552,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_NetworkComponentFeatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.NetworkComponentFeatureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2578,7 +2578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_EthernetPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.EthernetPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2658,7 +2658,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2691,7 +2691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2715,7 +2715,7 @@
     "schemaDefinitions": {
       "PnLinkStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
         "const": {
           "UP": 1,
           "DOWN": 2,
@@ -2758,7 +2758,7 @@
       },
       "PnPortStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
         "const": {
           "UNKNOWN": 0,
           "DISABLED_DISCARDING": 1,
@@ -2841,7 +2841,7 @@
       "LinkState": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnLinkStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2871,7 +2871,7 @@
       "PortState": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnPortStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2932,7 +2932,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnLinkStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2964,7 +2964,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnPortStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3003,7 +3003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3215,7 +3215,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3300,7 +3300,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnExpectedModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnExpectedModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3317,7 +3317,7 @@
     "schemaDefinitions": {
       "PnModuleStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
         "const": {
           "NO_MODULE": 0,
           "WRONG_MODULE": 1,
@@ -3367,7 +3367,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnModuleStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3386,7 +3386,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnModuleStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3410,7 +3410,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnExpectedSubmoduleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnExpectedSubmoduleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3443,7 +3443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnRealModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnRealModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3472,7 +3472,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -3520,7 +3520,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -3538,7 +3538,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -3566,7 +3566,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -3594,7 +3594,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -3642,7 +3642,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -3667,35 +3667,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3758,7 +3758,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -3783,35 +3783,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -3876,7 +3876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnRealSubmoduleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnRealSubmoduleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3909,7 +3909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4008,7 +4008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnExpectedSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnExpectedSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4040,7 +4040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnSubmoduleStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4051,7 +4051,7 @@
     "schemaDefinitions": {
       "PnSubmoduleAddInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
         "const": {
           "NO_ADD_INFO": 0,
           "TAKEOVER_NOT_ALLOWED": 1
@@ -4068,7 +4068,7 @@
       },
       "PnSubmoduleARInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
         "const": {
           "OWN": 0,
           "APPLICATION_READY_PENDING": 128,
@@ -4101,7 +4101,7 @@
       },
       "PnSubmoduleIdentInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
         "const": {
           "OK": 0,
           "SUBSTITUTE": 2048,
@@ -4146,7 +4146,7 @@
       "AddInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleAddInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4162,7 +4162,7 @@
       "ARInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleARInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4190,7 +4190,7 @@
       "IdentInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleIdentInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4245,7 +4245,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleAddInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4262,7 +4262,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleARInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4292,7 +4292,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleIdentInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4355,7 +4355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnRealSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnRealSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4378,7 +4378,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -4426,7 +4426,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -4444,7 +4444,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -4472,7 +4472,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -4500,7 +4500,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -4548,7 +4548,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -4573,35 +4573,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4664,7 +4664,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -4689,35 +4689,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4782,7 +4782,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPv4FeatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPv4FeatureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4951,7 +4951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4990,7 +4990,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -5021,7 +5021,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5049,7 +5049,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5077,7 +5077,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5114,7 +5114,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5142,7 +5142,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5467,7 +5467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5494,7 +5494,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -5519,7 +5519,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -5625,7 +5625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5652,7 +5652,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -5677,7 +5677,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -5699,7 +5699,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -5958,7 +5958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6054,7 +6054,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -6158,7 +6158,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -6179,7 +6179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6263,7 +6263,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6282,7 +6282,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -6302,7 +6302,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -6334,7 +6334,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -6377,7 +6377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6519,7 +6519,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6604,7 +6604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6650,7 +6650,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6696,7 +6696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6722,7 +6722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6748,7 +6748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PackML.TM.json
+++ b/wot-codegen/opc-output-integrated/PackML.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLAdminObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLAdminObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
         "items": {
           "title": "PackMLDescriptorDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
           "required": [ "ID", "Name", "Unit", "Value" ],
           "properties": {
             "ID": {
@@ -146,7 +146,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -188,7 +188,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -205,7 +205,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -253,7 +253,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -270,7 +270,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -318,7 +318,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -335,7 +335,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -550,7 +550,7 @@
           "items": {
             "title": "PackMLDescriptorDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
             "required": [ "ID", "Name", "Unit", "Value" ],
             "properties": {
               "ID": {
@@ -567,7 +567,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -610,7 +610,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -627,7 +627,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -676,7 +676,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -693,7 +693,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -742,7 +742,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -759,7 +759,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -884,7 +884,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -925,7 +925,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=350",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RemoteInterface" ],
           "properties": {
             "RemoteInterface": {
@@ -934,7 +934,7 @@
               "items": {
                 "title": "PackMLRemoteInterfaceDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
                 "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
                 "properties": {
                   "Number": {
@@ -961,7 +961,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -978,7 +978,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1023,7 +1023,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=351",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InterlockId", "State" ],
           "properties": {
             "InterlockId": {
@@ -1050,7 +1050,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=348",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestedMachineSpeed" ],
           "properties": {
             "RequestedMachineSpeed": {
@@ -1073,7 +1073,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=352",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -1082,7 +1082,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1099,7 +1099,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1141,7 +1141,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=349",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Product" ],
           "properties": {
             "Product": {
@@ -1150,7 +1150,7 @@
               "items": {
                 "title": "PackMLProductDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
                 "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
                 "properties": {
                   "ProductID": {
@@ -1165,7 +1165,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -1182,7 +1182,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1216,7 +1216,7 @@
                     "items": {
                       "title": "PackMLIngredientsDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                       "required": [ "IngredientID", "Parameter" ],
                       "properties": {
                         "IngredientID": {
@@ -1231,7 +1231,7 @@
                           "items": {
                             "title": "PackMLDescriptorDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                             "required": [ "ID", "Name", "Unit", "Value" ],
                             "properties": {
                               "ID": {
@@ -1248,7 +1248,7 @@
                                 "title": "EUInformation",
                                 "description": "OPC UA engineering unit information",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -1296,7 +1296,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=118",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestedMode" ],
           "properties": {
             "RequestedMode": {
@@ -1354,7 +1354,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1512,7 +1512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1682,7 +1682,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1915,7 +1915,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=342",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -1924,7 +1924,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1941,7 +1941,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2092,7 +2092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLStatusObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLStatusObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2187,7 +2187,7 @@
         "items": {
           "title": "PackMLDescriptorDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
           "required": [ "ID", "Name", "Unit", "Value" ],
           "properties": {
             "ID": {
@@ -2204,7 +2204,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -2246,7 +2246,7 @@
         "items": {
           "title": "PackMLProductDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
           "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
           "properties": {
             "ProductID": {
@@ -2261,7 +2261,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -2278,7 +2278,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2312,7 +2312,7 @@
               "items": {
                 "title": "PackMLIngredientsDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                 "required": [ "IngredientID", "Parameter" ],
                 "properties": {
                   "IngredientID": {
@@ -2327,7 +2327,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -2344,7 +2344,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2392,7 +2392,7 @@
         "items": {
           "title": "PackMLRemoteInterfaceDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
           "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
           "properties": {
             "Number": {
@@ -2419,7 +2419,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -2436,7 +2436,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2627,7 +2627,7 @@
           "items": {
             "title": "PackMLDescriptorDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
             "required": [ "ID", "Name", "Unit", "Value" ],
             "properties": {
               "ID": {
@@ -2644,7 +2644,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2687,7 +2687,7 @@
           "items": {
             "title": "PackMLProductDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
             "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
             "properties": {
               "ProductID": {
@@ -2702,7 +2702,7 @@
                 "items": {
                   "title": "PackMLDescriptorDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                   "required": [ "ID", "Name", "Unit", "Value" ],
                   "properties": {
                     "ID": {
@@ -2719,7 +2719,7 @@
                       "title": "EUInformation",
                       "description": "OPC UA engineering unit information",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2753,7 +2753,7 @@
                 "items": {
                   "title": "PackMLIngredientsDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                   "required": [ "IngredientID", "Parameter" ],
                   "properties": {
                     "IngredientID": {
@@ -2768,7 +2768,7 @@
                       "items": {
                         "title": "PackMLDescriptorDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                        "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                         "required": [ "ID", "Name", "Unit", "Value" ],
                         "properties": {
                           "ID": {
@@ -2785,7 +2785,7 @@
                             "title": "EUInformation",
                             "description": "OPC UA engineering unit information",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2834,7 +2834,7 @@
           "items": {
             "title": "PackMLRemoteInterfaceDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
             "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
             "properties": {
               "Number": {
@@ -2861,7 +2861,7 @@
                 "items": {
                   "title": "PackMLDescriptorDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                   "required": [ "ID", "Name", "Unit", "Value" ],
                   "properties": {
                     "ID": {
@@ -2878,7 +2878,7 @@
                       "title": "EUInformation",
                       "description": "OPC UA engineering unit information",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2995,7 +2995,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3016,7 +3016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3158,7 +3158,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3243,7 +3243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3289,7 +3289,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Calender.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Calender.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_CouplingProductForcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.CouplingProductForcesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_CouplingProductTensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.CouplingProductTensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -108,7 +108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_Calender_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.Calender_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -204,7 +204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -230,7 +230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -258,7 +258,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -270,7 +270,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -289,7 +289,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -299,7 +299,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -326,7 +326,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -336,7 +336,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -384,7 +384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -503,7 +503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -645,7 +645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -756,7 +756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -802,7 +802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1368,7 +1368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1418,7 +1418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1441,7 +1441,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1497,7 +1497,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1571,7 +1571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1693,7 +1693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1779,7 +1779,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1829,7 +1829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1840,7 +1840,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -1936,7 +1936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2025,7 +2025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2036,7 +2036,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2122,7 +2122,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2148,7 +2148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2302,7 +2302,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2331,7 +2331,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2343,7 +2343,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2365,7 +2365,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2375,7 +2375,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2397,7 +2397,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2407,7 +2407,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2458,7 +2458,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2485,7 +2485,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2542,7 +2542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2554,7 +2554,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -2698,7 +2698,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2725,7 +2725,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2766,7 +2766,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2778,14 +2778,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2886,7 +2886,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -2898,7 +2898,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3009,7 +3009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3037,7 +3037,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3066,7 +3066,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3107,7 +3107,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3227,7 +3227,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3243,7 +3243,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3256,7 +3256,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3265,7 +3265,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3367,7 +3367,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3376,7 +3376,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3488,7 +3488,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3569,7 +3569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3634,7 +3634,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -3720,7 +3720,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3772,7 +3772,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3823,7 +3823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3952,7 +3952,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4003,7 +4003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4108,7 +4108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4164,7 +4164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4214,7 +4214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4345,7 +4345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4548,7 +4548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4604,7 +4604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4675,7 +4675,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4697,7 +4697,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4719,7 +4719,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4741,7 +4741,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4751,7 +4751,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4773,7 +4773,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Calibrator.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Calibrator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_CalibrationZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.CalibrationZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_CalibrationZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.CalibrationZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -209,7 +209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_Calibrator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.Calibrator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -266,7 +266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -287,7 +287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -313,7 +313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -341,7 +341,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -353,7 +353,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -372,7 +372,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -382,7 +382,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -409,7 +409,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -419,7 +419,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -586,7 +586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -728,7 +728,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -813,7 +813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -839,7 +839,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -885,7 +885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -931,7 +931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -981,7 +981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1004,7 +1004,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1060,7 +1060,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1134,7 +1134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1256,7 +1256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1776,7 +1776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1862,7 +1862,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1912,7 +1912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1923,7 +1923,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2019,7 +2019,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2108,7 +2108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2119,7 +2119,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2205,7 +2205,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2231,7 +2231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2282,7 +2282,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2363,7 +2363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2517,7 +2517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2546,7 +2546,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2558,7 +2558,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2580,7 +2580,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2590,7 +2590,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2612,7 +2612,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2622,7 +2622,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2673,7 +2673,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2700,7 +2700,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2757,7 +2757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2769,7 +2769,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -2913,7 +2913,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2940,7 +2940,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2981,7 +2981,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2993,14 +2993,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3101,7 +3101,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3113,7 +3113,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3224,7 +3224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3252,7 +3252,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3281,7 +3281,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3322,7 +3322,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3442,7 +3442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3458,7 +3458,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3471,7 +3471,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3480,7 +3480,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3582,7 +3582,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3591,7 +3591,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3703,7 +3703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3768,7 +3768,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -3854,7 +3854,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3906,7 +3906,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4109,7 +4109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4165,7 +4165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4236,7 +4236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4258,7 +4258,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4280,7 +4280,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4302,7 +4302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4312,7 +4312,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4334,7 +4334,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Corrugator.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Corrugator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Corrugator_Corrugator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Corrugator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Corrugator.Corrugator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -84,7 +84,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -168,7 +168,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -233,7 +233,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -319,7 +319,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -371,7 +371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -434,7 +434,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -565,7 +565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -586,7 +586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -612,7 +612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -640,7 +640,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -652,7 +652,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -671,7 +671,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -681,7 +681,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -708,7 +708,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -718,7 +718,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -766,7 +766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -885,7 +885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1027,7 +1027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1112,7 +1112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1138,7 +1138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1184,7 +1184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1230,7 +1230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1280,7 +1280,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1303,7 +1303,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1359,7 +1359,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1433,7 +1433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1555,7 +1555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2075,7 +2075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2161,7 +2161,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2211,7 +2211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2222,7 +2222,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2318,7 +2318,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2407,7 +2407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2418,7 +2418,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2504,7 +2504,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2530,7 +2530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2684,7 +2684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2713,7 +2713,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2725,7 +2725,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2747,7 +2747,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2757,7 +2757,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2779,7 +2779,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2789,7 +2789,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2840,7 +2840,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2867,7 +2867,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2924,7 +2924,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2936,7 +2936,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3080,7 +3080,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3107,7 +3107,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3148,7 +3148,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3160,14 +3160,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3268,7 +3268,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3280,7 +3280,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3391,7 +3391,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3419,7 +3419,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3448,7 +3448,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3489,7 +3489,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3609,7 +3609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3625,7 +3625,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3638,7 +3638,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3647,7 +3647,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3749,7 +3749,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3758,7 +3758,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3870,7 +3870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3921,7 +3921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4002,7 +4002,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4205,7 +4205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4261,7 +4261,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4332,7 +4332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4354,7 +4354,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4376,7 +4376,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4398,7 +4398,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4408,7 +4408,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4430,7 +4430,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Cutter.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Cutter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CutEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CutEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CuttingProductsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CuttingProductsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CuttingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CuttingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -172,7 +172,7 @@
     "schemaDefinitions": {
       "WallThickeningEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.WallThickeningEnumeration",
         "const": {
           "NO": 0,
           "FRONT": 1,
@@ -344,7 +344,7 @@
       "WallThickeningPosition": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/",
         "title": "WallThickeningEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.WallThickeningEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_Cutter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.Cutter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -699,7 +699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -795,7 +795,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -899,7 +899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -920,7 +920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -946,7 +946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -974,7 +974,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -986,7 +986,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1005,7 +1005,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1015,7 +1015,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1042,7 +1042,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1052,7 +1052,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1100,7 +1100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1219,7 +1219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1361,7 +1361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1446,7 +1446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1472,7 +1472,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1518,7 +1518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1629,7 +1629,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -1715,7 +1715,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1767,7 +1767,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1817,7 +1817,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1840,7 +1840,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1896,7 +1896,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1970,7 +1970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2092,7 +2092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2612,7 +2612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2698,7 +2698,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2748,7 +2748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2759,7 +2759,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2855,7 +2855,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2944,7 +2944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2955,7 +2955,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -3041,7 +3041,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3067,7 +3067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3221,7 +3221,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3250,7 +3250,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3262,7 +3262,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3284,7 +3284,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3294,7 +3294,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3316,7 +3316,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3326,7 +3326,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3377,7 +3377,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3404,7 +3404,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3461,7 +3461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3473,7 +3473,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3617,7 +3617,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3644,7 +3644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3685,7 +3685,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3697,14 +3697,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3805,7 +3805,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3817,7 +3817,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3928,7 +3928,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3956,7 +3956,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3985,7 +3985,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -4026,7 +4026,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -4146,7 +4146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4162,7 +4162,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -4175,7 +4175,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4184,7 +4184,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4286,7 +4286,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4295,7 +4295,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4407,7 +4407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4610,7 +4610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4666,7 +4666,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4737,7 +4737,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4759,7 +4759,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4781,7 +4781,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4803,7 +4803,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4813,7 +4813,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4835,7 +4835,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Die.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Die.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Die_Die_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Die/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Die.Die_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -53,7 +53,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -118,7 +118,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -204,7 +204,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -319,7 +319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -450,7 +450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -471,7 +471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -497,7 +497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -525,7 +525,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -537,7 +537,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -556,7 +556,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -566,7 +566,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -593,7 +593,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -603,7 +603,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -651,7 +651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -770,7 +770,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -912,7 +912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -997,7 +997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1023,7 +1023,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1069,7 +1069,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1115,7 +1115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1165,7 +1165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1188,7 +1188,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1244,7 +1244,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1318,7 +1318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1440,7 +1440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1960,7 +1960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2046,7 +2046,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2096,7 +2096,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2107,7 +2107,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2203,7 +2203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2292,7 +2292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2303,7 +2303,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2389,7 +2389,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2415,7 +2415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2569,7 +2569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2598,7 +2598,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2610,7 +2610,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2632,7 +2632,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2642,7 +2642,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2664,7 +2664,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2674,7 +2674,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2725,7 +2725,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2752,7 +2752,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2809,7 +2809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2821,7 +2821,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -2965,7 +2965,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2992,7 +2992,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3033,7 +3033,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3045,14 +3045,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3153,7 +3153,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3165,7 +3165,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3276,7 +3276,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3304,7 +3304,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3333,7 +3333,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3374,7 +3374,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3494,7 +3494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3510,7 +3510,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3523,7 +3523,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3532,7 +3532,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3634,7 +3634,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3643,7 +3643,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3755,7 +3755,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3958,7 +3958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4014,7 +4014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4085,7 +4085,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4107,7 +4107,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4129,7 +4129,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4151,7 +4151,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4161,7 +4161,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4183,7 +4183,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Extruder.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Extruder.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "FeedingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedingModeEnumeration",
         "const": {
           "ONLY_CONVEYING": 0,
           "OTHER": 1,
@@ -111,7 +111,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/",
         "title": "FeedingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_HopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.HopperType",
     "links": [
       {
         "rel": "tm:extends",
@@ -293,7 +293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_Extruder_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.Extruder_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -445,7 +445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_FeedersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -495,7 +495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -576,7 +576,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -626,7 +626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -649,7 +649,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -705,7 +705,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -779,7 +779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -901,7 +901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1421,7 +1421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1507,7 +1507,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1557,7 +1557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1568,7 +1568,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -1664,7 +1664,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1753,7 +1753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1764,7 +1764,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -1850,7 +1850,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1876,7 +1876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2030,7 +2030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2121,7 +2121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2150,7 +2150,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2162,7 +2162,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2184,7 +2184,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2194,7 +2194,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2216,7 +2216,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2226,7 +2226,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2277,7 +2277,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2304,7 +2304,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2361,7 +2361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2373,7 +2373,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -2517,7 +2517,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2544,7 +2544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2585,7 +2585,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2597,14 +2597,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2705,7 +2705,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -2717,7 +2717,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2828,7 +2828,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2856,7 +2856,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -2885,7 +2885,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -2926,7 +2926,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3046,7 +3046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3062,7 +3062,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3075,7 +3075,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3084,7 +3084,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3186,7 +3186,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3195,7 +3195,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3307,7 +3307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3358,7 +3358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3408,7 +3408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3532,7 +3532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3553,7 +3553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3579,7 +3579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3607,7 +3607,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3619,7 +3619,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -3638,7 +3638,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3648,7 +3648,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -3675,7 +3675,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3685,7 +3685,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -3733,7 +3733,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3852,7 +3852,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3994,7 +3994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4079,7 +4079,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4105,7 +4105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4151,7 +4151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4197,7 +4197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4262,7 +4262,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -4348,7 +4348,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4400,7 +4400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4463,7 +4463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4594,7 +4594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4797,7 +4797,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4853,7 +4853,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4924,7 +4924,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4946,7 +4946,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4968,7 +4968,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4990,7 +4990,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5000,7 +5000,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5022,7 +5022,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.ExtrusionLine.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.ExtrusionLine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -101,7 +101,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -129,7 +129,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -167,7 +167,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -248,7 +248,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -288,7 +288,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_LotFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.LotFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_UnitFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.UnitFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -526,7 +526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_ExtrusionLine_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.ExtrusionLine_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -592,7 +592,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -657,7 +657,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Message2" ],
           "properties": {
             "Id": {
@@ -689,7 +689,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -710,7 +710,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -760,7 +760,7 @@
       "LineStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "ProductionStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -786,7 +786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -814,7 +814,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "EquipmentDescription", "ProductionDatasetName", "MaterialMapping", "Priority", "PlannedStart", "PlannedProductionTime", "PlannedSetUpTime", "LatestEnd" ],
           "properties": {
             "Id": {
@@ -834,7 +834,7 @@
               "items": {
                 "title": "MaterialMappingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.MaterialMappingType",
                 "required": [ "MaterialId", "MaterialLot", "HopperId" ],
                 "properties": {
                   "MaterialId": {
@@ -874,7 +874,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobGroupNodeId" ],
           "properties": {
             "JobGroupNodeId": {
@@ -894,7 +894,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6216",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -914,7 +914,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6215",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -934,7 +934,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -954,7 +954,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -996,7 +996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1013,7 +1013,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1098,7 +1098,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "CustomerName", "ProductName", "ProductDescription", "Strand", "Sequence", "ParameterSetting", "SetOutput", "LotSize" ],
           "properties": {
             "Id": {
@@ -1131,7 +1131,7 @@
               "items": {
                 "title": "ParameterSettingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
                 "required": [ "Id", "Value" ],
                 "properties": {
                   "Id": {
@@ -1160,7 +1160,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -1180,7 +1180,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1200,7 +1200,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1220,7 +1220,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1240,7 +1240,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1264,7 +1264,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -1285,7 +1285,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1398,7 +1398,7 @@
         "items": {
           "title": "MaterialMappingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.MaterialMappingType",
           "required": [ "MaterialId", "MaterialLot", "HopperId" ],
           "properties": {
             "MaterialId": {
@@ -1514,7 +1514,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1585,7 +1585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1596,7 +1596,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1867,7 +1867,7 @@
         "items": {
           "title": "ParameterSettingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
           "required": [ "Id", "Value" ],
           "properties": {
             "Id": {
@@ -1959,7 +1959,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2174,7 +2174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_ProductionParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.ProductionParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2342,7 +2342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2438,7 +2438,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2542,7 +2542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2563,7 +2563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2589,7 +2589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2617,7 +2617,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -2629,7 +2629,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -2648,7 +2648,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -2658,7 +2658,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -2685,7 +2685,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -2695,7 +2695,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -2743,7 +2743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2862,7 +2862,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3004,7 +3004,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3089,7 +3089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3115,7 +3115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3161,7 +3161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3207,7 +3207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3236,7 +3236,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3248,7 +3248,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3270,7 +3270,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3280,7 +3280,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3302,7 +3302,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3312,7 +3312,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3363,7 +3363,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3390,7 +3390,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3447,7 +3447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3459,7 +3459,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3603,7 +3603,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3630,7 +3630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3682,7 +3682,7 @@
           "title": "StandstillReasonType",
           "description": "Description of a standstill reason",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonType",
           "required": [ "Id", "Text", "LockedByMES" ],
           "properties": {
             "Id": {
@@ -3744,7 +3744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3773,7 +3773,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Name", "Density" ],
           "properties": {
             "Id": {
@@ -3801,7 +3801,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3823,7 +3823,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -3874,7 +3874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3965,7 +3965,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MESMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MESMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4038,7 +4038,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4079,7 +4079,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -4091,14 +4091,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -4199,7 +4199,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -4211,7 +4211,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -4322,7 +4322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4350,7 +4350,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -4379,7 +4379,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -4420,7 +4420,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -4540,7 +4540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4556,7 +4556,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -4569,7 +4569,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4578,7 +4578,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4680,7 +4680,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4689,7 +4689,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4801,7 +4801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4955,7 +4955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5005,7 +5005,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5129,7 +5129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5332,7 +5332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5388,7 +5388,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5459,7 +5459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5481,7 +5481,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5503,7 +5503,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5525,7 +5525,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5535,7 +5535,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5557,7 +5557,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Filter.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Filter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_Filter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.Filter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -198,7 +198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_FilterPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -215,7 +215,7 @@
     "schemaDefinitions": {
       "FilterPackageStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageStatusEnumeration",
         "const": {
           "NOT_ACTIVE": 0,
           "ACTIVE": 1,
@@ -323,7 +323,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/",
         "title": "FilterPackageStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -364,7 +364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_ScreenPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.ScreenPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -532,7 +532,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -618,7 +618,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -670,7 +670,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -733,7 +733,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -864,7 +864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -885,7 +885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -911,7 +911,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -939,7 +939,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -951,7 +951,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -970,7 +970,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -980,7 +980,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1007,7 +1007,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1017,7 +1017,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1184,7 +1184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1326,7 +1326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1411,7 +1411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1437,7 +1437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1483,7 +1483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1529,7 +1529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1579,7 +1579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1602,7 +1602,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1658,7 +1658,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1732,7 +1732,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1854,7 +1854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2374,7 +2374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2460,7 +2460,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2510,7 +2510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2521,7 +2521,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2617,7 +2617,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2706,7 +2706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2717,7 +2717,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2803,7 +2803,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2829,7 +2829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2983,7 +2983,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3012,7 +3012,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3024,7 +3024,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3046,7 +3046,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3056,7 +3056,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3078,7 +3078,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3088,7 +3088,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3139,7 +3139,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3166,7 +3166,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3223,7 +3223,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3235,7 +3235,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3379,7 +3379,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3406,7 +3406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3447,7 +3447,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3459,14 +3459,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3567,7 +3567,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3579,7 +3579,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3690,7 +3690,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3718,7 +3718,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3747,7 +3747,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3788,7 +3788,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3908,7 +3908,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3924,7 +3924,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3937,7 +3937,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3946,7 +3946,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4048,7 +4048,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4057,7 +4057,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4169,7 +4169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4250,7 +4250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4453,7 +4453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4509,7 +4509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4580,7 +4580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4602,7 +4602,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4624,7 +4624,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4646,7 +4646,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4656,7 +4656,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4678,7 +4678,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -73,7 +73,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -159,7 +159,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -274,7 +274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -405,7 +405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -456,7 +456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -585,7 +585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -635,7 +635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -691,7 +691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -742,7 +742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",
@@ -847,7 +847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -868,7 +868,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -894,7 +894,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -922,7 +922,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -934,7 +934,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -953,7 +953,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -963,7 +963,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -990,7 +990,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1000,7 +1000,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1048,7 +1048,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1167,7 +1167,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1309,7 +1309,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1394,7 +1394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1420,7 +1420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1466,7 +1466,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1512,7 +1512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1562,7 +1562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1585,7 +1585,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1641,7 +1641,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1715,7 +1715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1837,7 +1837,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2357,7 +2357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2443,7 +2443,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2493,7 +2493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2504,7 +2504,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2600,7 +2600,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2689,7 +2689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2700,7 +2700,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2786,7 +2786,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2812,7 +2812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2966,7 +2966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2995,7 +2995,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3007,7 +3007,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3029,7 +3029,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3039,7 +3039,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3061,7 +3061,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3071,7 +3071,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3122,7 +3122,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3149,7 +3149,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3206,7 +3206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3218,7 +3218,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3362,7 +3362,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3389,7 +3389,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3430,7 +3430,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3442,14 +3442,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3550,7 +3550,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3562,7 +3562,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3673,7 +3673,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3701,7 +3701,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3730,7 +3730,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3771,7 +3771,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3891,7 +3891,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3907,7 +3907,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3920,7 +3920,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3929,7 +3929,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4031,7 +4031,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4040,7 +4040,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4152,7 +4152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4233,7 +4233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4436,7 +4436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4492,7 +4492,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4563,7 +4563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4585,7 +4585,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4607,7 +4607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4629,7 +4629,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4639,7 +4639,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4661,7 +4661,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.HaulOff.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.HaulOff.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -92,7 +92,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -157,7 +157,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -243,7 +243,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -295,7 +295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -358,7 +358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -489,7 +489,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -510,7 +510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -536,7 +536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -564,7 +564,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -576,7 +576,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -595,7 +595,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -605,7 +605,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -632,7 +632,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -642,7 +642,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -690,7 +690,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -809,7 +809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -951,7 +951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1036,7 +1036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1062,7 +1062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1108,7 +1108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1154,7 +1154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1204,7 +1204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1227,7 +1227,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1283,7 +1283,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1357,7 +1357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1479,7 +1479,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1999,7 +1999,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2085,7 +2085,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2135,7 +2135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2146,7 +2146,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2242,7 +2242,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2331,7 +2331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2342,7 +2342,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2428,7 +2428,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2454,7 +2454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2608,7 +2608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2637,7 +2637,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2649,7 +2649,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2671,7 +2671,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2681,7 +2681,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2703,7 +2703,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2713,7 +2713,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2764,7 +2764,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2791,7 +2791,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2848,7 +2848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2860,7 +2860,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3004,7 +3004,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3031,7 +3031,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3072,7 +3072,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3084,14 +3084,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3192,7 +3192,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3204,7 +3204,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3315,7 +3315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3343,7 +3343,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3372,7 +3372,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3413,7 +3413,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3533,7 +3533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3549,7 +3549,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3562,7 +3562,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3571,7 +3571,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3673,7 +3673,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3682,7 +3682,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3794,7 +3794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3845,7 +3845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3926,7 +3926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4129,7 +4129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4185,7 +4185,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4256,7 +4256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4278,7 +4278,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4300,7 +4300,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4322,7 +4322,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4332,7 +4332,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4354,7 +4354,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.MeltPump.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.MeltPump.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_MeltPump_MeltPump_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/MeltPump/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.MeltPump.MeltPump_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -94,7 +94,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -159,7 +159,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -245,7 +245,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -297,7 +297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -360,7 +360,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -491,7 +491,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -512,7 +512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -538,7 +538,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -566,7 +566,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -578,7 +578,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -597,7 +597,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -607,7 +607,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -634,7 +634,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -644,7 +644,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -692,7 +692,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -811,7 +811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -953,7 +953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1038,7 +1038,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1064,7 +1064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1110,7 +1110,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1156,7 +1156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1206,7 +1206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1229,7 +1229,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1285,7 +1285,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1359,7 +1359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1481,7 +1481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2001,7 +2001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2087,7 +2087,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2137,7 +2137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2148,7 +2148,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2244,7 +2244,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2333,7 +2333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2344,7 +2344,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2430,7 +2430,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2456,7 +2456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2610,7 +2610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2639,7 +2639,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2651,7 +2651,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2673,7 +2673,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2683,7 +2683,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2705,7 +2705,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2715,7 +2715,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2766,7 +2766,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2793,7 +2793,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2850,7 +2850,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2862,7 +2862,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3006,7 +3006,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3033,7 +3033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3074,7 +3074,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3086,14 +3086,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3194,7 +3194,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3206,7 +3206,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3317,7 +3317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3345,7 +3345,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3374,7 +3374,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3415,7 +3415,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3535,7 +3535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3551,7 +3551,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3564,7 +3564,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3573,7 +3573,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3675,7 +3675,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3684,7 +3684,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3796,7 +3796,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3877,7 +3877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4080,7 +4080,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4136,7 +4136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4207,7 +4207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4229,7 +4229,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4251,7 +4251,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4273,7 +4273,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4283,7 +4283,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4305,7 +4305,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Pelletizer.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion.Pelletizer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_DiePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.DiePlateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_Pelletizer_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.Pelletizer_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -188,7 +188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_KnifePackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.KnifePackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -260,7 +260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -281,7 +281,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -307,7 +307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -335,7 +335,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -347,7 +347,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -366,7 +366,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -376,7 +376,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -403,7 +403,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -413,7 +413,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -461,7 +461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -580,7 +580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -722,7 +722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -807,7 +807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -833,7 +833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -879,7 +879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -925,7 +925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -990,7 +990,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -1076,7 +1076,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1128,7 +1128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1191,7 +1191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1322,7 +1322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1372,7 +1372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1395,7 +1395,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1451,7 +1451,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1525,7 +1525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1647,7 +1647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2167,7 +2167,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2253,7 +2253,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2303,7 +2303,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2314,7 +2314,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2410,7 +2410,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2499,7 +2499,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2510,7 +2510,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2596,7 +2596,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2622,7 +2622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2776,7 +2776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2805,7 +2805,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2817,7 +2817,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2839,7 +2839,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2849,7 +2849,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2871,7 +2871,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2881,7 +2881,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2932,7 +2932,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2959,7 +2959,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3016,7 +3016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3028,7 +3028,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3172,7 +3172,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3199,7 +3199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3240,7 +3240,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3252,14 +3252,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3360,7 +3360,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3372,7 +3372,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3483,7 +3483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3511,7 +3511,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3540,7 +3540,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3581,7 +3581,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3701,7 +3701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3717,7 +3717,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3730,7 +3730,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3739,7 +3739,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3841,7 +3841,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3850,7 +3850,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3962,7 +3962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4043,7 +4043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4246,7 +4246,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4302,7 +4302,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4373,7 +4373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4395,7 +4395,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -4417,7 +4417,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -4439,7 +4439,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -4449,7 +4449,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -4471,7 +4471,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Calender.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Calender.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_CouplingProductForcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.CouplingProductForcesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_CouplingProductTensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.CouplingProductTensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -108,7 +108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_Calender_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.Calender_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -204,7 +204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -230,7 +230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -258,7 +258,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -270,7 +270,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -289,7 +289,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -299,7 +299,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -326,7 +326,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -336,7 +336,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -384,7 +384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -503,7 +503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -645,7 +645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -756,7 +756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -802,7 +802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1368,7 +1368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1418,7 +1418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1441,7 +1441,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1497,7 +1497,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1571,7 +1571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1693,7 +1693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1779,7 +1779,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1829,7 +1829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1840,7 +1840,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -1936,7 +1936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2025,7 +2025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2036,7 +2036,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2122,7 +2122,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2148,7 +2148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2302,7 +2302,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2331,7 +2331,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2343,7 +2343,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2365,7 +2365,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2375,7 +2375,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2397,7 +2397,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2407,7 +2407,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2458,7 +2458,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2485,7 +2485,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2542,7 +2542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2583,7 +2583,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2595,14 +2595,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2703,7 +2703,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -2715,7 +2715,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2826,7 +2826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2854,7 +2854,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -2883,7 +2883,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -2924,7 +2924,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3044,7 +3044,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3060,7 +3060,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3073,7 +3073,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3082,7 +3082,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3184,7 +3184,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3193,7 +3193,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3305,7 +3305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3386,7 +3386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3451,7 +3451,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3577,7 +3577,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3616,7 +3616,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3667,7 +3667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3796,7 +3796,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3847,7 +3847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3952,7 +3952,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4008,7 +4008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4058,7 +4058,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Calibrator.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Calibrator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_CalibrationZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.CalibrationZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_CalibrationZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.CalibrationZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -209,7 +209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_Calibrator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.Calibrator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -266,7 +266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -287,7 +287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -313,7 +313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -341,7 +341,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -353,7 +353,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -372,7 +372,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -382,7 +382,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -409,7 +409,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -419,7 +419,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -586,7 +586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -728,7 +728,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -813,7 +813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -839,7 +839,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -885,7 +885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -931,7 +931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -981,7 +981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1004,7 +1004,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1060,7 +1060,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1134,7 +1134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1256,7 +1256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1776,7 +1776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1862,7 +1862,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1912,7 +1912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1923,7 +1923,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2019,7 +2019,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2108,7 +2108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2119,7 +2119,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2205,7 +2205,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2231,7 +2231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2282,7 +2282,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2363,7 +2363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2517,7 +2517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2546,7 +2546,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2558,7 +2558,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2580,7 +2580,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2590,7 +2590,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2612,7 +2612,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2622,7 +2622,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2673,7 +2673,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2700,7 +2700,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2757,7 +2757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2798,7 +2798,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2810,14 +2810,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2918,7 +2918,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -2930,7 +2930,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3041,7 +3041,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3069,7 +3069,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3098,7 +3098,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3139,7 +3139,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3259,7 +3259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3275,7 +3275,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3288,7 +3288,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3297,7 +3297,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3399,7 +3399,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3408,7 +3408,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3520,7 +3520,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3585,7 +3585,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3711,7 +3711,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Corrugator.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Corrugator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Corrugator_Corrugator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Corrugator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Corrugator.Corrugator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -84,7 +84,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -168,7 +168,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -233,7 +233,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -359,7 +359,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -398,7 +398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -461,7 +461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -592,7 +592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -613,7 +613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -639,7 +639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -667,7 +667,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -679,7 +679,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -698,7 +698,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -708,7 +708,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -735,7 +735,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -745,7 +745,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -793,7 +793,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -912,7 +912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1054,7 +1054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1139,7 +1139,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1165,7 +1165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1211,7 +1211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1257,7 +1257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1307,7 +1307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1330,7 +1330,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1386,7 +1386,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1460,7 +1460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1582,7 +1582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2102,7 +2102,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2188,7 +2188,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2238,7 +2238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2249,7 +2249,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2345,7 +2345,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2434,7 +2434,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2445,7 +2445,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2531,7 +2531,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2557,7 +2557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2711,7 +2711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2740,7 +2740,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2752,7 +2752,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2774,7 +2774,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2784,7 +2784,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2806,7 +2806,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2816,7 +2816,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2867,7 +2867,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2894,7 +2894,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2951,7 +2951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2992,7 +2992,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3004,14 +3004,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3112,7 +3112,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3124,7 +3124,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3235,7 +3235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3263,7 +3263,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3292,7 +3292,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3333,7 +3333,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3453,7 +3453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3469,7 +3469,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3482,7 +3482,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3491,7 +3491,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3593,7 +3593,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3602,7 +3602,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3714,7 +3714,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3765,7 +3765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Cutter.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Cutter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CutEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CutEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CuttingProductsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CuttingProductsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CuttingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CuttingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -172,7 +172,7 @@
     "schemaDefinitions": {
       "WallThickeningEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.WallThickeningEnumeration",
         "const": {
           "NO": 0,
           "FRONT": 1,
@@ -344,7 +344,7 @@
       "WallThickeningPosition": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/",
         "title": "WallThickeningEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.WallThickeningEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_Cutter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.Cutter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -699,7 +699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -795,7 +795,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -899,7 +899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -920,7 +920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -946,7 +946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -974,7 +974,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -986,7 +986,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1005,7 +1005,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1015,7 +1015,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1042,7 +1042,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1052,7 +1052,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1100,7 +1100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1219,7 +1219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1361,7 +1361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1446,7 +1446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1472,7 +1472,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1518,7 +1518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1629,7 +1629,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -1755,7 +1755,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1794,7 +1794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1844,7 +1844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1867,7 +1867,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1923,7 +1923,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1997,7 +1997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2119,7 +2119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2639,7 +2639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2725,7 +2725,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2775,7 +2775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2786,7 +2786,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2882,7 +2882,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2971,7 +2971,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2982,7 +2982,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -3068,7 +3068,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3094,7 +3094,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3248,7 +3248,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3277,7 +3277,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3289,7 +3289,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3311,7 +3311,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3321,7 +3321,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3343,7 +3343,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3353,7 +3353,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3404,7 +3404,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3431,7 +3431,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3488,7 +3488,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3529,7 +3529,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3541,14 +3541,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3649,7 +3649,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3661,7 +3661,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3772,7 +3772,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3800,7 +3800,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3829,7 +3829,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3870,7 +3870,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3990,7 +3990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4006,7 +4006,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -4019,7 +4019,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4028,7 +4028,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4130,7 +4130,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4139,7 +4139,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Die.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Die.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Die_Die_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Die/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Die.Die_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -53,7 +53,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -118,7 +118,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -244,7 +244,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -283,7 +283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -346,7 +346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -477,7 +477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -498,7 +498,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -524,7 +524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -552,7 +552,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -564,7 +564,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -583,7 +583,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -593,7 +593,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -620,7 +620,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -630,7 +630,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -678,7 +678,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -797,7 +797,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -939,7 +939,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1024,7 +1024,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1050,7 +1050,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1096,7 +1096,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1142,7 +1142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1192,7 +1192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1215,7 +1215,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1271,7 +1271,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1345,7 +1345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1467,7 +1467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1987,7 +1987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2073,7 +2073,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2123,7 +2123,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2134,7 +2134,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2230,7 +2230,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2319,7 +2319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2330,7 +2330,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2416,7 +2416,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2442,7 +2442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2596,7 +2596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2625,7 +2625,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2637,7 +2637,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2659,7 +2659,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2669,7 +2669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2691,7 +2691,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2701,7 +2701,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2752,7 +2752,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2779,7 +2779,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2836,7 +2836,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2877,7 +2877,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2889,14 +2889,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2997,7 +2997,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3009,7 +3009,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3120,7 +3120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3148,7 +3148,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3177,7 +3177,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3218,7 +3218,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3338,7 +3338,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3354,7 +3354,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3367,7 +3367,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3376,7 +3376,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3478,7 +3478,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3487,7 +3487,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Extruder.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Extruder.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "FeedingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedingModeEnumeration",
         "const": {
           "ONLY_CONVEYING": 0,
           "OTHER": 1,
@@ -111,7 +111,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/",
         "title": "FeedingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_HopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.HopperType",
     "links": [
       {
         "rel": "tm:extends",
@@ -293,7 +293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_Extruder_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.Extruder_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -445,7 +445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_FeedersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -495,7 +495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -576,7 +576,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -626,7 +626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -649,7 +649,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -705,7 +705,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -779,7 +779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -901,7 +901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1421,7 +1421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1507,7 +1507,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -1557,7 +1557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1568,7 +1568,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -1664,7 +1664,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1753,7 +1753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1764,7 +1764,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -1850,7 +1850,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1876,7 +1876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2030,7 +2030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2121,7 +2121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2150,7 +2150,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2162,7 +2162,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2184,7 +2184,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2194,7 +2194,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2216,7 +2216,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2226,7 +2226,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2277,7 +2277,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2304,7 +2304,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2361,7 +2361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2402,7 +2402,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2414,14 +2414,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2522,7 +2522,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -2534,7 +2534,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -2645,7 +2645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2673,7 +2673,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -2702,7 +2702,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -2743,7 +2743,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -2863,7 +2863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2879,7 +2879,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -2892,7 +2892,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -2901,7 +2901,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3003,7 +3003,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3012,7 +3012,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3124,7 +3124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3175,7 +3175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3225,7 +3225,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3349,7 +3349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3370,7 +3370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3396,7 +3396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3424,7 +3424,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3436,7 +3436,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -3455,7 +3455,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3465,7 +3465,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -3492,7 +3492,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3502,7 +3502,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -3550,7 +3550,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3669,7 +3669,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3811,7 +3811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3896,7 +3896,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3922,7 +3922,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3968,7 +3968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4014,7 +4014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4079,7 +4079,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -4205,7 +4205,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4244,7 +4244,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4307,7 +4307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.ExtrusionLine.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.ExtrusionLine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -101,7 +101,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -129,7 +129,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -167,7 +167,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -248,7 +248,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -288,7 +288,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_LotFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.LotFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_UnitFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.UnitFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -526,7 +526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_ExtrusionLine_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.ExtrusionLine_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -595,7 +595,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Message2" ],
           "properties": {
             "Id": {
@@ -627,7 +627,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -648,7 +648,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -691,7 +691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -719,7 +719,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "EquipmentDescription", "ProductionDatasetName", "MaterialMapping", "Priority", "PlannedStart", "PlannedProductionTime", "PlannedSetUpTime", "LatestEnd" ],
           "properties": {
             "Id": {
@@ -739,7 +739,7 @@
               "items": {
                 "title": "MaterialMappingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.MaterialMappingType",
                 "required": [ "MaterialId", "MaterialLot", "HopperId" ],
                 "properties": {
                   "MaterialId": {
@@ -779,7 +779,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobGroupNodeId" ],
           "properties": {
             "JobGroupNodeId": {
@@ -799,7 +799,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6216",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -819,7 +819,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6215",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -839,7 +839,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -859,7 +859,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -901,7 +901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -918,7 +918,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1003,7 +1003,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "CustomerName", "ProductName", "ProductDescription", "Strand", "Sequence", "ParameterSetting", "SetOutput", "LotSize" ],
           "properties": {
             "Id": {
@@ -1036,7 +1036,7 @@
               "items": {
                 "title": "ParameterSettingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
                 "required": [ "Id", "Value" ],
                 "properties": {
                   "Id": {
@@ -1065,7 +1065,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -1085,7 +1085,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1105,7 +1105,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1125,7 +1125,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1145,7 +1145,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1169,7 +1169,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -1190,7 +1190,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1303,7 +1303,7 @@
         "items": {
           "title": "MaterialMappingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.MaterialMappingType",
           "required": [ "MaterialId", "MaterialLot", "HopperId" ],
           "properties": {
             "MaterialId": {
@@ -1419,7 +1419,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1490,7 +1490,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1501,7 +1501,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1772,7 +1772,7 @@
         "items": {
           "title": "ParameterSettingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
           "required": [ "Id", "Value" ],
           "properties": {
             "Id": {
@@ -1864,7 +1864,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2079,7 +2079,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_ProductionParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.ProductionParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2247,7 +2247,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2343,7 +2343,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2447,7 +2447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2468,7 +2468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2494,7 +2494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2522,7 +2522,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -2534,7 +2534,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -2553,7 +2553,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -2563,7 +2563,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -2590,7 +2590,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -2600,7 +2600,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -2648,7 +2648,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2767,7 +2767,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2909,7 +2909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2994,7 +2994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3020,7 +3020,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3066,7 +3066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3112,7 +3112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3177,7 +3177,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3303,7 +3303,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3342,7 +3342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3392,7 +3392,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3415,7 +3415,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -3471,7 +3471,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3545,7 +3545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3667,7 +3667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4187,7 +4187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4273,7 +4273,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -4323,7 +4323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4334,7 +4334,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -4430,7 +4430,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4519,7 +4519,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4530,7 +4530,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -4616,7 +4616,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4642,7 +4642,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4796,7 +4796,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4825,7 +4825,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -4837,7 +4837,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -4859,7 +4859,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4869,7 +4869,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -4891,7 +4891,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -4901,7 +4901,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -4952,7 +4952,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -4979,7 +4979,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -5036,7 +5036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5077,7 +5077,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -5089,14 +5089,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -5197,7 +5197,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -5209,7 +5209,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -5320,7 +5320,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5348,7 +5348,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -5377,7 +5377,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -5418,7 +5418,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -5538,7 +5538,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5554,7 +5554,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -5567,7 +5567,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -5576,7 +5576,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -5678,7 +5678,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -5687,7 +5687,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -5799,7 +5799,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5851,7 +5851,7 @@
           "title": "StandstillReasonType",
           "description": "Description of a standstill reason",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonType",
           "required": [ "Id", "Text", "LockedByMES" ],
           "properties": {
             "Id": {
@@ -5913,7 +5913,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5942,7 +5942,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Name", "Density" ],
           "properties": {
             "Id": {
@@ -5970,7 +5970,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -5992,7 +5992,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -6043,7 +6043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6134,7 +6134,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MESMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MESMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6207,7 +6207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6257,7 +6257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Filter.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Filter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_Filter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.Filter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -198,7 +198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_FilterPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -215,7 +215,7 @@
     "schemaDefinitions": {
       "FilterPackageStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageStatusEnumeration",
         "const": {
           "NOT_ACTIVE": 0,
           "ACTIVE": 1,
@@ -323,7 +323,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/",
         "title": "FilterPackageStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -364,7 +364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_ScreenPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.ScreenPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -532,7 +532,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -658,7 +658,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -697,7 +697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -760,7 +760,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -891,7 +891,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -912,7 +912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -938,7 +938,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -966,7 +966,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -978,7 +978,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -997,7 +997,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1007,7 +1007,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1034,7 +1034,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1044,7 +1044,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1092,7 +1092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1211,7 +1211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1438,7 +1438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1464,7 +1464,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1510,7 +1510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1556,7 +1556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1606,7 +1606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1629,7 +1629,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1685,7 +1685,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1759,7 +1759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1881,7 +1881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2401,7 +2401,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2487,7 +2487,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2537,7 +2537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2548,7 +2548,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2644,7 +2644,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2733,7 +2733,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2744,7 +2744,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2830,7 +2830,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2856,7 +2856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3010,7 +3010,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3039,7 +3039,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3051,7 +3051,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3073,7 +3073,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3083,7 +3083,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3105,7 +3105,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3115,7 +3115,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3166,7 +3166,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3193,7 +3193,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3250,7 +3250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3291,7 +3291,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3303,14 +3303,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3411,7 +3411,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3423,7 +3423,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3534,7 +3534,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3562,7 +3562,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3591,7 +3591,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3632,7 +3632,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3752,7 +3752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3768,7 +3768,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3781,7 +3781,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3790,7 +3790,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3892,7 +3892,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3901,7 +3901,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4013,7 +4013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -73,7 +73,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -199,7 +199,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -238,7 +238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -301,7 +301,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -432,7 +432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -483,7 +483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -612,7 +612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -662,7 +662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -718,7 +718,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -769,7 +769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",
@@ -874,7 +874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -954,7 +954,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1135,7 +1135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1156,7 +1156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1182,7 +1182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1210,7 +1210,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1222,7 +1222,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1241,7 +1241,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1251,7 +1251,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1278,7 +1278,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1288,7 +1288,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1336,7 +1336,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1455,7 +1455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1597,7 +1597,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1682,7 +1682,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1708,7 +1708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1754,7 +1754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1800,7 +1800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1850,7 +1850,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1873,7 +1873,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1929,7 +1929,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2003,7 +2003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2125,7 +2125,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2645,7 +2645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2731,7 +2731,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2781,7 +2781,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2792,7 +2792,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2888,7 +2888,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2977,7 +2977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2988,7 +2988,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -3074,7 +3074,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3100,7 +3100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3254,7 +3254,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3283,7 +3283,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3295,7 +3295,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3317,7 +3317,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3327,7 +3327,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3349,7 +3349,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3359,7 +3359,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3410,7 +3410,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3437,7 +3437,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3494,7 +3494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3535,7 +3535,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3547,14 +3547,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3655,7 +3655,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3667,7 +3667,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3778,7 +3778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3806,7 +3806,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3835,7 +3835,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3876,7 +3876,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3996,7 +3996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4012,7 +4012,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -4025,7 +4025,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4034,7 +4034,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4136,7 +4136,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -4145,7 +4145,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -4257,7 +4257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4338,7 +4338,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.HaulOff.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.HaulOff.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -92,7 +92,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -157,7 +157,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -283,7 +283,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -322,7 +322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -385,7 +385,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -516,7 +516,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -537,7 +537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -563,7 +563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -591,7 +591,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -603,7 +603,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -622,7 +622,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -632,7 +632,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -659,7 +659,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -669,7 +669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -717,7 +717,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -836,7 +836,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -978,7 +978,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1063,7 +1063,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1089,7 +1089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1135,7 +1135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1181,7 +1181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1231,7 +1231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1254,7 +1254,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1310,7 +1310,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1384,7 +1384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1506,7 +1506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2026,7 +2026,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2112,7 +2112,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2162,7 +2162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2173,7 +2173,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2269,7 +2269,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2358,7 +2358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2369,7 +2369,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2455,7 +2455,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2481,7 +2481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2635,7 +2635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2664,7 +2664,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2676,7 +2676,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2698,7 +2698,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2708,7 +2708,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2730,7 +2730,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2740,7 +2740,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2791,7 +2791,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2818,7 +2818,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2875,7 +2875,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2916,7 +2916,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2928,14 +2928,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3036,7 +3036,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3048,7 +3048,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3159,7 +3159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3187,7 +3187,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3216,7 +3216,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3257,7 +3257,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3377,7 +3377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3393,7 +3393,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3406,7 +3406,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3415,7 +3415,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3517,7 +3517,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3526,7 +3526,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3638,7 +3638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3689,7 +3689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.MeltPump.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.MeltPump.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_MeltPump_MeltPump_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/MeltPump/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.MeltPump.MeltPump_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -94,7 +94,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -159,7 +159,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -285,7 +285,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -324,7 +324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -387,7 +387,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -518,7 +518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -539,7 +539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -565,7 +565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -593,7 +593,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -605,7 +605,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -624,7 +624,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -634,7 +634,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -661,7 +661,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -671,7 +671,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -719,7 +719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -838,7 +838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1091,7 +1091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1137,7 +1137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1183,7 +1183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1233,7 +1233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1256,7 +1256,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1312,7 +1312,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1386,7 +1386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1508,7 +1508,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2028,7 +2028,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2114,7 +2114,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2164,7 +2164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2175,7 +2175,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2271,7 +2271,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2360,7 +2360,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2371,7 +2371,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2457,7 +2457,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2483,7 +2483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2637,7 +2637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2666,7 +2666,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2678,7 +2678,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2700,7 +2700,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2710,7 +2710,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2732,7 +2732,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2742,7 +2742,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2793,7 +2793,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2820,7 +2820,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2877,7 +2877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2918,7 +2918,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -2930,14 +2930,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3038,7 +3038,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3050,7 +3050,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3161,7 +3161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3189,7 +3189,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3218,7 +3218,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3259,7 +3259,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3379,7 +3379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3395,7 +3395,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3408,7 +3408,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3417,7 +3417,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3519,7 +3519,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3528,7 +3528,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3640,7 +3640,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Pelletizer.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.Extrusion_v2.Pelletizer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_DiePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.DiePlateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_Pelletizer_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.Pelletizer_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -188,7 +188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_KnifePackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.KnifePackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -260,7 +260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -281,7 +281,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -307,7 +307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -335,7 +335,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -347,7 +347,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -366,7 +366,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -376,7 +376,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -403,7 +403,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -413,7 +413,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -461,7 +461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -580,7 +580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -722,7 +722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -807,7 +807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -833,7 +833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -879,7 +879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -925,7 +925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -990,7 +990,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -1116,7 +1116,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1155,7 +1155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1218,7 +1218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1349,7 +1349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1399,7 +1399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1422,7 +1422,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -1478,7 +1478,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1552,7 +1552,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1674,7 +1674,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2194,7 +2194,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2280,7 +2280,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2330,7 +2330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2341,7 +2341,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2437,7 +2437,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2526,7 +2526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2537,7 +2537,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -2623,7 +2623,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2649,7 +2649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2803,7 +2803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2832,7 +2832,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2844,7 +2844,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2866,7 +2866,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2876,7 +2876,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2898,7 +2898,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2908,7 +2908,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2959,7 +2959,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2986,7 +2986,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3043,7 +3043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3084,7 +3084,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -3096,14 +3096,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3204,7 +3204,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -3216,7 +3216,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -3327,7 +3327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3355,7 +3355,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -3384,7 +3384,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -3425,7 +3425,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -3545,7 +3545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3561,7 +3561,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -3574,7 +3574,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3583,7 +3583,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3685,7 +3685,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -3694,7 +3694,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -3806,7 +3806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ActiveJobValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveJobValuesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -175,7 +175,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "JobStatusEnumeration",
         "description": "Current status of the job",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ActiveCyclicJobValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveCyclicJobValuesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -716,7 +716,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -763,7 +763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1070",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -831,7 +831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MessageConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MessageConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -904,7 +904,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_CycleParametersEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleParametersEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -916,7 +916,7 @@
     "schemaDefinitions": {
       "CavityCycleQualityEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CavityCycleQualityEnumeration",
         "const": {
           "NO_PART": 0,
           "GOOD_PART": 1,
@@ -945,7 +945,7 @@
       },
       "CycleQualityEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleQualityEnumeration",
         "const": {
           "GOOD_CYCLE": 0,
           "BAD_CYCLE": 1,
@@ -974,7 +974,7 @@
       },
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1158,7 +1158,7 @@
         "type": "array",
         "items": {
           "title": "CavityCycleQualityEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CavityCycleQualityEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1189,7 +1189,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "CycleQualityEnumeration",
         "description": "Quality of the whole cycle",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleQualityEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1293,7 +1293,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "JobStatusEnumeration",
         "description": "Current status of the job",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1365,7 +1365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosisEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosisEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1377,7 +1377,7 @@
     "schemaDefinitions": {
       "DiagnosticsStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "const": {
           "OFF": 0,
           "ACTIVE_OK": 1,
@@ -1422,7 +1422,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "DiagnosticsStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1448,7 +1448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosisStepEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosisStepEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1506,7 +1506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1524,7 +1524,7 @@
     "schemaDefinitions": {
       "EventOriginatorEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EventOriginatorEnumeration",
         "const": {
           "OTHER": 0,
           "MACHINE": 1,
@@ -1571,7 +1571,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EventOriginatorEnumeration",
         "description": "Originator of a logbook event",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EventOriginatorEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1612,7 +1612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1736,7 +1736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1748,7 +1748,7 @@
     "schemaDefinitions": {
       "MachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -1800,7 +1800,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "New machine mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1817,7 +1817,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "Old machine mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1843,7 +1843,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MessageLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MessageLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1916,7 +1916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ParameterChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1955,7 +1955,7 @@
         "title": "EUInformation",
         "description": "New unit of the changed parameter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -2000,7 +2000,7 @@
         "title": "EUInformation",
         "description": "Old unit of the changed parameter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -2053,7 +2053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2113,7 +2113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetFrozenLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetFrozenLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2173,7 +2173,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionStatusChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2185,7 +2185,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -2237,7 +2237,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "New production status",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2254,7 +2254,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "Old production status",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2280,7 +2280,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RemoteAccessLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RemoteAccessLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2292,7 +2292,7 @@
     "schemaDefinitions": {
       "UserChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "const": {
           "LOG_ON": 0,
           "LOG_OFF": 1
@@ -2350,7 +2350,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "UserChangeEnumeration",
         "description": "Information if the user logs in or off",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2376,7 +2376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_SequenceChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2388,7 +2388,7 @@
     "schemaDefinitions": {
       "SequenceChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeEnumeration",
         "const": {
           "UPDATE": 0,
           "ADD": 1,
@@ -2435,7 +2435,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "SequenceChangeEnumeration",
         "description": "Classification of production sequence change",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2461,7 +2461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StandstillReasonLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2508,7 +2508,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserFeedbackLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserFeedbackLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2555,7 +2555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2567,7 +2567,7 @@
     "schemaDefinitions": {
       "UserChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "const": {
           "LOG_ON": 0,
           "LOG_OFF": 1
@@ -2599,7 +2599,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "UserChangeEnumeration",
         "description": "Information if the user logs in or off",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2625,7 +2625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2681,7 +2681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestCyclicJobListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestCyclicJobListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2708,7 +2708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestCyclicJobWriteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestCyclicJobWriteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2754,7 +2754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestJobListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestJobListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2781,7 +2781,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2841,7 +2841,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetReadEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetReadEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2853,7 +2853,7 @@
     "schemaDefinitions": {
       "StorageEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "const": {
           "PRODUCTION": 1,
           "PREPARATION": 2,
@@ -2903,7 +2903,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StorageEnumeration",
         "description": "Indication from where the dataset is read",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2929,7 +2929,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetWriteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetWriteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2941,7 +2941,7 @@
     "schemaDefinitions": {
       "StorageEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "const": {
           "PRODUCTION": 1,
           "PREPARATION": 2,
@@ -3009,7 +3009,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StorageEnumeration",
         "description": "Indication where the dataset is written to",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3035,7 +3035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3121,7 +3121,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -3171,7 +3171,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3183,7 +3183,7 @@
     "schemaDefinitions": {
       "DiagnosticsStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "const": {
           "OFF": 0,
           "ACTIVE_OK": 1,
@@ -3248,7 +3248,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "DiagnosticsStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3274,7 +3274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3325,7 +3325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3406,7 +3406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3456,7 +3456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3479,7 +3479,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -3535,7 +3535,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3609,7 +3609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3731,7 +3731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4251,7 +4251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4262,7 +4262,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -4358,7 +4358,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4447,7 +4447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4458,7 +4458,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -4544,7 +4544,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4570,7 +4570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4724,7 +4724,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4893,7 +4893,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_CyclicJobInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CyclicJobInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4922,7 +4922,7 @@
         "description": "Method for setting the data for cyclic jobs",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6268",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobName", "JobDescription", "CustomerName", "ProductionDatasetName", "ProductionDatasetDescription", "Material", "ProductName", "ProductDescription", "ContinueAtJobEnd", "NominalParts", "NominalBoxParts", "ExpectedCycleTime", "MouldId", "NumCavities" ],
           "properties": {
             "JobName": {
@@ -5095,7 +5095,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5130,7 +5130,7 @@
         "description": "Sends a list of jobs for cyclic processes available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6389",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -5139,7 +5139,7 @@
                 "title": "CyclicJobListElementType",
                 "description": "Description of a job in a cyclic job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3022",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CyclicJobListElementType",
                 "required": [ "NominalParts", "NominalBoxParts", "ExpectedCycleTime", "MouldId", "NumCavities" ],
                 "properties": {
                   "NominalParts": {
@@ -5187,7 +5187,7 @@
         "description": "Sends a list of jobs available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6384",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -5196,7 +5196,7 @@
                 "title": "JobListElementType",
                 "description": "Description of a job in a job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3021",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobListElementType",
                 "required": [ "JobName", "JobDescription", "JobClassification", "CustomerName", "ProductionDatasetName", "ProductionDatasetDescription", "Material", "ProductName", "ProductDescription", "JobPriority", "PlannedStart", "PlannedProductionTime", "LatestEnd" ],
                 "properties": {
                   "JobName": {
@@ -5291,7 +5291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5320,7 +5320,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -5332,7 +5332,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -5354,7 +5354,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -5364,7 +5364,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -5386,7 +5386,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -5396,7 +5396,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -5447,7 +5447,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -5474,7 +5474,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -5531,7 +5531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5583,7 +5583,7 @@
           "title": "StandstillReasonType",
           "description": "Description of a standstill reason",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonType",
           "required": [ "Id", "Text", "LockedByMES" ],
           "properties": {
             "Id": {
@@ -5645,7 +5645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5698,7 +5698,7 @@
         "description": "Method for setting the MESMessage",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Severity" ],
           "properties": {
             "Id": {
@@ -5750,7 +5750,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MESMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MESMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5823,7 +5823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5834,7 +5834,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -5934,7 +5934,7 @@
         "description": "Release of production for a given time",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6222",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "WatchDogTime" ],
           "properties": {
             "WatchDogTime": {
@@ -6004,7 +6004,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "Production status when the machine is in automatic or semi-automatic mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6030,7 +6030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StandstillMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6115,7 +6115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6133,7 +6133,7 @@
     "schemaDefinitions": {
       "MachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -6220,7 +6220,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "Current machine mode (as defined by mode selector on the machine)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6246,7 +6246,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6296,7 +6296,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6325,7 +6325,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Name", "Density" ],
           "properties": {
             "Id": {
@@ -6353,7 +6353,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -6375,7 +6375,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -6426,7 +6426,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6517,7 +6517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldCycleParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6565,7 +6565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6616,7 +6616,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6633,7 +6633,7 @@
     "schemaDefinitions": {
       "MouldStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "const": {
           "OTHER": 0,
           "MOULD_NOT_INSTALLED": 1,
@@ -6729,7 +6729,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MouldStatusEnumeration",
         "description": "Current (physical) status of the mould",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6755,7 +6755,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6805,7 +6805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6816,7 +6816,7 @@
     "schemaDefinitions": {
       "TemperatureZoneClassificationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "const": {
           "OTHER": 0,
           "HEATING": 1,
@@ -6855,7 +6855,7 @@
       },
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -6932,7 +6932,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "TemperatureZoneClassificationEnumeration",
         "description": "Type of the temperature zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6949,7 +6949,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
         "description": "Indication how the temperature is currently controlled",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7218,7 +7218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7269,7 +7269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7392,7 +7392,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ElectricDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ElectricDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7419,7 +7419,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HydraulicUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HydraulicUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7489,7 +7489,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7505,7 +7505,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -7518,7 +7518,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -7527,7 +7527,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -7629,7 +7629,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -7638,7 +7638,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -7750,7 +7750,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7791,7 +7791,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -7803,14 +7803,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -7911,7 +7911,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -7923,7 +7923,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -8034,7 +8034,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8062,7 +8062,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -8091,7 +8091,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -8132,7 +8132,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -8252,7 +8252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZoneCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneCycleParametersType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8264,7 +8264,7 @@
     "schemaDefinitions": {
       "TemperatureZoneClassificationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "const": {
           "OTHER": 0,
           "HEATING": 1,
@@ -8336,7 +8336,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "TemperatureZoneClassificationEnumeration",
         "description": "Type of the temperature zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8406,7 +8406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_BarrelTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.BarrelTemperatureZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8455,7 +8455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldTemperatureZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8482,7 +8482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_IdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.IdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8583,7 +8583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8595,7 +8595,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -8739,7 +8739,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8766,7 +8766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -8787,7 +8787,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8832,7 +8832,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8859,7 +8859,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8898,7 +8898,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -8929,7 +8929,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8957,7 +8957,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8985,7 +8985,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -9022,7 +9022,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -9050,7 +9050,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -9375,7 +9375,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9402,7 +9402,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9427,7 +9427,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9533,7 +9533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9560,7 +9560,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9585,7 +9585,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -9607,7 +9607,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -9866,7 +9866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9962,7 +9962,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -10066,7 +10066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10150,7 +10150,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -10169,7 +10169,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -10189,7 +10189,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -10221,7 +10221,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -10264,7 +10264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10406,7 +10406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10491,7 +10491,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10537,7 +10537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10583,7 +10583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10609,7 +10609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10635,7 +10635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10663,7 +10663,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -10675,7 +10675,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -10694,7 +10694,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -10704,7 +10704,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -10731,7 +10731,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -10741,7 +10741,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -10789,7 +10789,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10908,7 +10908,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10934,7 +10934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11137,7 +11137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11193,7 +11193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11264,7 +11264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11286,7 +11286,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -11308,7 +11308,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -11330,7 +11330,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -11340,7 +11340,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -11362,7 +11362,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.HotRunner.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.HotRunner.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZoneAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZoneAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     "schemaDefinitions": {
       "ControllerTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerTypeEnumeration",
         "const": {
           "CLOSED_LOOP_CONTROL": 0,
           "MANUAL": 1,
@@ -132,7 +132,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/HotRunner/",
         "title": "ControllerTypeEnumeration",
         "description": "Actual value for the controller type used by the zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HeatUpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HeatUpType",
     "links": [
       {
         "rel": "tm:extends",
@@ -663,7 +663,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HRD_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HRD_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -756,7 +756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_MaintenanceInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.MaintenanceInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -800,7 +800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -855,7 +855,7 @@
         "description": "Method to reset one error of the device",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=6378",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -876,7 +876,7 @@
         "description": "Method to set ReactionOnDisconnect and SessionNameForReactionOnDisconnect",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=6651",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReactionOnDisconnect" ],
           "properties": {
             "ReactionOnDisconnect": {
@@ -904,7 +904,7 @@
           "title": "ClassifiedActiveErrorDataType",
           "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
           "required": [ "SourceNodes", "Classification" ],
           "properties": {
             "SourceNodes": {
@@ -1063,7 +1063,7 @@
             "title": "ClassifiedActiveErrorDataType",
             "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
             "required": [ "SourceNodes", "Classification" ],
             "properties": {
               "SourceNodes": {
@@ -1149,7 +1149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1199,7 +1199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1371,7 +1371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HRDTemperatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HRDTemperatureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1502,7 +1502,7 @@
         "items": {
           "title": "TimeMethodPIDParametersDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.TimeMethodPIDParametersDataType",
           "required": [ "Xp", "Tn", "Tv", "Ts" ],
           "properties": {
             "Xp": {
@@ -1622,7 +1622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_TemperatureRiseMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.TemperatureRiseMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1751,7 +1751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1798,7 +1798,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2318,7 +2318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2330,7 +2330,7 @@
     "schemaDefinitions": {
       "DiagnosticsStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "const": {
           "OFF": 0,
           "ACTIVE_OK": 1,
@@ -2395,7 +2395,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "DiagnosticsStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2421,7 +2421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_IdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.IdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2522,7 +2522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2551,7 +2551,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -2563,7 +2563,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2585,7 +2585,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2595,7 +2595,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -2617,7 +2617,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -2627,7 +2627,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -2678,7 +2678,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -2705,7 +2705,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -2762,7 +2762,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2773,7 +2773,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -2869,7 +2869,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2958,7 +2958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3080,7 +3080,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3166,7 +3166,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -3216,7 +3216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3261,7 +3261,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3288,7 +3288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3327,7 +3327,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3358,7 +3358,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3386,7 +3386,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3414,7 +3414,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3451,7 +3451,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3479,7 +3479,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3804,7 +3804,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3831,7 +3831,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3856,7 +3856,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3962,7 +3962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3989,7 +3989,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4014,7 +4014,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4036,7 +4036,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4295,7 +4295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4391,7 +4391,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4495,7 +4495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4516,7 +4516,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4600,7 +4600,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4619,7 +4619,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -4639,7 +4639,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -4671,7 +4671,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4714,7 +4714,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4856,7 +4856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4941,7 +4941,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4987,7 +4987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5033,7 +5033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5059,7 +5059,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5085,7 +5085,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5288,7 +5288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5344,7 +5344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5415,7 +5415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5437,7 +5437,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5459,7 +5459,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5481,7 +5481,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5491,7 +5491,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5513,7 +5513,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.IMM2MES.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.IMM2MES.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_IMM_MES_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.IMM_MES_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -95,7 +95,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -145,7 +145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -349,7 +349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitCycleParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1421,7 +1421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1442,7 +1442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1468,7 +1468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1496,7 +1496,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -1508,7 +1508,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -1527,7 +1527,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1537,7 +1537,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -1564,7 +1564,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -1574,7 +1574,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -1622,7 +1622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1741,7 +1741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1883,7 +1883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1968,7 +1968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1994,7 +1994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2040,7 +2040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2086,7 +2086,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2136,7 +2136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2147,7 +2147,7 @@
     "schemaDefinitions": {
       "TemperatureZoneClassificationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "const": {
           "OTHER": 0,
           "HEATING": 1,
@@ -2186,7 +2186,7 @@
       },
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -2263,7 +2263,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "TemperatureZoneClassificationEnumeration",
         "description": "Type of the temperature zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2280,7 +2280,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
         "description": "Indication how the temperature is currently controlled",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2549,7 +2549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2584,7 +2584,7 @@
         "description": "Sends a list of jobs for cyclic processes available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6389",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -2593,7 +2593,7 @@
                 "title": "CyclicJobListElementType",
                 "description": "Description of a job in a cyclic job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3022",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CyclicJobListElementType",
                 "required": [ "NominalParts", "NominalBoxParts", "ExpectedCycleTime", "MouldId", "NumCavities" ],
                 "properties": {
                   "NominalParts": {
@@ -2641,7 +2641,7 @@
         "description": "Sends a list of jobs available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6384",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -2650,7 +2650,7 @@
                 "title": "JobListElementType",
                 "description": "Description of a job in a job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3021",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobListElementType",
                 "required": [ "JobName", "JobDescription", "JobClassification", "CustomerName", "ProductionDatasetName", "ProductionDatasetDescription", "Material", "ProductName", "ProductDescription", "JobPriority", "PlannedStart", "PlannedProductionTime", "LatestEnd" ],
                 "properties": {
                   "JobName": {
@@ -2745,7 +2745,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2914,7 +2914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ActiveJobValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveJobValuesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2925,7 +2925,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -3081,7 +3081,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "JobStatusEnumeration",
         "description": "Current status of the job",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3107,7 +3107,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3136,7 +3136,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3148,7 +3148,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3170,7 +3170,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3180,7 +3180,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3202,7 +3202,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3212,7 +3212,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3263,7 +3263,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3290,7 +3290,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3347,7 +3347,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3359,7 +3359,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -3503,7 +3503,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3530,7 +3530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3582,7 +3582,7 @@
           "title": "StandstillReasonType",
           "description": "Description of a standstill reason",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonType",
           "required": [ "Id", "Text", "LockedByMES" ],
           "properties": {
             "Id": {
@@ -3644,7 +3644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3697,7 +3697,7 @@
         "description": "Method for setting the MESMessage",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Severity" ],
           "properties": {
             "Id": {
@@ -3749,7 +3749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MESMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MESMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3822,7 +3822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3833,7 +3833,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -3933,7 +3933,7 @@
         "description": "Release of production for a given time",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6222",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "WatchDogTime" ],
           "properties": {
             "WatchDogTime": {
@@ -4003,7 +4003,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "Production status when the machine is in automatic or semi-automatic mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4029,7 +4029,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StandstillMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4114,7 +4114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4132,7 +4132,7 @@
     "schemaDefinitions": {
       "MachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -4219,7 +4219,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "Current machine mode (as defined by mode selector on the machine)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4245,7 +4245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4295,7 +4295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4419,7 +4419,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4470,7 +4470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4487,7 +4487,7 @@
     "schemaDefinitions": {
       "MouldStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "const": {
           "OTHER": 0,
           "MOULD_NOT_INSTALLED": 1,
@@ -4583,7 +4583,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MouldStatusEnumeration",
         "description": "Current (physical) status of the mould",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4609,7 +4609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4660,7 +4660,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4783,7 +4783,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4824,7 +4824,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -4836,14 +4836,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -4944,7 +4944,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -4956,7 +4956,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -5067,7 +5067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5095,7 +5095,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -5124,7 +5124,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -5165,7 +5165,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -5285,7 +5285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5301,7 +5301,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -5314,7 +5314,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -5323,7 +5323,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -5425,7 +5425,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -5434,7 +5434,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -5546,7 +5546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5749,7 +5749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5805,7 +5805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5876,7 +5876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5898,7 +5898,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5920,7 +5920,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5942,7 +5942,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5952,7 +5952,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5974,7 +5974,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.LDS.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.LDS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_AdditiveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "AdditiveStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveStatusEnumeration",
         "const": {
           "GOOD": 0,
           "WARNING": 1,
@@ -158,7 +158,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "AdditiveStatusEnumeration",
         "description": "Actual status of the additive provides a minimal error handling for devices without event support.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -184,7 +184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_AdditiveAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_ComponentAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -238,7 +238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_LDSCycleParametersEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.LDSCycleParametersEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -857,7 +857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -868,7 +868,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentStatusEnumeration",
         "const": {
           "GOOD": 0,
           "WARNING": 1,
@@ -934,7 +934,7 @@
         "description": "This optional method is used to modify SetValueDensity if allowed by the device.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Density" ],
           "properties": {
             "Density": {
@@ -1082,7 +1082,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "ComponentStatusEnumeration",
         "description": "Actual status of the component provides a minimal error handling for devices without event support.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1219,7 +1219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_LDS_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.LDS_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1312,7 +1312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     "schemaDefinitions": {
       "MaterialBalanceSystemTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.MaterialBalanceSystemTypeEnumeration",
         "const": {
           "NOT_AVAILABLE": 0,
           "ALWAYS_ACTIVE": 1,
@@ -1373,7 +1373,7 @@
       },
       "PurgeStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.PurgeStatusEnumeration",
         "const": {
           "OFF": 0,
           "COMPONENT_A": 1,
@@ -1445,7 +1445,7 @@
         "description": "Method to reset one error of the device",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1466,7 +1466,7 @@
         "description": "Method to set the cycle number of the LDS to synchronize it with the cycle number of the injection moulding machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6039",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CycleNumber" ],
           "properties": {
             "CycleNumber": {
@@ -1553,7 +1553,7 @@
           "title": "ClassifiedActiveErrorDataType",
           "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
           "required": [ "SourceNodes", "Classification" ],
           "properties": {
             "SourceNodes": {
@@ -1701,7 +1701,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "MaterialBalanceSystemTypeEnumeration",
         "description": "Type of the material balance system",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.MaterialBalanceSystemTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1850,7 +1850,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "PurgeStatusEnumeration",
         "description": "Actual status of the purge function",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.PurgeStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1993,7 +1993,7 @@
             "title": "ClassifiedActiveErrorDataType",
             "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
             "required": [ "SourceNodes", "Classification" ],
             "properties": {
               "SourceNodes": {
@@ -2311,7 +2311,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2332,7 +2332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2377,7 +2377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2404,7 +2404,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2443,7 +2443,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -2474,7 +2474,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2502,7 +2502,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2530,7 +2530,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2567,7 +2567,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2595,7 +2595,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -2920,7 +2920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2947,7 +2947,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -2972,7 +2972,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3078,7 +3078,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3105,7 +3105,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3130,7 +3130,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -3152,7 +3152,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -3411,7 +3411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3507,7 +3507,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3611,7 +3611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3695,7 +3695,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3714,7 +3714,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -3734,7 +3734,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -3766,7 +3766,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3809,7 +3809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3951,7 +3951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4036,7 +4036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4082,7 +4082,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4128,7 +4128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4154,7 +4154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4180,7 +4180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4302,7 +4302,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4822,7 +4822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4908,7 +4908,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -4958,7 +4958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5005,7 +5005,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_IdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.IdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5106,7 +5106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5135,7 +5135,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -5147,7 +5147,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -5169,7 +5169,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -5179,7 +5179,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -5201,7 +5201,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -5211,7 +5211,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -5262,7 +5262,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -5289,7 +5289,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -5346,7 +5346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5549,7 +5549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5605,7 +5605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5676,7 +5676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5698,7 +5698,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5720,7 +5720,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5742,7 +5742,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5752,7 +5752,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5774,7 +5774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/PlasticsRubber.TCD.TM.json
+++ b/wot-codegen/opc-output-integrated/PlasticsRubber.TCD.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCDHelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCDHelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_DeviceZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.DeviceZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -705,7 +705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalChannelsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalChannelsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -755,7 +755,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1022,7 +1022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1230,7 +1230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_LeakStopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.LeakStopperType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1278,7 +1278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_MaintenanceInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.MaintenanceInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1329,7 +1329,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_MouldEvacuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.MouldEvacuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1555,7 +1555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1566,7 +1566,7 @@
     "schemaDefinitions": {
       "OperatingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperatingModeEnumeration",
         "const": {
           "OTHER": 0,
           "READY_TO_OPERATE": 1,
@@ -1690,7 +1690,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/TCD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=6510",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1739,7 +1739,7 @@
           "title": "ActiveErrorDataType",
           "description": "Iinformation about an active error in a device",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3028",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveErrorDataType",
           "required": [ "Id", "Severity", "Message" ],
           "properties": {
             "Id": {
@@ -1823,7 +1823,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/TCD/",
         "title": "OperatingModeEnumeration",
         "description": "Actual operating mode of the TCD",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperatingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1859,7 +1859,7 @@
             "title": "ActiveErrorDataType",
             "description": "Iinformation about an active error in a device",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3028",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveErrorDataType",
             "required": [ "Id", "Severity", "Message" ],
             "properties": {
               "Id": {
@@ -1916,7 +1916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCD_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCD_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2004,7 +2004,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCDSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCDSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2257,7 +2257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2304,7 +2304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2824,7 +2824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2910,7 +2910,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -2960,7 +2960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2971,7 +2971,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -3067,7 +3067,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3156,7 +3156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3278,7 +3278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_IdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.IdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3379,7 +3379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3408,7 +3408,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -3420,7 +3420,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3442,7 +3442,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -3452,7 +3452,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -3474,7 +3474,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -3484,7 +3484,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -3535,7 +3535,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -3562,7 +3562,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3619,7 +3619,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3664,7 +3664,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3691,7 +3691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3730,7 +3730,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3761,7 +3761,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3789,7 +3789,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3817,7 +3817,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3854,7 +3854,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3882,7 +3882,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4207,7 +4207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4234,7 +4234,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4259,7 +4259,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4365,7 +4365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4392,7 +4392,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4417,7 +4417,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4439,7 +4439,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4698,7 +4698,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4794,7 +4794,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4898,7 +4898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4919,7 +4919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5003,7 +5003,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5022,7 +5022,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -5042,7 +5042,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -5074,7 +5074,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5117,7 +5117,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5259,7 +5259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5344,7 +5344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5390,7 +5390,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5436,7 +5436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5462,7 +5462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5488,7 +5488,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5691,7 +5691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5747,7 +5747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5818,7 +5818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5840,7 +5840,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5862,7 +5862,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5884,7 +5884,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5894,7 +5894,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5916,7 +5916,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/Powertrain.TM.json
+++ b/wot-codegen/opc-output-integrated/Powertrain.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_IPtTagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15898",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.IPtTagNameplateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -98,7 +98,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16337",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -152,7 +152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtBleedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtBleedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -271,7 +271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtBrakeAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16609",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtBrakeAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -990,7 +990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCapacitanceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCapacitanceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1078,7 +1078,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCommonAssetAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16873",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCommonAssetAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1132,7 +1132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAmbientAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16875",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAmbientAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1394,7 +1394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAnalogInputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16907",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAnalogInputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1470,7 +1470,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1497,7 +1497,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1584,7 +1584,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1612,7 +1612,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1661,7 +1661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAnalogOutputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16913",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAnalogOutputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1725,7 +1725,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1798,7 +1798,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1847,7 +1847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAuxiliarySupplyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16928",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAuxiliarySupplyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2051,7 +2051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCertificateAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16960",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCertificateAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2120,7 +2120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCommunicationInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16963",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCommunicationInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2310,7 +2310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCoolingAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16970",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCoolingAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2398,7 +2398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDigitalInputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17000",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDigitalInputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2512,7 +2512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDigitalOutputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17009",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDigitalOutputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtFunctionalSafetyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17144",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtFunctionalSafetyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2743,7 +2743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtSafetyFunctionsAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17149",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtSafetyFunctionsAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2933,7 +2933,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtFuseAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17024",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtFuseAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3120,7 +3120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtHardwareAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16973",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtHardwareAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3368,7 +3368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17046",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3460,7 +3460,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -3529,7 +3529,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -3632,7 +3632,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -3705,7 +3705,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -3754,7 +3754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMechanicalStrengthAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17136",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMechanicalStrengthAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3838,7 +3838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17085",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4028,7 +4028,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4207,7 +4207,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -4256,7 +4256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtProtectionClassAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17140",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtProtectionClassAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4356,7 +4356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtStandardAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17156",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtStandardAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4425,7 +4425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtContactorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16847",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtContactorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4454,7 +4454,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4562,7 +4562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDcBusAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16798",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDcBusAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4596,7 +4596,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4657,7 +4657,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -4707,7 +4707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtElectronicOverloadRelayAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtElectronicOverloadRelayAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4795,7 +4795,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4898,7 +4898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16553",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5016,7 +5016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderLinearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderLinearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5219,7 +5219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderRotaryAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderRotaryAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5596,7 +5596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5691,7 +5691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderInterfaceProtocolAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16605",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderInterfaceProtocolAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5779,7 +5779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtGearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16503",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtGearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6146,7 +6146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputConverterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16806",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputConverterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6364,7 +6364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputFilterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16827",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputFilterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6539,7 +6539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16383",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6628,7 +6628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorLinearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorLinearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6774,7 +6774,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRotaryAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRotaryAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6905,7 +6905,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorDutyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16499",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorDutyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7008,7 +7008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorManagementDeviceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorManagementDeviceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7042,7 +7042,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -7213,7 +7213,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -7362,7 +7362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16399",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRatedAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7591,7 +7591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorLinearRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorLinearRatedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7824,7 +7824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRotaryRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRotaryRatedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8057,7 +8057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorStarterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16854",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorStarterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8091,7 +8091,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8190,7 +8190,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8255,7 +8255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputConverterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16818",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputConverterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8374,7 +8374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputFilterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16838",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputFilterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8491,7 +8491,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtPrechargeAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtPrechargeAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8724,7 +8724,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtReactorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtReactorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8812,7 +8812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtSoftStarterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtSoftStarterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8895,7 +8895,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8931,7 +8931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtTemperatureSensorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16708",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtTemperatureSensorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9118,7 +9118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtVibrationSensorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16747",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtVibrationSensorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9238,7 +9238,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -9279,7 +9279,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -9426,7 +9426,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -9469,7 +9469,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -9548,7 +9548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15912",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9662,7 +9662,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -9695,7 +9695,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -9718,7 +9718,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -9767,14 +9767,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1422",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "type": "array",
               "items": {
                 "title": "AssetVerificationModeEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -9785,7 +9785,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -9802,12 +9802,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1423",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9948,7 +9948,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10267,7 +10267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -10291,7 +10291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetBleedType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetBleedType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10353,7 +10353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetBrakeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15116",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetBrakeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10415,7 +10415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetCommunicationModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15430",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetCommunicationModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10484,7 +10484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetContactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15549",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetContactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10546,7 +10546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetControlModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15447",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetControlModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10622,7 +10622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetCoolingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15541",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetCoolingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10684,7 +10684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDcBusModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDcBusModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10753,7 +10753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10892,7 +10892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetFrequencyConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetFrequencyConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10947,7 +10947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetServoDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetServoDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11009,7 +11009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetVariableSpeedDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetVariableSpeedDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11071,7 +11071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetElectricalBrakingModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15148",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetElectricalBrakingModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11147,7 +11147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetElectricOverloadRelayType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetElectricOverloadRelayType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11216,7 +11216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderInterfaceModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderInterfaceModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11285,7 +11285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15108",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11361,7 +11361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11423,7 +11423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11485,7 +11485,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15122",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11561,7 +11561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15168",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11693,7 +11693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15196",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11769,7 +11769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputOutputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputOutputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11915,7 +11915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputReactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15241",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputReactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11984,7 +11984,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetIoModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15468",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetIoModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12053,7 +12053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorManagementDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorManagementDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12122,7 +12122,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorStarterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15561",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorStarterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12191,7 +12191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15083",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12274,7 +12274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12350,7 +12350,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12447,7 +12447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedGearMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedGearMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12509,7 +12509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12571,7 +12571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12647,7 +12647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12744,7 +12744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedGearMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedGearMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12806,7 +12806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12868,7 +12868,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15182",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13000,7 +13000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15303",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13076,7 +13076,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputReactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15368",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputReactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13145,7 +13145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetPrechargeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetPrechargeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13235,7 +13235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetReactorFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetReactorFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13304,7 +13304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetSafetyModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15527",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetSafetyModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13373,7 +13373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetSoftStarterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetSoftStarterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13442,7 +13442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetTemperatureSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15130",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetTemperatureSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13504,7 +13504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetVibrationSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15136",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetVibrationSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13566,7 +13566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineTagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineTagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13622,7 +13622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ITagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15048",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ITagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13679,7 +13679,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13705,7 +13705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -13726,7 +13726,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Pumps.TM.json
+++ b/wot-codegen/opc-output-integrated/Pumps.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_IPumpVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.IPumpVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -136,7 +136,7 @@
         "title": "PhysicalAddressDataType",
         "description": "Physical address of the manufacturer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PhysicalAddressDataType",
         "properties": {
           "Street": {
             "description": "Street name where the manufacturer is located.",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -312,7 +312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteInputObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteInputObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -377,7 +377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteOutputObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteOutputObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -517,7 +517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpKickObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -528,7 +528,7 @@
     "schemaDefinitions": {
       "PumpKickModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "Disabled": 1,
@@ -575,7 +575,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PumpKickModeEnum",
         "description": "This property describes the pump kick mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -654,7 +654,7 @@
         "data": {
           "title": "PumpKickModeEnum",
           "description": "This property describes the pump kick mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -713,7 +713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ActuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ActuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1013,7 +1013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpActuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpActuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1078,7 +1078,7 @@
     "schemaDefinitions": {
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "const": {
           "ConstantPressureControl": 0,
           "ConstantTemperatureControl": 1,
@@ -1147,7 +1147,7 @@
       },
       "OperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "const": {
           "AutoControl": 0,
           "ClosedLoopStandardPID": 1,
@@ -1234,7 +1234,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "This property describes the actual control mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1251,7 +1251,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperationModeEnum",
         "description": "This property describes the actual operation mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1335,7 +1335,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "This property describes the desired control mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1357,7 +1357,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperationModeEnum",
         "description": "This property describes the desired operation mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1382,7 +1382,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "This property describes the actual control mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1400,7 +1400,7 @@
         "data": {
           "title": "OperationModeEnum",
           "description": "This property describes the actual operation mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1474,7 +1474,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "This property describes the desired control mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1492,7 +1492,7 @@
         "data": {
           "title": "OperationModeEnum",
           "description": "This property describes the desired operation mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1517,7 +1517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_BreakdownMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.BreakdownMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1719,7 +1719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConditionBasedMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConditionBasedMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2274,7 +2274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConfigurationGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConfigurationGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2319,7 +2319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2372,7 +2372,7 @@
     "schemaDefinitions": {
       "DeclarationOfConformityOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
         "const": {
           "S2006_42_EC": 0,
           "S2009_125_EC": 1,
@@ -2421,7 +2421,7 @@
       },
       "ExplosionProtectionOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
         "const": {
           "M1": 0,
           "M2": 1,
@@ -2470,7 +2470,7 @@
       },
       "OfferedControlModesOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
         "const": {
           "Constant_pressure_control": 0,
           "Constant_temperature_control": 1,
@@ -2539,7 +2539,7 @@
       },
       "OfferedFieldbusesOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
         "const": {
           "Other": 0,
           "ARCNET": 1,
@@ -2798,7 +2798,7 @@
       },
       "DeviceTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
         "const": {
           "RotodynamicPump": 0,
           "PositiveDisplacementPump": 1,
@@ -3060,7 +3060,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DeclarationOfConformityOptionSet",
         "description": "Set of directives on the basis of which conformity was determined.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3094,7 +3094,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExplosionProtectionOptionSet",
         "description": "Device category for explosion protection according to 2014/34/EU (ATEX).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3570,7 +3570,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OfferedControlModesOptionSet",
         "description": "Control modes supported by the manufacturer for the product.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3587,7 +3587,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OfferedFieldbusesOptionSet",
         "description": "Fieldbuses supported by the manufacturer for the product.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3705,7 +3705,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DeviceTypeEnum",
         "description": "Pump type according to functional principle and pumped fluid",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5013,7 +5013,7 @@
         "data": {
           "title": "DeclarationOfConformityOptionSet",
           "description": "Set of directives on the basis of which conformity was determined.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5049,7 +5049,7 @@
         "data": {
           "title": "ExplosionProtectionOptionSet",
           "description": "Device category for explosion protection according to 2014/34/EU (ATEX).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5553,7 +5553,7 @@
         "data": {
           "title": "OfferedControlModesOptionSet",
           "description": "Control modes supported by the manufacturer for the product.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5571,7 +5571,7 @@
         "data": {
           "title": "OfferedFieldbusesOptionSet",
           "description": "Fieldbuses supported by the manufacturer for the product.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5696,7 +5696,7 @@
         "data": {
           "title": "DeviceTypeEnum",
           "description": "Pump type according to functional principle and pumped fluid",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6097,7 +6097,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7857,7 +7857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7868,7 +7868,7 @@
     "schemaDefinitions": {
       "ExplosionZoneOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
         "const": {
           "Zone_0": 0,
           "Zone_1": 1,
@@ -7907,7 +7907,7 @@
       },
       "FieldbusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
         "const": {
           "Other": 0,
           "ARCNET": 1,
@@ -8166,7 +8166,7 @@
       },
       "OperatingModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
         "const": {
           "SingleOperation": 0,
           "SeriesOperation": 1,
@@ -8190,7 +8190,7 @@
       },
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "const": {
           "ConstantPressureControl": 0,
           "ConstantTemperatureControl": 1,
@@ -8302,7 +8302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExplosionZoneOptionSet",
         "description": "Categories of explosion zones for devices according to 2014/34/EU (ATEX).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8324,7 +8324,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "FieldbusEnum",
         "description": "Selected fieldbus for the product",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8866,7 +8866,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperatingModeEnum",
         "description": "Specifies whether the pump is to be operated in single, parallel or series connection.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8954,7 +8954,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "Specifies which control mode is to be used for the use case.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9465,7 +9465,7 @@
         "data": {
           "title": "ExplosionZoneOptionSet",
           "description": "Categories of explosion zones for devices according to 2014/34/EU (ATEX).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9483,7 +9483,7 @@
         "data": {
           "title": "FieldbusEnum",
           "description": "Selected fieldbus for the product",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9925,7 +9925,7 @@
         "data": {
           "title": "OperatingModeEnum",
           "description": "Specifies whether the pump is to be operated in single, parallel or series connection.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9997,7 +9997,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "Specifies which control mode is to be used for the use case.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -10111,7 +10111,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10177,7 +10177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10592,7 +10592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10959,7 +10959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11035,7 +11035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11287,7 +11287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11539,7 +11539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12042,7 +12042,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DocumentationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DocumentationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12807,7 +12807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DriveDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DriveDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13370,7 +13370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DriveMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DriveMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14004,7 +14004,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_GeneralMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.GeneralMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14015,7 +14015,7 @@
     "schemaDefinitions": {
       "MaintenanceLevelEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
         "const": {
           "Level1": 0,
           "Level2": 1,
@@ -14049,7 +14049,7 @@
       },
       "StateOfTheItemEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
         "const": {
           "IdleState": 0,
           "StandByState": 1,
@@ -14186,7 +14186,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "MaintenanceLevelEnum",
         "description": "Maintenance task categorization by complexity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -14369,7 +14369,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "StateOfTheItemEnum",
         "description": "Current state of the item",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -14734,7 +14734,7 @@
         "data": {
           "title": "MaintenanceLevelEnum",
           "description": "Maintenance task categorization by complexity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -14928,7 +14928,7 @@
         "data": {
           "title": "StateOfTheItemEnum",
           "description": "Current state of the item",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15007,7 +15007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15140,7 +15140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionSystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionSystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15235,7 +15235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15372,7 +15372,7 @@
         "title": "PhysicalAddressDataType",
         "description": "Physical address of the manufacturer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PhysicalAddressDataType",
         "properties": {
           "Street": {
             "description": "Street name where the manufacturer is located.",
@@ -15447,7 +15447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MarkingsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MarkingsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15479,7 +15479,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MaintenanceGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15530,7 +15530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PreventiveMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PreventiveMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15848,7 +15848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18211,7 +18211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_VibrationMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.VibrationMeasurementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19794,7 +19794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MultiPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19805,7 +19805,7 @@
     "schemaDefinitions": {
       "DistributionTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "OperatorSpecific": 1,
@@ -19834,7 +19834,7 @@
       },
       "ExchangeModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "ExchangeDisabled": 1,
@@ -19858,7 +19858,7 @@
       },
       "MultiPumpOperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
         "const": {
           "Standalone": 0,
           "RedundancyOperation": 1,
@@ -19887,7 +19887,7 @@
       },
       "PumpRoleEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
         "const": {
           "Slave": 0,
           "Master": 1,
@@ -19955,7 +19955,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DistributionTypeEnum",
         "description": "This property describes the share of operation time of different pumps of the pump system in addition operation mode.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19977,7 +19977,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExchangeModeEnum",
         "description": "This property specifies the exchange mode of the pump",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20060,7 +20060,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "MultiPumpOperationModeEnum",
         "description": "This property specifies the actual multi pump operation mode. In redundant operation mode a pump fulfils the process function of another pump. Addition operation mode characterizes the supplementary fulfilling of the process function. The mixed mode characterizes both operation tasks.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20123,7 +20123,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PumpRoleEnum",
         "description": "This property identifies the role rsp. task of the pump within the multi pump management.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20198,7 +20198,7 @@
         "data": {
           "title": "DistributionTypeEnum",
           "description": "This property describes the share of operation time of different pumps of the pump system in addition operation mode.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20216,7 +20216,7 @@
         "data": {
           "title": "ExchangeModeEnum",
           "description": "This property specifies the exchange mode of the pump",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20283,7 +20283,7 @@
         "data": {
           "title": "MultiPumpOperationModeEnum",
           "description": "This property specifies the actual multi pump operation mode. In redundant operation mode a pump fulfils the process function of another pump. Addition operation mode characterizes the supplementary fulfilling of the process function. The mixed mode characterizes both operation tasks.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20334,7 +20334,7 @@
         "data": {
           "title": "PumpRoleEnum",
           "description": "This property identifies the role rsp. task of the pump within the multi pump management.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20375,7 +20375,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OperationalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20443,7 +20443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SignalsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SignalsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20596,7 +20596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20729,7 +20729,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionSystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionSystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20824,7 +20824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PortsGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PortsGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20868,7 +20868,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DrivePortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DrivePortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20906,7 +20906,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20917,7 +20917,7 @@
     "schemaDefinitions": {
       "PortDirectionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
         "const": {
           "In": 0,
           "Out": 1,
@@ -20982,7 +20982,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PortDirectionEnum",
         "description": "Ports with the direction “In” can only be connected to ports with the direction “Out” or “InOut” and ports with the direction “Out” can only be connected with ports with the direction “In” or “InOut”. Ports with the direction “InOut” can be connected to Ports of arbitrary direction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21039,7 +21039,7 @@
         "data": {
           "title": "PortDirectionEnum",
           "description": "Ports with the direction “In” can only be connected to ports with the direction “Out” or “InOut” and ports with the direction “Out” can only be connected with ports with the direction “In” or “InOut”. Ports with the direction “InOut” can be connected to Ports of arbitrary direction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21077,7 +21077,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21127,7 +21127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21177,7 +21177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionAuxiliaryDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionAuxiliaryDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22160,7 +22160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionElectronicsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionElectronicsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22738,7 +22738,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionHardwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionHardwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23100,7 +23100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionMechanicsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionMechanicsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23570,7 +23570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionProcessFluidType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionProcessFluidType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23959,7 +23959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionPumpOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionPumpOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24996,7 +24996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionSoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionSoftwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25250,7 +25250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25318,7 +25318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25387,7 +25387,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25433,7 +25433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineryItemVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineryItemVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25536,7 +25536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25618,7 +25618,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25870,7 +25870,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15035",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26077,7 +26077,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26148,7 +26148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26204,7 +26204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26226,7 +26226,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -26248,7 +26248,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -26270,7 +26270,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -26280,7 +26280,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -26302,7 +26302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -26395,7 +26395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26421,7 +26421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -26442,7 +26442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26468,7 +26468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26489,7 +26489,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -26510,7 +26510,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -26522,7 +26522,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -26543,7 +26543,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -26555,7 +26555,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -26576,7 +26576,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -26593,7 +26593,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -26613,7 +26613,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -26639,7 +26639,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {

--- a/wot-codegen/opc-output-integrated/RSL.TM.json
+++ b/wot-codegen/opc-output-integrated/RSL.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "RSL_SpatialObjectsListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/RSL/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.RSL.SpatialObjectsListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -153,7 +153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "RSL_SpatialObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/RSL/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.RSL.SpatialObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -335,7 +335,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Robotics.TM.json
+++ b/wot-codegen/opc-output-integrated/Robotics.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MultiAcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MultiAcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -67,7 +67,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_EmergencyStopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17230",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.EmergencyStopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -145,7 +145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_LoadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.LoadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -175,13 +175,13 @@
         "title": "ThreeDFrame",
         "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
         "required": [ "CartesianCoordinates", "Orientation" ],
         "properties": {
           "CartesianCoordinates": {
             "title": "ThreeDCartesianCoordinates",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
             "required": [ "X", "Y", "Z" ],
             "properties": {
               "X": {
@@ -204,7 +204,7 @@
           "Orientation": {
             "title": "ThreeDOrientation",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
             "required": [ "A", "B", "C" ],
             "properties": {
               "A": {
@@ -238,7 +238,7 @@
       "CenterOfMass_CartesianCoordinates": {
         "title": "ThreeDCartesianCoordinates",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -313,7 +313,7 @@
       "CenterOfMass_Orientation": {
         "title": "ThreeDOrientation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -390,7 +390,7 @@
         "title": "ThreeDVector",
         "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -484,13 +484,13 @@
           "title": "ThreeDFrame",
           "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
           "required": [ "CartesianCoordinates", "Orientation" ],
           "properties": {
             "CartesianCoordinates": {
               "title": "ThreeDCartesianCoordinates",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
               "required": [ "X", "Y", "Z" ],
               "properties": {
                 "X": {
@@ -513,7 +513,7 @@
             "Orientation": {
               "title": "ThreeDOrientation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
               "required": [ "A", "B", "C" ],
               "properties": {
                 "A": {
@@ -548,7 +548,7 @@
         "data": {
           "title": "ThreeDCartesianCoordinates",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -627,7 +627,7 @@
         "data": {
           "title": "ThreeDOrientation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -708,7 +708,7 @@
           "title": "ThreeDVector",
           "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -809,7 +809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ProtectiveStopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17233",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ProtectiveStopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -914,7 +914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ExecutingSubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ExecutingSubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1032,7 +1032,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_IdleSubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.IdleSubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1156,7 +1156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_OperationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.OperationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1242,7 +1242,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6023",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1265,7 +1265,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -1278,7 +1278,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1354,7 +1354,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -1435,7 +1435,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -1471,7 +1471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SystemOperationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SystemOperationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1569,7 +1569,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1592,7 +1592,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1615,7 +1615,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1638,7 +1638,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -1651,7 +1651,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1727,7 +1727,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -1808,7 +1808,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -1844,7 +1844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1936,7 +1936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6143",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -1947,7 +1947,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1970,7 +1970,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1981,7 +1981,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6142",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2004,7 +2004,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2027,7 +2027,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -2040,7 +2040,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6103",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2063,7 +2063,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -2073,7 +2073,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2095,7 +2095,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6146",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2106,7 +2106,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6147",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2129,7 +2129,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2205,7 +2205,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -2286,7 +2286,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -2322,7 +2322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ReadySubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ReadySubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2378,7 +2378,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2469,7 +2469,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SystemOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SystemOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2535,7 +2535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2610,7 +2610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2699,7 +2699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_AuxiliaryComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17725",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.AuxiliaryComponentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2758,7 +2758,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_AxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16601",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2788,7 +2788,7 @@
     "schemaDefinitions": {
       "AxisMotionProfileEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "const": {
           "OTHER": 0,
           "ROTARY": 1,
@@ -2846,7 +2846,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "AxisMotionProfileEnumeration",
         "description": "The kind of axis motion as defined with the AxisMotionProfileEnumeration.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2872,7 +2872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_PowerTrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16794",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.PowerTrainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2943,7 +2943,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_GearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.GearType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2985,7 +2985,7 @@
         "title": "RationalNumber",
         "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+        "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
         "required": [ "Numerator", "Denominator" ],
         "properties": {
           "Numerator": {
@@ -3108,7 +3108,7 @@
           "title": "RationalNumber",
           "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+          "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
           "required": [ "Numerator", "Denominator" ],
           "properties": {
             "Numerator": {
@@ -3189,7 +3189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3295,7 +3295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3462,7 +3462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3503,7 +3503,7 @@
     "schemaDefinitions": {
       "MotionDeviceCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "ARTICULATED_ROBOT": 1,
@@ -3624,7 +3624,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "MotionDeviceCategoryEnumeration",
         "description": "The variable MotionDeviceCategory provides the kind of motion device defined by MotionDeviceCategoryEnumeration based on ISO 8373.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3699,7 +3699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SafetyStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SafetyStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3762,7 +3762,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18175",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.UserType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3821,7 +3821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17793",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.DriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3880,7 +3880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3944,7 +3944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4009,7 +4009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4036,7 +4036,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4061,7 +4061,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4167,7 +4167,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4194,7 +4194,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4219,7 +4219,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4241,7 +4241,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4500,7 +4500,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4596,7 +4596,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4700,7 +4700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4721,7 +4721,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4863,7 +4863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4948,7 +4948,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4974,7 +4974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5020,7 +5020,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5066,7 +5066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5092,7 +5092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5106,7 +5106,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -5116,7 +5116,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -5135,7 +5135,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -5148,7 +5148,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -5172,7 +5172,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -5191,7 +5191,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -5210,7 +5210,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -5241,7 +5241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5444,7 +5444,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5500,7 +5500,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5571,7 +5571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5593,7 +5593,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -5615,7 +5615,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -5637,7 +5637,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -5647,7 +5647,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -5669,7 +5669,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {

--- a/wot-codegen/opc-output-integrated/Safety.TM.json
+++ b/wot-codegen/opc-output-integrated/Safety.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyConsumerParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyConsumerParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyObjectsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyObjectsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyConsumerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyConsumerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyProviderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyProviderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -114,7 +114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyPDUsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyPDUsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -140,7 +140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyProviderParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyProviderParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -166,7 +166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/Scales.V2.TM.json
+++ b/wot-codegen/opc-output-integrated/Scales.V2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -358,7 +358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=35",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_MaterialAutomaticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.MaterialAutomaticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -498,7 +498,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticFillingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=16",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticFillingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -821,7 +821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1058,7 +1058,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_StatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=25",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.StatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1148,7 +1148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1255,7 +1255,7 @@
         "title": "WeightType",
         "description": "Defines the registered weight that may be unmistakeable referenced to one item.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -1373,7 +1373,7 @@
           "title": "WeightType",
           "description": "Defines the registered weight that may be unmistakeable referenced to one item.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -1426,7 +1426,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_StatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.StatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1482,7 +1482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ProductionPresetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ProductionPresetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1521,7 +1521,7 @@
         "description": "Creates an object with the JobType from the address space.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=246",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductName", "ProductId", "ProductType" ],
           "properties": {
             "ProductName": {
@@ -1537,7 +1537,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=177",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductNodeId" ],
           "properties": {
             "ProductNodeId": {
@@ -1557,7 +1557,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -1578,7 +1578,7 @@
         "description": "Removes an object with the JobType from the address space.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=647",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -1598,7 +1598,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -1618,7 +1618,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=988",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -1685,7 +1685,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CatchweigherProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=17",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CatchweigherProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1730,7 +1730,7 @@
         "description": "Adds a zone to the zone array.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=145",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ZoneName", "LowerLimit", "UpperLimit", "EngineeringUnits" ],
           "properties": {
             "ZoneName": {
@@ -1749,7 +1749,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1772,7 +1772,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=146",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ZoneNodeId" ],
           "properties": {
             "ZoneNodeId": {
@@ -1793,7 +1793,7 @@
         "description": "Removes a zone from the zone array.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=147",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ZoneNodeId" ],
           "properties": {
             "ZoneNodeId": {
@@ -1950,7 +1950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2095,7 +2095,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticWeightPriceLabelerProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=47",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticWeightPriceLabelerProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2176,7 +2176,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PriceItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=833",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PriceItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2251,7 +2251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=46",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2392,7 +2392,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=48",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherStatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2509,7 +2509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AcceptedStatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AcceptedStatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2535,7 +2535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RejectedStatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RejectedStatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2561,7 +2561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ContinuousProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=18",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ContinuousProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2700,7 +2700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PieceCountingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PieceCountingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2733,7 +2733,7 @@
         "description": "Set the number of TargetItemCount.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=398",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetItemCount" ],
           "properties": {
             "TargetItemCount": {
@@ -2756,7 +2756,7 @@
         "description": "Sets the value of TargetPieceCount. See TargetPieceCount.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetPieceCount", "PlusTolerance", "MinusTolerance" ],
           "properties": {
             "TargetPieceCount": {
@@ -3071,7 +3071,7 @@
         "title": "WeightType",
         "description": "Defines the summed up number of weight. Will be reset either triggered by the user or a different product selection.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3332,7 +3332,7 @@
           "title": "WeightType",
           "description": "Defines the summed up number of weight. Will be reset either triggered by the user or a different product selection.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -3371,7 +3371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=19",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3432,7 +3432,7 @@
         "items": {
           "title": "RecipeReportElementType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeReportElementType",
           "required": [ "ReportMessage", "Timestamp" ],
           "properties": {
             "ReportMessage": {
@@ -3482,7 +3482,7 @@
           "items": {
             "title": "RecipeReportElementType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=59",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeReportElementType",
             "required": [ "ReportMessage", "Timestamp" ],
             "properties": {
               "ReportMessage": {
@@ -3514,7 +3514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_SimpleProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.SimpleProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3604,7 +3604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizingHopperProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizingHopperProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3713,7 +3713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_VehicleProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=832",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.VehicleProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3751,7 +3751,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1208",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -3824,7 +3824,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3929,7 +3929,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3983,7 +3983,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -4089,7 +4089,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -4164,7 +4164,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -4197,7 +4197,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -4230,7 +4230,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -4269,7 +4269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4295,7 +4295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ActivationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ActivationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4406,7 +4406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ConditionSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ConditionSleepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4579,7 +4579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AnalogConditionSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AnalogConditionSleepType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4591,7 +4591,7 @@
     "schemaDefinitions": {
       "EqualityAndRelationalOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=61",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EqualityAndRelationalOperator",
         "const": {
           "Equal_0": 0,
           "NotEqual_1": 1,
@@ -4647,7 +4647,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "EqualityAndRelationalOperator",
         "description": "Defines the type of condition operator that is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=61",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EqualityAndRelationalOperator",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4710,7 +4710,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_EdgeTriggeredSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=39",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeTriggeredSleepType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4722,7 +4722,7 @@
     "schemaDefinitions": {
       "EdgeOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeOperator",
         "const": {
           "Rising_0": 0,
           "Falling_1": 1
@@ -4761,7 +4761,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "EdgeOperator",
         "description": "Defines the type of condition operator that is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeOperator",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4824,7 +4824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TimerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=36",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TimerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4902,7 +4902,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_UserInstructionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=33",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.UserInstructionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5012,7 +5012,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5126,7 +5126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5148,7 +5148,7 @@
         "description": "Method to add an additional recipe of RecipeType.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=181",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId", "RecipeName" ],
           "properties": {
             "RecipeId": {
@@ -5161,7 +5161,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=182",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -5182,7 +5182,7 @@
         "description": "Method to remove a recipe of RecipeType.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -5213,7 +5213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5252,7 +5252,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=437",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ElementType", "ElementName", "PreviousElements" ],
           "properties": {
             "ElementType": {
@@ -5271,7 +5271,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=438",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ElementNodeId" ],
           "properties": {
             "ElementNodeId": {
@@ -5291,7 +5291,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=439",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeElementNodeId" ],
           "properties": {
             "RecipeElementNodeId": {
@@ -5358,7 +5358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_FloatingStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.FloatingStatisticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5416,7 +5416,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_FeederModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.FeederModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5450,7 +5450,7 @@
         "description": "Allows to set a new value for the speed of the feeder system. The OPC UA server must check if the value is between the minimal and maximum allowed speed and if the unit is allowed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=337",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FeederSpeed", "EngineeringUnits" ],
           "properties": {
             "FeederSpeed": {
@@ -5461,7 +5461,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -5626,7 +5626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PrinterModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=29",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PrinterModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5805,7 +5805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5893,7 +5893,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1353",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PresetTare", "EngineeringUnits" ],
           "properties": {
             "PresetTare": {
@@ -5904,7 +5904,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -5961,7 +5961,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -5999,7 +5999,7 @@
         "title": "WeightType",
         "description": "Defines the current value that is measured at the sensor at the current timestamp. Might be a highly fluctuating value.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -6128,7 +6128,7 @@
         "title": "WeightType",
         "description": "Defines the last valid measurement that was recorded and will be used for further processing. This is the legal registered value of the scale.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -6169,7 +6169,7 @@
           "title": "WeightType",
           "description": "Defines the current value that is measured at the sensor at the current timestamp. Might be a highly fluctuating value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -6216,7 +6216,7 @@
           "title": "WeightType",
           "description": "Defines the last valid measurement that was recorded and will be used for further processing. This is the legal registered value of the scale.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -6255,7 +6255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingRangeElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingRangeElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6310,7 +6310,7 @@
         "title": "Range",
         "description": "Defines the range within the scale may be operated depending on the additional parameters within this type.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -6382,7 +6382,7 @@
           "title": "Range",
           "description": "Defines the range within the scale may be operated depending on the additional parameters within this type.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -6432,7 +6432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticFillingScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticFillingScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6450,7 +6450,7 @@
     "schemaDefinitions": {
       "ToleranceState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=60",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ToleranceState",
         "const": {
           "In_0": 0,
           "Under_1": 1,
@@ -6515,7 +6515,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "ToleranceState",
         "description": "Describes the state of the tolerance deviation. The option under and over needs to be determined via TargetItemType information of TargetWeight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=60",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ToleranceState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6560,7 +6560,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CatchweigherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CatchweigherType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6593,7 +6593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticWeightPriceLabelerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticWeightPriceLabelerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6626,7 +6626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=45",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6708,7 +6708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ContinuousScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ContinuousScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6738,7 +6738,7 @@
     "schemaDefinitions": {
       "RateControlMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
         "const": {
           "Gravimetric_0": 0,
           "Volumetric_1": 1
@@ -6864,7 +6864,7 @@
       "RateControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "RateControlMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6990,7 +6990,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "data": {
           "title": "RateControlMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7040,7 +7040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7116,7 +7116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_LossInWeightScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.LossInWeightScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7333,7 +7333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PieceCountingScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PieceCountingScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7372,7 +7372,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=990",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NumberOfReferencePieces" ],
           "properties": {
             "NumberOfReferencePieces": {
@@ -7395,7 +7395,7 @@
         "description": "Sets the value for the ReferencePieceWeight (product-specific data).",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=604",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReferencePieceWeight", "EngineeringUnits" ],
           "properties": {
             "ReferencePieceWeight": {
@@ -7406,7 +7406,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -7440,7 +7440,7 @@
         "description": "Triggers the reference weighing process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1013",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NumberOfReferencePieces" ],
           "properties": {
             "NumberOfReferencePieces": {
@@ -7537,7 +7537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7588,7 +7588,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1017",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -7608,7 +7608,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1015",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -7628,7 +7628,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1016",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -7648,7 +7648,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=373",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -7668,7 +7668,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1014",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -7693,7 +7693,7 @@
         "items": {
           "title": "RecipeTargetValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=58",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeTargetValueType",
           "required": [ "TargetValueId", "TargetValueName" ],
           "properties": {
             "TargetValueId": {
@@ -7730,7 +7730,7 @@
         "items": {
           "title": "RecipeThresholdType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=57",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeThresholdType",
           "required": [ "ThresholdId", "ThresholdName" ],
           "properties": {
             "ThresholdId": {
@@ -7770,7 +7770,7 @@
           "items": {
             "title": "RecipeTargetValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=58",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeTargetValueType",
             "required": [ "TargetValueId", "TargetValueName" ],
             "properties": {
               "TargetValueId": {
@@ -7803,7 +7803,7 @@
           "items": {
             "title": "RecipeThresholdType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=57",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeThresholdType",
             "required": [ "ThresholdId", "ThresholdName" ],
             "properties": {
               "ThresholdId": {
@@ -7839,7 +7839,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_SimpleScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.SimpleScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7872,7 +7872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_HopperScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.HopperScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8035,7 +8035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_LaboratoryScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.LaboratoryScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8047,7 +8047,7 @@
     "schemaDefinitions": {
       "DraftShieldType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
         "const": {
           "Right_0": 0,
           "Left_1": 1,
@@ -8088,12 +8088,12 @@
         "description": "Method to close a certain or all draft shields.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=762",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Shield" ],
           "properties": {
             "Shield": {
               "title": "DraftShieldType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+              "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8113,12 +8113,12 @@
         "description": "Method to open a certain or all draft shields.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Shield" ],
           "properties": {
             "Shield": {
               "title": "DraftShieldType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+              "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8317,7 +8317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8343,7 +8343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizingHopperScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizingHopperScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8376,7 +8376,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_VehicleScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=834",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.VehicleScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8398,7 +8398,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=946",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -8418,7 +8418,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=949",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -8438,7 +8438,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=947",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -8469,7 +8469,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8600,7 +8600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -8639,7 +8639,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -8670,7 +8670,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8698,7 +8698,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8726,7 +8726,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8763,7 +8763,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -8791,7 +8791,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -9116,7 +9116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9143,7 +9143,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9168,7 +9168,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9274,7 +9274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9301,7 +9301,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -9326,7 +9326,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -9348,7 +9348,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -9607,7 +9607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9703,7 +9703,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -9807,7 +9807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -9828,7 +9828,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9912,7 +9912,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -9931,7 +9931,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -9951,7 +9951,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -9983,7 +9983,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -10026,7 +10026,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10168,7 +10168,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10253,7 +10253,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10299,7 +10299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10345,7 +10345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10371,7 +10371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10397,7 +10397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10418,7 +10418,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -10439,7 +10439,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -10451,7 +10451,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -10472,7 +10472,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -10484,7 +10484,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -10505,7 +10505,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -10522,7 +10522,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -10542,7 +10542,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -10568,7 +10568,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -10689,7 +10689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10711,7 +10711,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -10733,7 +10733,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -10755,7 +10755,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -10765,7 +10765,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -10787,7 +10787,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -10880,7 +10880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11083,7 +11083,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11139,7 +11139,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11210,7 +11210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfigurableObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfigurableObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11249,7 +11249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11407,7 +11407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11577,7 +11577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11810,7 +11810,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=342",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -11819,7 +11819,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -11836,7 +11836,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {

--- a/wot-codegen/opc-output-integrated/Scheduler.TM.json
+++ b/wot-codegen/opc-output-integrated/Scheduler.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scheduler_CalendarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "Month": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
         "const": {
           "Unspecified": 0,
           "January": 1,
@@ -89,7 +89,7 @@
       },
       "DayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
         "const": {
           "Unspecified": 0,
           "Day1": 1,
@@ -238,7 +238,7 @@
       },
       "DayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
         "const": {
           "Unspecified": 0,
           "Monday": 1,
@@ -296,7 +296,7 @@
         "description": "Adds elements to the DateList",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=41",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -305,13 +305,13 @@
                 "title": "CalendarEntryType",
                 "description": "This union that defines various calendar date values",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                 "properties": {
                   "Date": {
                     "title": "DateType",
                     "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -321,21 +321,21 @@
                       },
                       "Month": {
                         "title": "Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "DayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "DayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -346,14 +346,14 @@
                     "title": "DateRangeType",
                     "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                     "required": [ "StartDate", "EndDate" ],
                     "properties": {
                       "StartDate": {
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -363,21 +363,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -388,7 +388,7 @@
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -398,21 +398,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -428,7 +428,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=42",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -454,7 +454,7 @@
         "description": "Removes elements of the DateList",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=44",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -463,13 +463,13 @@
                 "title": "CalendarEntryType",
                 "description": "This union that defines various calendar date values",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                 "properties": {
                   "Date": {
                     "title": "DateType",
                     "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -479,21 +479,21 @@
                       },
                       "Month": {
                         "title": "Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "DayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "DayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -504,14 +504,14 @@
                     "title": "DateRangeType",
                     "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                     "required": [ "StartDate", "EndDate" ],
                     "properties": {
                       "StartDate": {
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -521,21 +521,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -546,7 +546,7 @@
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -556,21 +556,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -586,7 +586,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=45",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -617,13 +617,13 @@
           "title": "CalendarEntryType",
           "description": "This union that defines various calendar date values",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
           "properties": {
             "Date": {
               "title": "DateType",
               "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
               "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
               "properties": {
                 "Year": {
@@ -633,21 +633,21 @@
                 },
                 "Month": {
                   "title": "Month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfMonth": {
                   "title": "DayOfMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfWeek": {
                   "title": "DayOfWeek",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -658,14 +658,14 @@
               "title": "DateRangeType",
               "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
               "required": [ "StartDate", "EndDate" ],
               "properties": {
                 "StartDate": {
                   "title": "DateType",
                   "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -675,21 +675,21 @@
                     },
                     "Month": {
                       "title": "Month",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "DayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "DayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -700,7 +700,7 @@
                   "title": "DateType",
                   "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -710,21 +710,21 @@
                     },
                     "Month": {
                       "title": "Month",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "DayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "DayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -784,7 +784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scheduler_ScheduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.Scheduler.ScheduleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -796,7 +796,7 @@
     "schemaDefinitions": {
       "Month": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
         "const": {
           "Unspecified": 0,
           "January": 1,
@@ -865,7 +865,7 @@
       },
       "DayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
         "const": {
           "Unspecified": 0,
           "Day1": 1,
@@ -1014,7 +1014,7 @@
       },
       "DayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
         "const": {
           "Unspecified": 0,
           "Monday": 1,
@@ -1067,7 +1067,7 @@
         "description": "Adds elements to the ExceptionSchedule",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecialEvents" ],
           "properties": {
             "SpecialEvents": {
@@ -1076,26 +1076,26 @@
                 "title": "SpecialEventType",
                 "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
                 "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
                 "properties": {
                   "Period": {
                     "title": "SpecialEventPeriodType",
                     "description": "This union contains a calendar entry or a reference to a calendar object",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
                     "properties": {
                       "CalendarEntry": {
                         "title": "CalendarEntryType",
                         "description": "This union that defines various calendar date values",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                         "properties": {
                           "Date": {
                             "title": "DateType",
                             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -1105,21 +1105,21 @@
                               },
                               "Month": {
                                 "title": "Month",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "DayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "DayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -1130,14 +1130,14 @@
                             "title": "DateRangeType",
                             "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                             "required": [ "StartDate", "EndDate" ],
                             "properties": {
                               "StartDate": {
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1147,21 +1147,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1172,7 +1172,7 @@
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1182,21 +1182,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1218,14 +1218,14 @@
                       "title": "TimeActionsType",
                       "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                       "required": [ "Time", "Actions" ],
                       "properties": {
                         "Time": {
                           "title": "TimeType",
                           "description": "This structure that represents a point in time during a day",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                           "required": [ "Hour", "Minute", "Second" ],
                           "properties": {
                             "Hour": {
@@ -1251,7 +1251,7 @@
                             "title": "BaseActionType",
                             "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                             "required": [ "LastActionResult" ],
                             "properties": {
                               "LastActionResult": {
@@ -1275,7 +1275,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=56",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -1301,7 +1301,7 @@
         "description": "Removes elements from the ExceptionSchedule",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=58",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecialEvents" ],
           "properties": {
             "SpecialEvents": {
@@ -1310,26 +1310,26 @@
                 "title": "SpecialEventType",
                 "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
                 "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
                 "properties": {
                   "Period": {
                     "title": "SpecialEventPeriodType",
                     "description": "This union contains a calendar entry or a reference to a calendar object",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
                     "properties": {
                       "CalendarEntry": {
                         "title": "CalendarEntryType",
                         "description": "This union that defines various calendar date values",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                         "properties": {
                           "Date": {
                             "title": "DateType",
                             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -1339,21 +1339,21 @@
                               },
                               "Month": {
                                 "title": "Month",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "DayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "DayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -1364,14 +1364,14 @@
                             "title": "DateRangeType",
                             "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                             "required": [ "StartDate", "EndDate" ],
                             "properties": {
                               "StartDate": {
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1381,21 +1381,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1406,7 +1406,7 @@
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1416,21 +1416,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1452,14 +1452,14 @@
                       "title": "TimeActionsType",
                       "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                       "required": [ "Time", "Actions" ],
                       "properties": {
                         "Time": {
                           "title": "TimeType",
                           "description": "This structure that represents a point in time during a day",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                           "required": [ "Hour", "Minute", "Second" ],
                           "properties": {
                             "Hour": {
@@ -1485,7 +1485,7 @@
                             "title": "BaseActionType",
                             "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                             "required": [ "LastActionResult" ],
                             "properties": {
                               "LastActionResult": {
@@ -1509,7 +1509,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -1550,14 +1550,14 @@
         "title": "DateRangeType",
         "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
         "required": [ "StartDate", "EndDate" ],
         "properties": {
           "StartDate": {
             "title": "DateType",
             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -1567,21 +1567,21 @@
               },
               "Month": {
                 "title": "Month",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "DayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "DayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1592,7 +1592,7 @@
             "title": "DateType",
             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -1602,21 +1602,21 @@
               },
               "Month": {
                 "title": "Month",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "DayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "DayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1641,26 +1641,26 @@
           "title": "SpecialEventType",
           "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
           "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
           "properties": {
             "Period": {
               "title": "SpecialEventPeriodType",
               "description": "This union contains a calendar entry or a reference to a calendar object",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
               "properties": {
                 "CalendarEntry": {
                   "title": "CalendarEntryType",
                   "description": "This union that defines various calendar date values",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                   "properties": {
                     "Date": {
                       "title": "DateType",
                       "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                       "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                       "properties": {
                         "Year": {
@@ -1670,21 +1670,21 @@
                         },
                         "Month": {
                           "title": "Month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfMonth": {
                           "title": "DayOfMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfWeek": {
                           "title": "DayOfWeek",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -1695,14 +1695,14 @@
                       "title": "DateRangeType",
                       "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                       "required": [ "StartDate", "EndDate" ],
                       "properties": {
                         "StartDate": {
                           "title": "DateType",
                           "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -1712,21 +1712,21 @@
                             },
                             "Month": {
                               "title": "Month",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "DayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "DayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -1737,7 +1737,7 @@
                           "title": "DateType",
                           "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -1747,21 +1747,21 @@
                             },
                             "Month": {
                               "title": "Month",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "DayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "DayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -1783,14 +1783,14 @@
                 "title": "TimeActionsType",
                 "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                 "required": [ "Time", "Actions" ],
                 "properties": {
                   "Time": {
                     "title": "TimeType",
                     "description": "This structure that represents a point in time during a day",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                     "required": [ "Hour", "Minute", "Second" ],
                     "properties": {
                       "Hour": {
@@ -1816,7 +1816,7 @@
                       "title": "BaseActionType",
                       "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                       "required": [ "LastActionResult" ],
                       "properties": {
                         "LastActionResult": {
@@ -1848,7 +1848,7 @@
         "title": "TimeZoneDataType",
         "description": "Provides information about the local time of the schedule Object. All scheduled times are UTC time. Clients need to consider this Property to calculate the local time of the schedule. If this Property is changed, it is server-specific whether the times of the schedule are adjusted or not.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -1877,7 +1877,7 @@
           "title": "DailyScheduleType",
           "description": "This structure defines a sequence of TimeActionsType structures. Each element in the sequence defines a time/actions pair that describes the actions to be executed at a given point in the day.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=86",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DailyScheduleType",
           "required": [ "DaySchedule" ],
           "properties": {
             "DaySchedule": {
@@ -1886,14 +1886,14 @@
                 "title": "TimeActionsType",
                 "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                 "required": [ "Time", "Actions" ],
                 "properties": {
                   "Time": {
                     "title": "TimeType",
                     "description": "This structure that represents a point in time during a day",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                     "required": [ "Hour", "Minute", "Second" ],
                     "properties": {
                       "Hour": {
@@ -1919,7 +1919,7 @@
                       "title": "BaseActionType",
                       "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                       "required": [ "LastActionResult" ],
                       "properties": {
                         "LastActionResult": {
@@ -1955,7 +1955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {

--- a/wot-codegen/opc-output-integrated/SurfaceTechnology.Plasma.TM.json
+++ b/wot-codegen/opc-output-integrated/SurfaceTechnology.Plasma.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_CirculationSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.CirculationSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -104,7 +104,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_GasSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.GasSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -142,7 +142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_HeatingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.HeatingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -180,7 +180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlantCoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlantCoolingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -218,7 +218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaGeneratorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaGeneratorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaJetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaJetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -294,7 +294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -333,7 +333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -366,7 +366,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -399,7 +399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PrecursorSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PrecursorSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -437,7 +437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_ProcessingChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.ProcessingChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -475,7 +475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_RegulatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.RegulatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -808,7 +808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaNotExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaNotExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -887,7 +887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaNotExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaNotExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -966,7 +966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -998,7 +998,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1030,7 +1030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_WorkpieceMotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.WorkpieceMotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1068,7 +1068,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -1089,7 +1089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1115,7 +1115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1257,7 +1257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1342,7 +1342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1388,7 +1388,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1434,7 +1434,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1504,7 +1504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/TMC.v2.TM.json
+++ b/wot-codegen/opc-output-integrated/TMC.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ExternalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ExternalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37,7 +37,7 @@
         "description": "The Method SetMessage sets the Message that the underlying system will display for the alarm.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10316",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Message" ],
           "properties": {
             "Message": {
@@ -48,14 +48,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10317",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -69,7 +69,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -128,7 +128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierEnteredLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1085",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierEnteredLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -202,7 +202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierReleasedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierReleasedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -249,7 +249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierSublotsChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierSublotsChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -261,7 +261,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -315,7 +315,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -330,7 +330,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -349,7 +349,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -368,7 +368,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -412,7 +412,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -435,7 +435,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -457,7 +457,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1089",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -608,7 +608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -620,7 +620,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -687,7 +687,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The control mode after the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -704,7 +704,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The control mode prior to the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSpecificationChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSpecificationChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -742,7 +742,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -771,7 +771,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -812,7 +812,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -830,7 +830,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -849,7 +849,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -893,7 +893,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -941,7 +941,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -959,7 +959,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -978,7 +978,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1022,7 +1022,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1070,7 +1070,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1088,7 +1088,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1107,7 +1107,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1151,7 +1151,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1199,7 +1199,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -1210,7 +1210,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -1229,7 +1229,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1273,7 +1273,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -1297,7 +1297,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1325,7 +1325,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1333,7 +1333,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1371,7 +1371,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1389,7 +1389,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1408,7 +1408,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1452,7 +1452,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1500,7 +1500,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1518,7 +1518,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1537,7 +1537,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1581,7 +1581,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1629,7 +1629,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1647,7 +1647,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1666,7 +1666,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1710,7 +1710,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1758,7 +1758,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -1769,7 +1769,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -1788,7 +1788,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1832,7 +1832,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -1856,7 +1856,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1884,7 +1884,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1892,7 +1892,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1921,7 +1921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1983,7 +1983,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DataSetChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2012,7 +2012,7 @@
           "title": "DataSetEntryType",
           "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
           "required": [ "ID", "Value" ],
           "properties": {
             "ID": {
@@ -2055,7 +2055,7 @@
           "title": "DataSetEntryType",
           "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
           "required": [ "ID", "Value" ],
           "properties": {
             "ID": {
@@ -2103,7 +2103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectDetectedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectDetectedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2131,7 +2131,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -2204,7 +2204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DetectionModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DetectionModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2251,7 +2251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DowntimeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DowntimeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2294,7 +2294,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -2320,7 +2320,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -2355,7 +2355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1086",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2415,7 +2415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_IntegrityRejectedMaterialLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.IntegrityRejectedMaterialLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2427,7 +2427,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -2465,7 +2465,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -2480,7 +2480,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -2499,7 +2499,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -2518,7 +2518,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2562,7 +2562,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -2585,7 +2585,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2607,7 +2607,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -2680,7 +2680,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_LoadingPointUnloadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.LoadingPointUnloadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2692,7 +2692,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -2730,7 +2730,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -2745,7 +2745,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -2764,7 +2764,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -2783,7 +2783,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2827,7 +2827,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -2850,7 +2850,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2872,7 +2872,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -2945,7 +2945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialConsumedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialConsumedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3116,7 +3116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialDispensedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDispensedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3287,7 +3287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialOutputProducedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialOutputProducedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3458,7 +3458,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialRejectedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialRejectedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3629,7 +3629,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialUnloadingRequiredLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialUnloadingRequiredLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3641,7 +3641,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -3679,7 +3679,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -3694,7 +3694,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -3713,7 +3713,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -3732,7 +3732,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3776,7 +3776,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -3799,7 +3799,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -3821,7 +3821,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -3894,7 +3894,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_NewPresentedMaterialLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.NewPresentedMaterialLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3906,7 +3906,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -3944,7 +3944,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -3959,7 +3959,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -3978,7 +3978,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -3997,7 +3997,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -4041,7 +4041,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -4064,7 +4064,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4086,7 +4086,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -4159,7 +4159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_POStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1091",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.POStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4186,7 +4186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_POStoppedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1092",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.POStoppedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4213,7 +4213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessItemResetLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessItemResetLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4467,7 +4467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RejectionModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RejectionModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4514,7 +4514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_StateChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4526,7 +4526,7 @@
     "schemaDefinitions": {
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -4633,7 +4633,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state after the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4650,7 +4650,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state prior to the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4676,7 +4676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RootCauseGroupListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4705,7 +4705,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -4739,7 +4739,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -4778,7 +4778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RootCauseListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4807,7 +4807,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -4833,7 +4833,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -4864,7 +4864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_StopReasonListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StopReasonListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4893,7 +4893,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -4923,7 +4923,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -4958,7 +4958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5018,7 +5018,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadingEndedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadingEndedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5065,7 +5065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadingStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1080",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadingStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5112,7 +5112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5172,7 +5172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadingEndedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1082",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadingEndedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5219,7 +5219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadingStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1083",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadingStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5266,7 +5266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderTransitionLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1088",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderTransitionLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5326,7 +5326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1074",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5349,7 +5349,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -5395,14 +5395,14 @@
         "description": "The EndSubCarrierLoading Method informs the underlying system that the loading of (sub) carriers into   the carrier is complete.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13434",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5416,7 +5416,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5447,14 +5447,14 @@
         "description": "The EndSubCarrierUnloading Method informs the underlying system that the unloading of (sub) carriers   into the carrier is complete.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13436",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5468,7 +5468,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5499,7 +5499,7 @@
         "description": "The LoadSubCarrier Method requests the underlying system to load a subcarrier into the carrier that is   currently being loaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13439",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ID", "MESID", "ParentCarrierID", "Sublots" ],
           "properties": {
             "ID": {
@@ -5521,7 +5521,7 @@
                 "title": "MaterialSublotType",
                 "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                 "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                 "properties": {
                   "ID": {
@@ -5536,7 +5536,7 @@
                     "title": "MaterialLotType",
                     "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                     "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                     "properties": {
                       "ID": {
@@ -5555,7 +5555,7 @@
                         "title": "MaterialDefinitionType",
                         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                         "properties": {
                           "ID": {
@@ -5574,7 +5574,7 @@
                             "title": "EUInformation",
                             "description": "The base unit of measure for the material definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5618,7 +5618,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -5641,7 +5641,7 @@
                       "Status": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The stock status of the material lot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -5663,7 +5663,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -5720,14 +5720,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13440",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5741,7 +5741,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5772,7 +5772,7 @@
         "description": "The LoadSublot Method requests the underlying system to load one or more material sublots into the   carrier that is currently being loaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Sublots" ],
           "properties": {
             "Sublots": {
@@ -5782,7 +5782,7 @@
                 "title": "MaterialSublotType",
                 "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                 "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                 "properties": {
                   "ID": {
@@ -5797,7 +5797,7 @@
                     "title": "MaterialLotType",
                     "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                     "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                     "properties": {
                       "ID": {
@@ -5816,7 +5816,7 @@
                         "title": "MaterialDefinitionType",
                         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                         "properties": {
                           "ID": {
@@ -5835,7 +5835,7 @@
                             "title": "EUInformation",
                             "description": "The base unit of measure for the material definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5879,7 +5879,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -5902,7 +5902,7 @@
                       "Status": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The stock status of the material lot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -5924,7 +5924,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -5981,14 +5981,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9213",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6002,7 +6002,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6033,14 +6033,14 @@
         "description": "The StartSubCarrierLoading Method informs the underlying system that the loading of (sub) carriers into   the carrier has started.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13443",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6054,7 +6054,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6085,14 +6085,14 @@
         "description": "The StartSubCarrierUnLoading Method informs the underlying system that the unloading of (sub)   carriers from the carrier has started.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13445",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6106,7 +6106,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6137,7 +6137,7 @@
         "description": "The UnloadSubCarrier Method requests the underlying system to unload a subcarrier from the carrier   that is currently being unloaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -6148,14 +6148,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13449",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6169,7 +6169,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6200,7 +6200,7 @@
         "description": "The UnloadSublots Method requests the underlying system to unload one or more sublots from the   carrier that is currently being unloaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10821",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SublotIDs" ],
           "properties": {
             "SublotIDs": {
@@ -6214,14 +6214,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10822",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6235,7 +6235,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6328,7 +6328,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -6343,7 +6343,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -6362,7 +6362,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -6381,7 +6381,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -6425,7 +6425,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -6448,7 +6448,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -6470,7 +6470,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -6542,7 +6542,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -6557,7 +6557,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -6576,7 +6576,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -6595,7 +6595,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6639,7 +6639,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -6662,7 +6662,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -6684,7 +6684,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -6756,7 +6756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6784,14 +6784,14 @@
         "description": "The ResetAggregates Method resets the aggregates of the control module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6098",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6805,7 +6805,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6889,7 +6889,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6989,7 +6989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7058,7 +7058,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7154,7 +7154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7201,7 +7201,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -7255,7 +7255,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -7349,7 +7349,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -7420,14 +7420,14 @@
         "description": "The AcknowledgeAlarms Method acknowledges the alarms of the control module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6405",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7441,7 +7441,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7472,13 +7472,13 @@
         "description": "The Method SendCommand sends a command to change the state of the control module state   machine remotely.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7258",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7487,14 +7487,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7259",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7508,7 +7508,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7539,13 +7539,13 @@
         "description": "The SetControlMode Method sets the control mode of the control module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7279",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7554,14 +7554,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7280",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7575,7 +7575,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7607,7 +7607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode describes the current control mode of the equipment module.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7629,7 +7629,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The State Property describes the status of the state machine controlling the control module. State provides   a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7655,7 +7655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7879,7 +7879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8120,7 +8120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8371,7 +8371,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6935",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -8380,7 +8380,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -8397,7 +8397,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -8988,7 +8988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9065,7 +9065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_AnalogInputSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.AnalogInputSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9144,7 +9144,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DigitalInputSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DigitalInputSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9219,7 +9219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9230,7 +9230,7 @@
     "schemaDefinitions": {
       "MotorDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
         "const": {
           "Clockwise": 0,
           "CounterClockwise": 1
@@ -9272,7 +9272,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MotorDirectionEnumeration",
         "description": "The rotation direction of the motor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9297,7 +9297,7 @@
         "data": {
           "title": "MotorDirectionEnumeration",
           "description": "The rotation direction of the motor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9321,7 +9321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9400,7 +9400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectReasonType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectReasonType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9439,7 +9439,7 @@
         "description": "The Method SetDetectionMode enables or disables the defect reason.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -9450,14 +9450,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6189",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9471,7 +9471,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9592,7 +9592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_UIInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.UIInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9626,7 +9626,7 @@
         "description": "The Method DeleteUIResource permanently removes a UI resource from the underlying system   memory.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16748",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResourceName" ],
           "properties": {
             "ResourceName": {
@@ -9637,14 +9637,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16749",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9658,7 +9658,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9689,7 +9689,7 @@
         "description": "The Method LoadUIResource loads a UI resource in the underlying system for visualization. It will   override the existing UI resource by the same name.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16539",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResourceName", "ResourceValue" ],
           "properties": {
             "ResourceName": {
@@ -9704,14 +9704,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16540",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9725,7 +9725,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9864,7 +9864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9945,7 +9945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9974,7 +9974,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -10028,7 +10028,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -10122,7 +10122,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -10193,14 +10193,14 @@
         "description": "The AcknowledgeAlarms method acknowledges the alarms of the equipment module and control   modules belonging to it.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11663",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10214,7 +10214,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10245,13 +10245,13 @@
         "description": "The Method SendCommand sends a command to change the state of the equipment module   state machine remotely.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11702",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10260,14 +10260,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11703",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10281,7 +10281,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10312,13 +10312,13 @@
         "description": "The SetControlMode Method sets the control mode of the equipment module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11705",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10327,14 +10327,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11706",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10348,7 +10348,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10380,7 +10380,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode describes the current control mode of the equipment module.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10402,7 +10402,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The State Property describes the status of the state machine controlling the equipment module. State   provides a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10428,7 +10428,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1070",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10505,7 +10505,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10516,7 +10516,7 @@
     "schemaDefinitions": {
       "ParameterDependencyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
         "const": {
           "Machine": 0,
           "Brand": 1,
@@ -10557,13 +10557,13 @@
         "description": "The GetDatasetList Method returns the list of descriptions for parameters of the dataset filtered   by the dependency and subset created by the user.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6425",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Dependency", "UserSubset", "CompleteSet" ],
           "properties": {
             "Dependency": {
               "title": "ParameterDependencyEnumeration",
               "description": "Dependency specifies how to select (filter) a subset of the dataset based on dependency.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10580,14 +10580,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6429",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetList", "ExecutionFeedback" ],
           "properties": {
             "DataSetList": {
               "title": "DataSetDefinitionType",
               "description": "The DataSetDefinition structure contains the description and other necessary metadata of the   complete set of machine settings required for production.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetDefinitionType",
               "required": [ "ID", "Description", "Definitions" ],
               "properties": {
                 "ID": {
@@ -10605,14 +10605,14 @@
                     "title": "DataDefinitionType",
                     "description": "The DataDefinitionType structure contains the metadata that describes a parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDefinitionType",
                     "required": [ "EngineeringUnits", "DisplayFormat", "Dependency", "DataType", "UserSubset", "ControlRange", "AlarmRange" ],
                     "properties": {
                       "EngineeringUnits": {
                         "title": "EUInformation",
                         "description": "Unit of measure for the parameter.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -10638,7 +10638,7 @@
                       "Dependency": {
                         "title": "ParameterDependencyEnumeration",
                         "description": "The dependency of the parameter with respect to machine and   brand.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -10655,7 +10655,7 @@
                         "title": "Range",
                         "description": "The range where the parameter actual values is considered in   control.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                        "dov:typeRef": "org.opcfoundation.UA.Range",
                         "required": [ "Low", "High" ],
                         "properties": {
                           "Low": {
@@ -10674,7 +10674,7 @@
                         "title": "Range",
                         "description": "Outside this range, the underlying system generates an alarm for the   parameter.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                        "dov:typeRef": "org.opcfoundation.UA.Range",
                         "required": [ "Low", "High" ],
                         "properties": {
                           "Low": {
@@ -10698,7 +10698,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10712,7 +10712,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10743,7 +10743,7 @@
         "description": "The GetRootCauseGroupList Method returns the complete list of root cause groups as persisted   by the server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7322",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RootCauseGroupList", "ExecutionFeedback" ],
           "properties": {
             "RootCauseGroupList": {
@@ -10753,7 +10753,7 @@
                 "title": "RootCauseGroupType",
                 "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
                 "required": [ "ID", "ParentID", "Description" ],
                 "properties": {
                   "ID": {
@@ -10775,7 +10775,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10789,7 +10789,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10820,7 +10820,7 @@
         "description": "The GetRootCauseList Method returns the complete list of root causes as persisted by the   server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6210",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RootCauseList", "ExecutionFeedback" ],
           "properties": {
             "RootCauseList": {
@@ -10830,7 +10830,7 @@
                 "title": "RootCauseMessageType",
                 "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
                 "required": [ "GroupID" ],
                 "properties": {
                   "GroupID": {
@@ -10844,7 +10844,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10858,7 +10858,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10889,7 +10889,7 @@
         "description": "The GetStopReasonList Method returns the complete list of stop reasons as persisted by the   server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "StopReasonList", "ExecutionFeedback" ],
           "properties": {
             "StopReasonList": {
@@ -10899,7 +10899,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -10917,7 +10917,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10931,7 +10931,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10962,7 +10962,7 @@
         "description": "The SetDataSetListMESID Method sets the MES_ID of one or more items of the array Definitions contained in the DataSetList.  Each item of Definitions is identified by its ID.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9125",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IDs", "MESIDs" ],
           "properties": {
             "IDs": {
@@ -10983,14 +10983,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=19982",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11004,7 +11004,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11035,7 +11035,7 @@
         "description": "The SetRootCauseLists Method sets both the RootCauseList and RootCauseGroupList   according to the input arguments.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6326",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RootCauseList", "RootCauseGroupList" ],
           "properties": {
             "RootCauseList": {
@@ -11045,7 +11045,7 @@
                 "title": "RootCauseMessageType",
                 "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
                 "required": [ "GroupID" ],
                 "properties": {
                   "GroupID": {
@@ -11062,7 +11062,7 @@
                 "title": "RootCauseGroupType",
                 "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
                 "required": [ "ID", "ParentID", "Description" ],
                 "properties": {
                   "ID": {
@@ -11084,14 +11084,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6327",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11105,7 +11105,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11138,7 +11138,7 @@
         "title": "DataSetDefinitionType",
         "description": "The DataSetDefinition structure contains the description and other necessary metadata of the   complete set of machine settings required for production.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetDefinitionType",
         "required": [ "ID", "Description", "Definitions" ],
         "properties": {
           "ID": {
@@ -11156,14 +11156,14 @@
               "title": "DataDefinitionType",
               "description": "The DataDefinitionType structure contains the metadata that describes a parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDefinitionType",
               "required": [ "EngineeringUnits", "DisplayFormat", "Dependency", "DataType", "UserSubset", "ControlRange", "AlarmRange" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "description": "Unit of measure for the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -11189,7 +11189,7 @@
                 "Dependency": {
                   "title": "ParameterDependencyEnumeration",
                   "description": "The dependency of the parameter with respect to machine and   brand.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -11206,7 +11206,7 @@
                   "title": "Range",
                   "description": "The range where the parameter actual values is considered in   control.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -11225,7 +11225,7 @@
                   "title": "Range",
                   "description": "Outside this range, the underlying system generates an alarm for the   parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -11295,7 +11295,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -11334,7 +11334,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -11383,7 +11383,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -11418,7 +11418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleHistoricalRecordType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleHistoricalRecordType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11471,7 +11471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11488,7 +11488,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -11517,7 +11517,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -11558,7 +11558,7 @@
         "description": "The DeleteSpecificationRecord Method deletes a specification record.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecificationRecord" ],
           "properties": {
             "SpecificationRecord": {
@@ -11569,14 +11569,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11590,7 +11590,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11621,7 +11621,7 @@
         "description": "The LoadMachineModuleDocumentation Method allows to securely load any machine module   documentation to the documentation repository DocumentationRep folder where it can be reached by   applications.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9268",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DocumentToBeLoaded", "DocumentName" ],
           "properties": {
             "DocumentToBeLoaded": {
@@ -11637,14 +11637,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9269",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11658,7 +11658,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11689,7 +11689,7 @@
         "description": "The RemoveMachineModuleDocumentation Method allows to securely remove, i.e. permanently delete,  any machine module documentation from the documentation repository Documentation.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9271",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DocumentName" ],
           "properties": {
             "DocumentName": {
@@ -11700,14 +11700,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9272",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11721,7 +11721,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11752,7 +11752,7 @@
         "description": "The Method SetNewSpecification saves its arguments as the new specification for the machine module.   Prior to that it saves the previous specification into the PastSpecification Records Object of the same   machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NewMaterialLoadingPoints", "NewMaterialStorageBuffers", "NewMaterialOutputPoints", "NewMaterialRejectionPoints" ],
           "properties": {
             "NewMaterialLoadingPoints": {
@@ -11762,7 +11762,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -11780,7 +11780,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -11799,7 +11799,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -11843,7 +11843,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -11882,7 +11882,7 @@
                 "title": "MaterialStorageBufferDataType",
                 "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
                 "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
                 "properties": {
                   "ID": {
@@ -11893,7 +11893,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -11912,7 +11912,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -11956,7 +11956,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -11980,7 +11980,7 @@
                     "title": "EUInformation",
                     "description": "The unit of measure for the material stored in the buffer.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -12008,7 +12008,7 @@
                   "StorageLogic": {
                     "title": "StorageLogicEnumeration",
                     "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -12016,7 +12016,7 @@
                   "MixingLogic": {
                     "title": "StorageMixingLogicEnumeration",
                     "description": "How different material loaded into the material storage buffer mix.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -12031,7 +12031,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -12049,7 +12049,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -12068,7 +12068,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -12112,7 +12112,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -12151,7 +12151,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -12169,7 +12169,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -12188,7 +12188,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -12232,7 +12232,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -12268,14 +12268,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -12289,7 +12289,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -12343,7 +12343,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -12361,7 +12361,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -12380,7 +12380,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -12424,7 +12424,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -12472,7 +12472,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -12490,7 +12490,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -12509,7 +12509,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -12553,7 +12553,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -12601,7 +12601,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -12619,7 +12619,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -12638,7 +12638,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -12682,7 +12682,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -12730,7 +12730,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -12741,7 +12741,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -12760,7 +12760,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -12804,7 +12804,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -12828,7 +12828,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -12856,7 +12856,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -12864,7 +12864,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -12885,7 +12885,7 @@
         "title": "TimeZoneDataType",
         "description": "The local time zone where the machine operates. It is required to convert UTC times into local   time.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -12971,7 +12971,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13000,7 +13000,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -13054,7 +13054,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -13148,7 +13148,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -13219,14 +13219,14 @@
         "description": "The AcknowledgeAlarms Method acknowledges all alarms of the machine module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12166",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13240,7 +13240,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13271,14 +13271,14 @@
         "description": "The method resets all aggregated values calculated by each ProcessItem",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=19799",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13292,7 +13292,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13323,13 +13323,13 @@
         "description": "The Method SendCommand sends a command to change the state of the machine module state machine.  The Method SendCommand sends a command to change the state of the machine module state machine.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -13338,14 +13338,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6385",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13359,7 +13359,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13390,13 +13390,13 @@
         "description": "The SetControlMode Method sets the control mode of the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -13405,14 +13405,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13426,7 +13426,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13457,7 +13457,7 @@
         "description": "The Method SetIdleEnergySavingMode activates the energy saving mode when the machine   module is idle.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IdleEnergySavingMode" ],
           "properties": {
             "IdleEnergySavingMode": {
@@ -13468,14 +13468,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6393",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13489,7 +13489,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13521,7 +13521,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode property describes the current control mode of the machine.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13561,7 +13561,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The Property State describes the status of the state machine controlling the machine module. State   provides a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13587,7 +13587,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13610,7 +13610,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -13634,7 +13634,7 @@
       },
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionStatusEnumeration",
         "const": {
           "Other": 0,
           "BrandChange": 1,
@@ -13680,14 +13680,14 @@
         "description": "The AbortProductionOrder method is used to abnormally terminate, or abort, a production order   that is in execution or starting or completing. Aborting cannot be reversed or undone.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22399",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAbort" ],
           "properties": {
             "POToAbort": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -13698,7 +13698,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -13717,7 +13717,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -13761,7 +13761,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -13823,14 +13823,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22400",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13844,7 +13844,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13875,21 +13875,21 @@
         "description": "The AssignProductionOrder Method is used to transfer the information of an upcoming   production order to the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22538",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAssign" ],
           "properties": {
             "POToAssign": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -13900,7 +13900,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -13919,7 +13919,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -13963,7 +13963,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -14025,7 +14025,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -14043,7 +14043,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -14062,7 +14062,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -14077,7 +14077,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -14096,7 +14096,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -14115,7 +14115,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -14159,7 +14159,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -14182,7 +14182,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -14204,7 +14204,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -14259,7 +14259,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -14271,7 +14271,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -14286,7 +14286,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -14305,7 +14305,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -14324,7 +14324,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -14368,7 +14368,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -14391,7 +14391,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -14413,7 +14413,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -14475,7 +14475,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -14493,7 +14493,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -14515,14 +14515,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22539",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14536,7 +14536,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14567,14 +14567,14 @@
         "description": "The ClearProductionOrder method is used to positively confirm that the machine module where   a production order is aborted has been cleared of the product or parts left by the aborted   production order.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22403",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14588,7 +14588,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14619,14 +14619,14 @@
         "description": "The CompleteProductionOrder method is used to complete a production order in execution.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22405",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14640,7 +14640,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14671,14 +14671,14 @@
         "description": "The Method ResetProductionTotals simultaneously resets the totals of the machine components   belonging to the following machine folders: DefectDetectionSensors, MaterialLoadingPoints, MaterialOutputPoints, MaterialRejectionPoints.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14692,7 +14692,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14722,14 +14722,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9654",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeaderToStart", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POHeaderToStart": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -14740,7 +14740,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -14759,7 +14759,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -14803,7 +14803,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -14879,14 +14879,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9655",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14900,7 +14900,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14931,21 +14931,21 @@
         "description": "The StartProductionOrder Method starts a production order at the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22409",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToStart", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POToStart": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -14956,7 +14956,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -14975,7 +14975,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -15019,7 +15019,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -15081,7 +15081,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -15099,7 +15099,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -15118,7 +15118,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -15133,7 +15133,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -15152,7 +15152,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -15171,7 +15171,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -15215,7 +15215,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -15238,7 +15238,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -15260,7 +15260,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -15315,7 +15315,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -15327,7 +15327,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -15342,7 +15342,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -15361,7 +15361,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -15380,7 +15380,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -15424,7 +15424,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -15447,7 +15447,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -15469,7 +15469,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -15531,7 +15531,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -15549,7 +15549,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -15585,14 +15585,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22410",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -15606,7 +15606,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -15637,14 +15637,14 @@
         "description": "The UnAssignProductionOrder method is used to remove the specified production order from   AssignedProductionOrders[] of an infeed machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22412",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnassign" ],
           "properties": {
             "POToUnassign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -15655,7 +15655,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -15674,7 +15674,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -15718,7 +15718,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -15780,14 +15780,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22413",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -15801,7 +15801,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -15837,14 +15837,14 @@
           "title": "ProductionOrderType",
           "description": "The ProductionOrderType structure contains the complete production order information.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
           "required": [ "Header", "MaterialList", "DataSet" ],
           "properties": {
             "Header": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -15855,7 +15855,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -15874,7 +15874,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -15918,7 +15918,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -15980,7 +15980,7 @@
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -15998,7 +15998,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -16017,7 +16017,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -16032,7 +16032,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -16051,7 +16051,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -16070,7 +16070,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -16114,7 +16114,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -16137,7 +16137,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -16159,7 +16159,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -16214,7 +16214,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -16226,7 +16226,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -16241,7 +16241,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -16260,7 +16260,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -16279,7 +16279,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -16323,7 +16323,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -16346,7 +16346,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -16368,7 +16368,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -16430,7 +16430,7 @@
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -16448,7 +16448,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -16516,7 +16516,7 @@
         "title": "ProductionOrderHeaderType",
         "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
         "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
         "properties": {
           "Number": {
@@ -16527,7 +16527,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -16546,7 +16546,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -16590,7 +16590,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -16660,7 +16660,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ProductionStatusEnumeration",
         "description": "The execution status of the production order.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16686,7 +16686,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleProductionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17130,7 +17130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17153,7 +17153,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -17194,14 +17194,14 @@
         "description": "The LoadDataSet Method loads the dataset to the underlying system after having validated that (a) the dataset is complete when IsCompleteDataset is True and (b) the dataset is valid.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6437",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSet", "IsCompleteDataSet" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -17219,7 +17219,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -17243,14 +17243,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6438",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -17264,7 +17264,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -17295,14 +17295,14 @@
         "description": "The LoadMaterialList Method loads the material list to the underlying system after having validated that   (a) the material list is complete and (b) the material list is valid.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaterialList" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -17320,7 +17320,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -17339,7 +17339,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -17354,7 +17354,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -17373,7 +17373,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -17392,7 +17392,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -17436,7 +17436,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -17459,7 +17459,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -17481,7 +17481,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -17536,7 +17536,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -17548,7 +17548,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -17563,7 +17563,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -17582,7 +17582,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -17601,7 +17601,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -17645,7 +17645,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -17668,7 +17668,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -17690,7 +17690,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -17752,14 +17752,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6329",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -17773,7 +17773,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -17804,14 +17804,14 @@
         "description": "The ValidateDataSet Method transfers a dataset, complete when IsCompleteDataSet is True, to the underlying system and returns the result of the validation, i.e. verifying that the dataset is complete and can run in production.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6185",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSet", "IsCompleteDataSet" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -17829,7 +17829,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -17853,7 +17853,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FailedValidationEntries", "FailedValidationMessages", "ExecutionFeedback" ],
           "properties": {
             "FailedValidationEntries": {
@@ -17863,7 +17863,7 @@
                 "title": "DataSetEntryType",
                 "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -17884,7 +17884,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -17902,7 +17902,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -17916,7 +17916,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -17947,14 +17947,14 @@
         "description": "The ValidateMaterialList Method transfers a material list to the underlying system and returns the result   of the validation.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaterialList" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -17972,7 +17972,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -17991,7 +17991,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -18006,7 +18006,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -18025,7 +18025,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -18044,7 +18044,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -18088,7 +18088,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -18111,7 +18111,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -18133,7 +18133,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -18188,7 +18188,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -18200,7 +18200,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -18215,7 +18215,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -18234,7 +18234,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -18253,7 +18253,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -18297,7 +18297,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -18320,7 +18320,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -18342,7 +18342,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -18404,7 +18404,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6332",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FailedValidationEntries", "FailedValidationMessages", "ExecutionFeedback" ],
           "properties": {
             "FailedValidationEntries": {
@@ -18414,7 +18414,7 @@
                 "title": "MaterialListItemType",
                 "description": "The MaterialListItemType structure contains a single material to be processed.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                 "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                 "properties": {
                   "AssemblyID": {
@@ -18433,7 +18433,7 @@
                     "title": "MaterialSublotType",
                     "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                     "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                     "properties": {
                       "ID": {
@@ -18448,7 +18448,7 @@
                         "title": "MaterialLotType",
                         "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                         "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                         "properties": {
                           "ID": {
@@ -18467,7 +18467,7 @@
                             "title": "MaterialDefinitionType",
                             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                             "properties": {
                               "ID": {
@@ -18486,7 +18486,7 @@
                                 "title": "EUInformation",
                                 "description": "The base unit of measure for the material definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -18530,7 +18530,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -18553,7 +18553,7 @@
                           "Status": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The stock status of the material lot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -18575,7 +18575,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -18630,7 +18630,7 @@
                   "MaterialStockStatus": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The requested stock status for the material sublot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -18642,7 +18642,7 @@
                       "title": "MaterialSublotType",
                       "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                       "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                       "properties": {
                         "ID": {
@@ -18657,7 +18657,7 @@
                           "title": "MaterialLotType",
                           "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                           "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                           "properties": {
                             "ID": {
@@ -18676,7 +18676,7 @@
                               "title": "MaterialDefinitionType",
                               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                               "properties": {
                                 "ID": {
@@ -18695,7 +18695,7 @@
                                   "title": "EUInformation",
                                   "description": "The base unit of measure for the material definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                   "properties": {
                                     "NamespaceUri": {
@@ -18739,7 +18739,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -18762,7 +18762,7 @@
                             "Status": {
                               "title": "MaterialStockStatusEnumeration",
                               "description": "The stock status of the material lot.",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -18784,7 +18784,7 @@
                                 "title": "DataDescriptionType",
                                 "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                 "required": [ "ID", "MES_ID", "Description" ],
                                 "properties": {
                                   "ID": {
@@ -18847,7 +18847,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -18865,7 +18865,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -18879,7 +18879,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -18912,7 +18912,7 @@
         "title": "DataSetType",
         "description": "The DataSetType structure contains a set of data values.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
         "required": [ "ID", "Description", "Values" ],
         "properties": {
           "ID": {
@@ -18930,7 +18930,7 @@
               "title": "DataSetEntryType",
               "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -18964,7 +18964,7 @@
         "title": "MaterialListType",
         "description": "The MaterialListType structure contains a set of material list items.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
         "required": [ "ID", "Description", "Items" ],
         "properties": {
           "ID": {
@@ -18982,7 +18982,7 @@
               "title": "MaterialListItemType",
               "description": "The MaterialListItemType structure contains a single material to be processed.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
               "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
               "properties": {
                 "AssemblyID": {
@@ -19001,7 +19001,7 @@
                   "title": "MaterialSublotType",
                   "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                   "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                   "properties": {
                     "ID": {
@@ -19016,7 +19016,7 @@
                       "title": "MaterialLotType",
                       "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                       "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                       "properties": {
                         "ID": {
@@ -19035,7 +19035,7 @@
                           "title": "MaterialDefinitionType",
                           "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                           "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                           "properties": {
                             "ID": {
@@ -19054,7 +19054,7 @@
                               "title": "EUInformation",
                               "description": "The base unit of measure for the material definition.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -19098,7 +19098,7 @@
                                 "title": "DataDescriptionType",
                                 "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                 "required": [ "ID", "MES_ID", "Description" ],
                                 "properties": {
                                   "ID": {
@@ -19121,7 +19121,7 @@
                         "Status": {
                           "title": "MaterialStockStatusEnumeration",
                           "description": "The stock status of the material lot.",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -19143,7 +19143,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -19198,7 +19198,7 @@
                 "MaterialStockStatus": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The requested stock status for the material sublot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -19210,7 +19210,7 @@
                     "title": "MaterialSublotType",
                     "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                     "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                     "properties": {
                       "ID": {
@@ -19225,7 +19225,7 @@
                         "title": "MaterialLotType",
                         "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                         "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                         "properties": {
                           "ID": {
@@ -19244,7 +19244,7 @@
                             "title": "MaterialDefinitionType",
                             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                             "properties": {
                               "ID": {
@@ -19263,7 +19263,7 @@
                                 "title": "EUInformation",
                                 "description": "The base unit of measure for the material definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -19307,7 +19307,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -19330,7 +19330,7 @@
                           "Status": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The stock status of the material lot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -19352,7 +19352,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -19431,7 +19431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialLocationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1077",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLocationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19460,7 +19460,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -19484,7 +19484,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -19658,7 +19658,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state the material location is in.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19678,7 +19678,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -19693,7 +19693,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -19712,7 +19712,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -19731,7 +19731,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -19775,7 +19775,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -19798,7 +19798,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -19820,7 +19820,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -19891,7 +19891,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -19906,7 +19906,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -19925,7 +19925,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -19944,7 +19944,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -19988,7 +19988,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -20011,7 +20011,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -20033,7 +20033,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -20105,7 +20105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20150,14 +20150,14 @@
         "description": "The Method ResetAggregates restarts from new the computation of aggregates performed by the   underlying system.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -20171,7 +20171,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -20468,7 +20468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessControlItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessControlItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20501,7 +20501,7 @@
         "description": "The SetRemoteControl Method enables or disables the remote control mode.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -20512,14 +20512,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6042",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -20533,7 +20533,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -20654,7 +20654,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20699,7 +20699,7 @@
         "description": "The Method LoadReferenceFeatures loads binary profiles to be used as references for defect detection.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7443",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Features" ],
           "properties": {
             "Features": {
@@ -20714,14 +20714,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6233",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -20735,7 +20735,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -20766,7 +20766,7 @@
         "description": "The method SetDetectionMode enables or disables the detection function and the underneath defect reasons.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7441",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -20777,14 +20777,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7442",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -20798,7 +20798,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -20884,7 +20884,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderExecutionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderExecutionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21225,7 +21225,7 @@
         "title": "ProductionOrderHeaderType",
         "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
         "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
         "properties": {
           "Number": {
@@ -21236,7 +21236,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -21255,7 +21255,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -21299,7 +21299,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -21732,7 +21732,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21764,7 +21764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21814,7 +21814,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_AnalogInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.AnalogInputType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21916,7 +21916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DigitalInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DigitalInputType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21987,7 +21987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22025,7 +22025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22057,7 +22057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1067",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22101,7 +22101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectDetectionSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectDetectionSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22146,7 +22146,7 @@
         "description": "The Method SetDetectionMode enables or disables the defect detection sensor.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7467",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -22157,14 +22157,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7468",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -22178,7 +22178,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -22299,7 +22299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1071",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22361,7 +22361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22504,7 +22504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialLoadingPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLoadingPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22515,7 +22515,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -22539,7 +22539,7 @@
       },
       "MaterialValidationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
         "const": {
           "None": 0,
           "Waiting": 1,
@@ -22568,7 +22568,7 @@
       },
       "MaterialIntegrityAgentEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialIntegrityAgentEnumeration",
         "const": {
           "None": 0,
           "Local": 1,
@@ -22614,13 +22614,13 @@
         "description": "The SetPresentedMaterialValidationStatus Method provides a client with an affordance to perform the   validation of the PresentedMaterial against the ExpectedMaterials and set the result of the validation in   the PresentedMaterialValidationStatus variable.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13570",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ValidationResult" ],
           "properties": {
             "ValidationResult": {
               "title": "MaterialValidationStatusEnumeration",
               "description": "The result of the validation of the PresentedMaterial.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -22629,14 +22629,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13571",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -22650,7 +22650,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -22877,7 +22877,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -22892,7 +22892,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -22911,7 +22911,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -22930,7 +22930,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -22974,7 +22974,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -22997,7 +22997,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -23019,7 +23019,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -23088,7 +23088,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -23103,7 +23103,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -23122,7 +23122,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -23141,7 +23141,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -23185,7 +23185,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -23208,7 +23208,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -23230,7 +23230,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -23295,7 +23295,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MaterialIntegrityAgentEnumeration",
         "description": "MaterialIntegrityAgent defines how material validation is performed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialIntegrityAgentEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23318,7 +23318,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -23336,7 +23336,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -23355,7 +23355,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -23399,7 +23399,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -23493,7 +23493,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -23508,7 +23508,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -23527,7 +23527,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -23546,7 +23546,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -23590,7 +23590,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -23613,7 +23613,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -23635,7 +23635,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -23704,7 +23704,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MaterialValidationStatusEnumeration",
         "description": "The status of the validation of the presented material.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23925,7 +23925,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -23940,7 +23940,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -23959,7 +23959,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -23978,7 +23978,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -24022,7 +24022,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -24045,7 +24045,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -24067,7 +24067,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -24168,7 +24168,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -24183,7 +24183,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -24202,7 +24202,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -24221,7 +24221,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -24265,7 +24265,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -24288,7 +24288,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -24310,7 +24310,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -24375,7 +24375,7 @@
         "data": {
           "title": "MaterialValidationStatusEnumeration",
           "description": "The status of the validation of the presented material.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -24399,7 +24399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialOutputPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialOutputPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24410,7 +24410,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -24503,7 +24503,7 @@
         "title": "MaterialDefinitionType",
         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
         "properties": {
           "ID": {
@@ -24522,7 +24522,7 @@
             "title": "EUInformation",
             "description": "The base unit of measure for the material definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -24566,7 +24566,7 @@
               "title": "DataDescriptionType",
               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
               "required": [ "ID", "MES_ID", "Description" ],
               "properties": {
                 "ID": {
@@ -24599,7 +24599,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -24617,7 +24617,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -24636,7 +24636,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -24680,7 +24680,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -24774,7 +24774,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -24789,7 +24789,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -24808,7 +24808,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -24827,7 +24827,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -24871,7 +24871,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -24894,7 +24894,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -24916,7 +24916,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -25129,7 +25129,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -25144,7 +25144,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -25163,7 +25163,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -25182,7 +25182,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -25226,7 +25226,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -25249,7 +25249,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -25271,7 +25271,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -25424,7 +25424,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialRejectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialRejectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25457,7 +25457,7 @@
         "description": "The Method SetRejectionMode turns the rejection on or off.  The Method SetRejectionMode turns the rejection on or off.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6868",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RejectionMode" ],
           "properties": {
             "RejectionMode": {
@@ -25468,14 +25468,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6917",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -25489,7 +25489,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -25522,7 +25522,7 @@
         "title": "MaterialDefinitionType",
         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
         "properties": {
           "ID": {
@@ -25541,7 +25541,7 @@
             "title": "EUInformation",
             "description": "The base unit of measure for the material definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -25585,7 +25585,7 @@
               "title": "DataDescriptionType",
               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
               "required": [ "ID", "MES_ID", "Description" ],
               "properties": {
                 "ID": {
@@ -25618,7 +25618,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -25636,7 +25636,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -25655,7 +25655,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -25699,7 +25699,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -26043,7 +26043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialStorageBufferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26054,7 +26054,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -26083,7 +26083,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -26208,7 +26208,7 @@
         "title": "MaterialStorageBufferDataType",
         "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
         "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
         "properties": {
           "ID": {
@@ -26219,7 +26219,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -26238,7 +26238,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -26282,7 +26282,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -26306,7 +26306,7 @@
             "title": "EUInformation",
             "description": "The unit of measure for the material stored in the buffer.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -26334,7 +26334,7 @@
           "StorageLogic": {
             "title": "StorageLogicEnumeration",
             "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -26342,7 +26342,7 @@
           "MixingLogic": {
             "title": "StorageMixingLogicEnumeration",
             "description": "How different material loaded into the material storage buffer mix.",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -26379,7 +26379,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StorageMixingLogicEnumeration",
         "description": "MixingLogic identifies if and how materials can be mixed in the MaterialStorageBuffer.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -26463,7 +26463,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StorageLogicEnumeration",
         "description": "The logic used at the buffer storage to store and retrieve material.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -26750,7 +26750,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessControlLoopType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessControlLoopType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26849,7 +26849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderOrchestrationLayerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1073",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderOrchestrationLayerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26867,7 +26867,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -26908,14 +26908,14 @@
         "description": "The AbortProductionOrder Method is used to abort a production order that is in execution or starting or   completing in the production line.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11950",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAbort" ],
           "properties": {
             "POToAbort": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -26926,7 +26926,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -26945,7 +26945,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -26989,7 +26989,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27051,14 +27051,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11951",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27072,7 +27072,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27103,14 +27103,14 @@
         "description": "The AssignProductionOrder Method is used to assign a production order to one infeed machine module   where it shall be executed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11953",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAssign", "MachineModuleUserName" ],
           "properties": {
             "POToAssign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27121,7 +27121,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27140,7 +27140,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27184,7 +27184,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27253,14 +27253,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11954",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27274,7 +27274,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27305,14 +27305,14 @@
         "description": "The CompleteProductionOrder Method is used to complete a production order in execution.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11956",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToComplete", "MachineModuleUserName" ],
           "properties": {
             "POToComplete": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27323,7 +27323,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27342,7 +27342,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27386,7 +27386,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27452,14 +27452,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11957",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27473,7 +27473,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27504,14 +27504,14 @@
         "description": "The GetDataset Method is used to retrieve the data set from a production order header.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11959",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27522,7 +27522,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27541,7 +27541,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27585,7 +27585,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27651,14 +27651,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11960",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSet", "ExecutionFeedback" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -27676,7 +27676,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -27696,7 +27696,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27710,7 +27710,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27741,14 +27741,14 @@
         "description": "The GetMaterialList Method is used to retrieve the material list information from a production order   header.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11962",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27759,7 +27759,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27778,7 +27778,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27822,7 +27822,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27888,14 +27888,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11963",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "MaterialList", "ExecutionFeedback" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -27913,7 +27913,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -27932,7 +27932,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -27947,7 +27947,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -27966,7 +27966,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -27985,7 +27985,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -28029,7 +28029,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -28052,7 +28052,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -28074,7 +28074,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -28129,7 +28129,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -28141,7 +28141,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -28156,7 +28156,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -28175,7 +28175,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -28194,7 +28194,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -28238,7 +28238,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -28261,7 +28261,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -28283,7 +28283,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -28345,7 +28345,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -28359,7 +28359,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -28390,14 +28390,14 @@
         "description": "The GetProductionOrder Method is used to retrieve the complete production order information starting   with a production order header as an input argument.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11965",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -28408,7 +28408,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -28427,7 +28427,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -28471,7 +28471,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -28537,21 +28537,21 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11966",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionOrder", "ExecutionFeedback" ],
           "properties": {
             "ProductionOrder": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -28562,7 +28562,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -28581,7 +28581,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -28625,7 +28625,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -28687,7 +28687,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -28705,7 +28705,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -28724,7 +28724,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -28739,7 +28739,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -28758,7 +28758,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -28777,7 +28777,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -28821,7 +28821,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -28844,7 +28844,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -28866,7 +28866,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -28921,7 +28921,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -28933,7 +28933,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -28948,7 +28948,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -28967,7 +28967,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -28986,7 +28986,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -29030,7 +29030,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -29053,7 +29053,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -29075,7 +29075,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -29137,7 +29137,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -29155,7 +29155,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -29177,7 +29177,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29191,7 +29191,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29222,14 +29222,14 @@
         "description": "The ReleaseProductionOrder Method is used to make a production order available to a machine module   for orchestrated execution in a production line (Process Cell according to ANSI/ISA-88.00.01-2010   Physical Model).",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12008",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToRelease", "MachineModuleUserName" ],
           "properties": {
             "POToRelease": {
               "title": "OrchestrationProductionOrderType",
               "description": "The OrchestrationProductionOrderType structure contains the complete production order   information used by the Production Order Orchestration Layer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.OrchestrationProductionOrderType",
               "required": [ "ActiveMachineModules" ],
               "properties": {
                 "ActiveMachineModules": {
@@ -29249,14 +29249,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12009",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29270,7 +29270,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29301,14 +29301,14 @@
         "description": "The StartProductionOrder Method is used to start the execution of a production order at a machine   module specifying the loading points that input materials will be fed to and the output points where output   will be directed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12011",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToStart", "MachineModuleUserName", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POToStart": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29319,7 +29319,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29338,7 +29338,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29382,7 +29382,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29462,14 +29462,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12012",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29483,7 +29483,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29514,14 +29514,14 @@
         "description": "The UnAssignProductionOrder Method is used to unassign a production order previously assigned to   an infeed machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12014",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnassign" ],
           "properties": {
             "POToUnassign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29532,7 +29532,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29551,7 +29551,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29595,7 +29595,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29657,14 +29657,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12015",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29678,7 +29678,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29709,14 +29709,14 @@
         "description": "The UnreleaseProductionOrder Method is used to reverse the effect of the ReleaseProductionOrder  method and make a previously released production order unavailable for assignment and production.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12017",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnrelease" ],
           "properties": {
             "POToUnrelease": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29727,7 +29727,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29746,7 +29746,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29790,7 +29790,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29852,14 +29852,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12018",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29873,7 +29873,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29934,7 +29934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_UserInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.UserInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -29997,7 +29997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -30024,7 +30024,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -30063,7 +30063,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -30094,7 +30094,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -30122,7 +30122,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -30150,7 +30150,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -30187,7 +30187,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -30215,7 +30215,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -30540,7 +30540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -30567,7 +30567,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -30592,7 +30592,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -30698,7 +30698,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -30725,7 +30725,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -30750,7 +30750,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -30772,7 +30772,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -31031,7 +31031,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31127,7 +31127,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -31231,7 +31231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -31252,7 +31252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31336,7 +31336,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -31355,7 +31355,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -31375,7 +31375,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -31407,7 +31407,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -31450,7 +31450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31592,7 +31592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31677,7 +31677,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31723,7 +31723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31769,7 +31769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31795,7 +31795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31821,7 +31821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31929,7 +31929,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31955,7 +31955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLevelAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10060",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLevelAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31982,7 +31982,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9906",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -32136,7 +32136,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -32378,7 +32378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -32536,7 +32536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -32706,7 +32706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -32939,7 +32939,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=342",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -32948,7 +32948,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -32965,7 +32965,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -33116,7 +33116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33163,7 +33163,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -33225,7 +33225,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33378,7 +33378,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -33402,7 +33402,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33605,7 +33605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33661,7 +33661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33732,7 +33732,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33754,7 +33754,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -33776,7 +33776,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -33798,7 +33798,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -33808,7 +33808,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -33830,7 +33830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -33923,7 +33923,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33968,7 +33968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33994,7 +33994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/TTD.TM.json
+++ b/wot-codegen/opc-output-integrated/TTD.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TTDResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TTDResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -73,14 +73,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -146,7 +146,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -181,7 +181,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -236,14 +236,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -309,7 +309,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -344,7 +344,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -397,7 +397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_JobStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.JobStatisticsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -496,7 +496,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_MachineStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.MachineStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -562,7 +562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_RecurrentPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.RecurrentPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -672,7 +672,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -699,7 +699,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -719,7 +719,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -729,20 +729,20 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Recipe" ],
           "properties": {
             "Recipe": {
               "title": "RecipeDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
               "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
               "properties": {
                 "RecipeId": {
                   "title": "RecipeIdDataType",
                   "description": "RecipeId meta data describing this recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Name": {
@@ -805,7 +805,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RecipeIds" ],
           "properties": {
             "RecipeIds": {
@@ -813,7 +813,7 @@
               "items": {
                 "title": "RecipeIdDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                 "required": [ "Id" ],
                 "properties": {
                   "Name": {
@@ -866,7 +866,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Recipes" ],
           "properties": {
             "Recipes": {
@@ -874,14 +874,14 @@
               "items": {
                 "title": "RecipeDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
                 "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
                 "properties": {
                   "RecipeId": {
                     "title": "RecipeIdDataType",
                     "description": "RecipeId meta data describing this recipe.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Name": {
@@ -945,20 +945,20 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Recipe", "Overwrite" ],
           "properties": {
             "Recipe": {
               "title": "RecipeDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
               "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
               "properties": {
                 "RecipeId": {
                   "title": "RecipeIdDataType",
                   "description": "RecipeId meta data describing this recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Name": {
@@ -1024,7 +1024,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Recipes", "Overwrite" ],
           "properties": {
             "Recipes": {
@@ -1032,14 +1032,14 @@
               "items": {
                 "title": "RecipeDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
                 "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
                 "properties": {
                   "RecipeId": {
                     "title": "RecipeIdDataType",
                     "description": "RecipeId meta data describing this recipe.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Name": {
@@ -1110,7 +1110,7 @@
         "items": {
           "title": "RecipeIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Name": {
@@ -1175,7 +1175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TTDResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TTDResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1198,7 +1198,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -1231,7 +1231,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6111",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -1248,7 +1248,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6112",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -1261,14 +1261,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -1334,7 +1334,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -1369,7 +1369,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -1434,7 +1434,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TextileTestingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TextileTestingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1484,7 +1484,7 @@
         "items": {
           "title": "ExchangeablePartDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.ExchangeablePartDataType",
           "required": [ "PartType", "Mounted" ],
           "properties": {
             "PartType": {
@@ -1534,7 +1534,7 @@
         "items": {
           "title": "OptionalModuleDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.OptionalModuleDataType",
           "required": [ "ModuleName", "ModuleType", "IsInstalled" ],
           "properties": {
             "ModuleName": {
@@ -1575,7 +1575,7 @@
         "items": {
           "title": "TestProcedureIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3034",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.TestProcedureIdDataType",
           "required": [ "TestProcedureId" ],
           "properties": {
             "TestProcedureId": {
@@ -1626,7 +1626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1638,7 +1638,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -1691,14 +1691,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -1764,7 +1764,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -1799,7 +1799,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1854,14 +1854,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -1927,7 +1927,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -1962,7 +1962,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2015,7 +2015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2039,7 +2039,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -2068,7 +2068,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -2164,7 +2164,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -2178,7 +2178,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -2210,7 +2210,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -2223,7 +2223,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -2236,14 +2236,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -2309,7 +2309,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -2344,7 +2344,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2399,7 +2399,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -2416,7 +2416,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -2429,14 +2429,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -2502,7 +2502,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -2537,7 +2537,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2591,14 +2591,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -2606,12 +2606,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2633,7 +2633,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -2641,7 +2641,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -2678,7 +2678,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -2714,7 +2714,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -2727,7 +2727,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2778,7 +2778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2792,14 +2792,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -2812,7 +2812,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -2854,7 +2854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2950,7 +2950,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3054,7 +3054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3075,7 +3075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3101,7 +3101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3129,7 +3129,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -3141,7 +3141,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -3160,7 +3160,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3170,7 +3170,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -3197,7 +3197,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -3207,7 +3207,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -3255,7 +3255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3374,7 +3374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3516,7 +3516,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3601,7 +3601,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3627,7 +3627,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3673,7 +3673,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3719,7 +3719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3765,7 +3765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3803,7 +3803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3829,7 +3829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/WMTP.TM.json
+++ b/wot-codegen/opc-output-integrated/WMTP.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPMeasurementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -46,7 +46,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6200",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeltaValue" ],
           "properties": {
             "DeltaValue": {
@@ -66,7 +66,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6182",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TriggerDuration" ],
           "properties": {
             "TriggerDuration": {
@@ -411,7 +411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WirelessMachineToolPeripheralType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WirelessMachineToolPeripheralType",
     "dov:isComposite": true,
     "links": [
       {
@@ -474,7 +474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPServiceCycleDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPServiceCycleDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -499,7 +499,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -507,13 +507,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -550,7 +550,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -568,7 +568,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -638,19 +638,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -687,7 +687,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -705,7 +705,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -774,7 +774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6243",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -791,7 +791,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -799,13 +799,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -842,7 +842,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -860,7 +860,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -930,19 +930,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6245",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -979,7 +979,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -997,7 +997,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1066,7 +1066,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6247",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1081,7 +1081,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6248",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -1089,13 +1089,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1132,7 +1132,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -1150,7 +1150,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -1220,7 +1220,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6164",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeleteAllStoredRecordsSuccessfull" ],
           "properties": {
             "DeleteAllStoredRecordsSuccessfull": {
@@ -1240,7 +1240,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6170",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -1267,7 +1267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6166",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1292,7 +1292,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -1314,7 +1314,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6178",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1329,7 +1329,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6179",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -1362,7 +1362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPWorkCycleDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPWorkCycleDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1387,19 +1387,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6233",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1436,7 +1436,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1454,7 +1454,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1523,19 +1523,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6240",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1572,7 +1572,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1590,7 +1590,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1659,7 +1659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6235",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -1676,19 +1676,19 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6236",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1725,7 +1725,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1743,7 +1743,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1812,19 +1812,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6239",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1861,7 +1861,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1879,7 +1879,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1948,7 +1948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6237",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1963,19 +1963,19 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6238",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -2012,7 +2012,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -2030,7 +2030,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -2099,7 +2099,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6165",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeleteAllStoredRecordsSuccessfull" ],
           "properties": {
             "DeleteAllStoredRecordsSuccessfull": {
@@ -2119,7 +2119,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6172",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -2146,7 +2146,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6168",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -2171,7 +2171,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -2193,7 +2193,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -2208,7 +2208,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -2242,7 +2242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2636,7 +2636,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2732,7 +2732,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2787,7 +2787,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -2808,7 +2808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2864,7 +2864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2932,7 +2932,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3174,7 +3174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3213,7 +3213,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3244,7 +3244,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3272,7 +3272,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3300,7 +3300,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3337,7 +3337,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3365,7 +3365,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3690,7 +3690,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3717,7 +3717,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3742,7 +3742,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3848,7 +3848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3875,7 +3875,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -3900,7 +3900,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -3922,7 +3922,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4181,7 +4181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4277,7 +4277,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4381,7 +4381,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4465,7 +4465,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4484,7 +4484,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -4504,7 +4504,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -4536,7 +4536,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4579,7 +4579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4721,7 +4721,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4806,7 +4806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4852,7 +4852,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4898,7 +4898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4924,7 +4924,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4950,7 +4950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5024,7 +5024,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5137,7 +5137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/Weihenstephan.TM.json
+++ b/wot-codegen/opc-output-integrated/Weihenstephan.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSBaseObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSAlarmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSWarningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSWarningType",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSBaseStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSExecuteStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSHeldStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSHeldStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSSuspendedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSSuspendedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -222,7 +222,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -243,7 +243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -385,7 +385,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -470,7 +470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -516,7 +516,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -562,7 +562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -720,7 +720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -890,7 +890,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1123,7 +1123,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=342",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -1132,7 +1132,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1149,7 +1149,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {

--- a/wot-codegen/opc-output-integrated/WireHarness.TM.json
+++ b/wot-codegen/opc-output-integrated/WireHarness.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_ArticleSpecManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.ArticleSpecManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,14 +40,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArticleSpec" ],
           "properties": {
             "ArticleSpec": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -85,7 +85,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -111,7 +111,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -133,7 +133,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -178,14 +178,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArticleSpec" ],
           "properties": {
             "ArticleSpec": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -223,7 +223,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -249,7 +249,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -271,7 +271,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -321,7 +321,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -359,7 +359,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -385,7 +385,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -407,7 +407,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -462,7 +462,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -500,7 +500,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -526,7 +526,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -548,7 +548,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -599,7 +599,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_ProductFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.ProductFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -611,7 +611,7 @@
     "schemaDefinitions": {
       "JobResult": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobResult",
         "const": {
           "Unknown": 0,
           "Successful": 1,
@@ -777,7 +777,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "title": "JobResult",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobResult",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -808,7 +808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_RunCompleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.RunCompleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -977,7 +977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1033,7 +1033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_PartManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.PartManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1065,14 +1065,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Part" ],
           "properties": {
             "Part": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1110,7 +1110,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1136,7 +1136,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1158,7 +1158,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1203,7 +1203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6028",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TypeNodeId" ],
           "properties": {
             "TypeNodeId": {
@@ -1213,7 +1213,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6034",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Parts" ],
           "properties": {
             "Parts": {
@@ -1222,7 +1222,7 @@
                 "title": "ISA95MaterialDataType",
                 "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                 "properties": {
                   "MaterialClassID": {
                     "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1260,7 +1260,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1286,7 +1286,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -1308,7 +1308,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1354,14 +1354,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Part" ],
           "properties": {
             "Part": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1399,7 +1399,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1425,7 +1425,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1447,7 +1447,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1497,7 +1497,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1535,7 +1535,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1561,7 +1561,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1583,7 +1583,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1635,7 +1635,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1673,7 +1673,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1699,7 +1699,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1721,7 +1721,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1773,7 +1773,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1811,7 +1811,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1837,7 +1837,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1859,7 +1859,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1911,7 +1911,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1949,7 +1949,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1975,7 +1975,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1997,7 +1997,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2052,7 +2052,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2090,7 +2090,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2116,7 +2116,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2138,7 +2138,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2186,7 +2186,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2224,7 +2224,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2250,7 +2250,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2272,7 +2272,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2320,7 +2320,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2358,7 +2358,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2384,7 +2384,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2406,7 +2406,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2454,7 +2454,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2492,7 +2492,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2518,7 +2518,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2540,7 +2540,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2591,7 +2591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessJobOrderReceiverSubStatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessJobOrderReceiverSubStatesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2607,7 +2607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6021",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2625,7 +2625,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2648,7 +2648,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2666,7 +2666,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2689,7 +2689,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2707,7 +2707,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2730,7 +2730,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6103",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2748,7 +2748,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6104",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2771,7 +2771,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2789,7 +2789,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2812,7 +2812,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6105",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2830,7 +2830,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6106",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2853,14 +2853,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6107",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -2881,7 +2881,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2899,7 +2899,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2921,7 +2921,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2976,7 +2976,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -2998,7 +2998,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3034,7 +3034,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3061,7 +3061,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3087,7 +3087,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3109,7 +3109,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3148,7 +3148,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3175,7 +3175,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3201,7 +3201,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3223,7 +3223,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3262,7 +3262,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3289,7 +3289,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3315,7 +3315,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3337,7 +3337,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3376,7 +3376,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3414,7 +3414,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3440,7 +3440,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3462,7 +3462,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3507,7 +3507,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -3541,7 +3541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3586,7 +3586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -3607,7 +3607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3703,7 +3703,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -3807,7 +3807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3833,7 +3833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3975,7 +3975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4060,7 +4060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4106,7 +4106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4152,7 +4152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4234,7 +4234,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4486,7 +4486,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4557,7 +4557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverSubStatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverSubStatesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4722,7 +4722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4864,7 +4864,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4882,7 +4882,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4905,7 +4905,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4923,7 +4923,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4946,7 +4946,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4964,7 +4964,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4987,7 +4987,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5005,7 +5005,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5028,7 +5028,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5046,7 +5046,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5069,7 +5069,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5087,7 +5087,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5110,7 +5110,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5128,7 +5128,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5151,7 +5151,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5169,7 +5169,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5192,14 +5192,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5220,7 +5220,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5238,7 +5238,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5260,7 +5260,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5315,7 +5315,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -5337,7 +5337,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5373,7 +5373,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5400,7 +5400,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5426,7 +5426,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5448,7 +5448,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5487,7 +5487,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5514,7 +5514,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5540,7 +5540,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5562,7 +5562,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5601,7 +5601,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5628,7 +5628,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5654,7 +5654,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5676,7 +5676,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5715,7 +5715,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -5753,7 +5753,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5779,7 +5779,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5801,7 +5801,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5846,7 +5846,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5869,14 +5869,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5897,7 +5897,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5915,7 +5915,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5937,7 +5937,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5992,7 +5992,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6014,7 +6014,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6050,7 +6050,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6077,7 +6077,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6103,7 +6103,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6125,7 +6125,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6164,7 +6164,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6191,7 +6191,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6217,7 +6217,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6239,7 +6239,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6278,7 +6278,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6305,7 +6305,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6331,7 +6331,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6353,7 +6353,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6392,7 +6392,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -6430,7 +6430,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6456,7 +6456,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6478,7 +6478,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6523,7 +6523,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -6546,14 +6546,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -6574,7 +6574,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6592,7 +6592,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6614,7 +6614,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6669,7 +6669,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6691,7 +6691,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6727,7 +6727,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6754,7 +6754,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6780,7 +6780,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6802,7 +6802,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6841,7 +6841,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6868,7 +6868,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6894,7 +6894,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6916,7 +6916,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6955,7 +6955,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6982,7 +6982,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7008,7 +7008,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7030,7 +7030,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7069,7 +7069,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7107,7 +7107,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7133,7 +7133,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7155,7 +7155,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7200,7 +7200,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -7245,14 +7245,14 @@
           "title": "ISA95JobOrderAndStateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
           "required": [ "JobOrder", "State" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -7273,7 +7273,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7291,7 +7291,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7313,7 +7313,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7368,7 +7368,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -7390,7 +7390,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7426,7 +7426,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7453,7 +7453,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7479,7 +7479,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7501,7 +7501,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7540,7 +7540,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7567,7 +7567,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7593,7 +7593,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7615,7 +7615,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7654,7 +7654,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7681,7 +7681,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7707,7 +7707,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7729,7 +7729,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7768,7 +7768,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7806,7 +7806,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7832,7 +7832,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7854,7 +7854,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7895,14 +7895,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -7910,7 +7910,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -8040,7 +8040,7 @@
           "title": "ISA95WorkMasterDataType",
           "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -8058,7 +8058,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -8080,7 +8080,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -8148,14 +8148,14 @@
             "title": "ISA95JobOrderAndStateDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
             "required": [ "JobOrder", "State" ],
             "properties": {
               "JobOrder": {
                 "title": "ISA95JobOrderDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
                 "required": [ "JobOrderID" ],
                 "properties": {
                   "JobOrderID": {
@@ -8176,7 +8176,7 @@
                       "title": "ISA95WorkMasterDataType",
                       "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8194,7 +8194,7 @@
                             "title": "ISA95ParameterDataType",
                             "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8216,7 +8216,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8271,7 +8271,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -8293,7 +8293,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8329,7 +8329,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8356,7 +8356,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8382,7 +8382,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8404,7 +8404,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8443,7 +8443,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8470,7 +8470,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8496,7 +8496,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8518,7 +8518,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8557,7 +8557,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8584,7 +8584,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8610,7 +8610,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8632,7 +8632,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8671,7 +8671,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -8709,7 +8709,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8735,7 +8735,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8757,7 +8757,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8798,14 +8798,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -8813,7 +8813,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -8934,7 +8934,7 @@
             "title": "ISA95WorkMasterDataType",
             "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
             "required": [ "ID" ],
             "properties": {
               "ID": {
@@ -8952,7 +8952,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -8974,7 +8974,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -9025,7 +9025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95PrepareStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PrepareStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9099,7 +9099,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95EndedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EndedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9143,7 +9143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95InterruptedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95InterruptedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/WoT-Con.TM.json
+++ b/wot-codegen/opc-output-integrated/WoT-Con.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetConnectionManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetConnectionManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36,7 +36,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=76",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetEndpoint" ],
           "properties": {
             "AssetEndpoint": {
@@ -46,7 +46,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=77",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Success", "Status" ],
           "properties": {
             "Success": {
@@ -69,7 +69,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=27",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetName" ],
           "properties": {
             "AssetName": {
@@ -79,7 +79,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -99,7 +99,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=50",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetName", "AssetEndpoint" ],
           "properties": {
             "AssetName": {
@@ -112,7 +112,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -132,7 +132,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=30",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -152,7 +152,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=48",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetEndpoints" ],
           "properties": {
             "AssetEndpoints": {
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=105",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -260,7 +260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_IWoTAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.IWoTAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -311,7 +311,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=110",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -326,7 +326,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -359,7 +359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -380,7 +380,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -406,7 +406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -427,7 +427,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -448,7 +448,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -460,7 +460,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -481,7 +481,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -493,7 +493,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -514,7 +514,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -531,7 +531,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -551,7 +551,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -577,7 +577,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {

--- a/wot-codegen/opc-output-integrated/Woodworking.TM.json
+++ b/wot-codegen/opc-output-integrated/Woodworking.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwAlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwAlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -76,14 +76,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -196,7 +196,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -293,7 +293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwAcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwAcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -305,7 +305,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -361,14 +361,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -481,7 +481,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -578,7 +578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -590,7 +590,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -646,14 +646,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -766,7 +766,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -863,7 +863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwBaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwBaseEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -875,7 +875,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -931,14 +931,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -1051,7 +1051,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1148,7 +1148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwBaseStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwBaseStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1192,7 +1192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwEventMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwEventMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1203,7 +1203,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -1259,14 +1259,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -1379,7 +1379,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1476,7 +1476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1514,7 +1514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwSubUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwSubUnitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1546,7 +1546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitFlagsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitFlagsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2284,7 +2284,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitOverviewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitOverviewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2295,7 +2295,7 @@
     "schemaDefinitions": {
       "WwUnitModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -2334,7 +2334,7 @@
       },
       "WwUnitStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
         "const": {
           "OFFLINE": 0,
           "STANDBY": 1,
@@ -2386,7 +2386,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwUnitModeEnumeration",
         "description": "The CurrentMode Variable provides the generalized mode of the component.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2403,7 +2403,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwUnitStateEnumeration",
         "description": "The CurrentState Variable provides the generalized state of the component.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2423,7 +2423,7 @@
         "data": {
           "title": "WwUnitModeEnumeration",
           "description": "The CurrentMode Variable provides the generalized mode of the component.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2441,7 +2441,7 @@
         "data": {
           "title": "WwUnitStateEnumeration",
           "description": "The CurrentState Variable provides the generalized state of the component.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2465,7 +2465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitValuesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3588,7 +3588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwEventsDispatcherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventsDispatcherType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3614,7 +3614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3665,7 +3665,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3704,7 +3704,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -3735,7 +3735,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3763,7 +3763,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3791,7 +3791,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3828,7 +3828,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -3856,7 +3856,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4181,7 +4181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4208,7 +4208,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4233,7 +4233,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4339,7 +4339,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4366,7 +4366,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -4391,7 +4391,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -4413,7 +4413,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -4672,7 +4672,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4768,7 +4768,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4872,7 +4872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -4893,7 +4893,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4977,7 +4977,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -4996,7 +4996,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -5016,7 +5016,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -5048,7 +5048,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -5091,7 +5091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5233,7 +5233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5318,7 +5318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5364,7 +5364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5410,7 +5410,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5436,7 +5436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5462,7 +5462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/isa95-jobcontrol.TM.json
+++ b/wot-codegen/opc-output-integrated/isa95-jobcontrol.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderStatusEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderStatusEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -39,7 +39,7 @@
         "title": "ISA95JobOrderDataType",
         "description": "Defines the information needed to schedule and execute a job.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
         "required": [ "JobOrderID" ],
         "properties": {
           "JobOrderID": {
@@ -60,7 +60,7 @@
               "title": "ISA95WorkMasterDataType",
               "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -78,7 +78,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -100,7 +100,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -155,7 +155,7 @@
               "title": "ISA95ParameterDataType",
               "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -177,7 +177,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the value",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -213,7 +213,7 @@
               "title": "ISA95PersonnelDataType",
               "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -240,7 +240,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -266,7 +266,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -288,7 +288,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -327,7 +327,7 @@
               "title": "ISA95EquipmentDataType",
               "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -354,7 +354,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -380,7 +380,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -402,7 +402,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -441,7 +441,7 @@
               "title": "ISA95PhysicalAssetDataType",
               "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -468,7 +468,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -494,7 +494,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -516,7 +516,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -555,7 +555,7 @@
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -593,7 +593,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -619,7 +619,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -641,7 +641,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -693,7 +693,7 @@
         "title": "ISA95JobResponseDataType",
         "description": "Defines the information needed to schedule and execute a job.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
         "required": [ "JobResponseID", "JobOrderID", "JobState" ],
         "properties": {
           "JobResponseID": {
@@ -725,14 +725,14 @@
               "title": "ISA95StateDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
               "required": [ "BrowsePath", "StateText", "StateNumber" ],
               "properties": {
                 "BrowsePath": {
                   "title": "RelativePath",
                   "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                  "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -740,7 +740,7 @@
                       "items": {
                         "title": "RelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
@@ -780,7 +780,7 @@
               "title": "ISA95ParameterDataType",
               "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -802,7 +802,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the value",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -838,7 +838,7 @@
               "title": "ISA95PersonnelDataType",
               "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -865,7 +865,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -891,7 +891,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -913,7 +913,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -952,7 +952,7 @@
               "title": "ISA95EquipmentDataType",
               "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -979,7 +979,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1005,7 +1005,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1027,7 +1027,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1066,7 +1066,7 @@
               "title": "ISA95PhysicalAssetDataType",
               "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -1093,7 +1093,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1119,7 +1119,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1141,7 +1141,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1180,7 +1180,7 @@
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1218,7 +1218,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1244,7 +1244,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1266,7 +1266,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1320,14 +1320,14 @@
           "title": "ISA95StateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
           "required": [ "BrowsePath", "StateText", "StateNumber" ],
           "properties": {
             "BrowsePath": {
               "title": "RelativePath",
               "description": "The browse path of substates. Shall be null when the top-level state is represented.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+              "dov:typeRef": "org.opcfoundation.UA.RelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -1335,7 +1335,7 @@
                   "items": {
                     "title": "RelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
@@ -1394,7 +1394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobResponseProviderObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseProviderObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1427,7 +1427,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6042",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID" ],
           "properties": {
             "JobOrderID": {
@@ -1438,14 +1438,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponse", "ReturnStatus" ],
           "properties": {
             "JobResponse": {
               "title": "ISA95JobResponseDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
               "required": [ "JobResponseID", "JobOrderID", "JobState" ],
               "properties": {
                 "JobResponseID": {
@@ -1477,14 +1477,14 @@
                     "title": "ISA95StateDataType",
                     "description": "Defines the information needed to schedule and execute a job.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                     "required": [ "BrowsePath", "StateText", "StateNumber" ],
                     "properties": {
                       "BrowsePath": {
                         "title": "RelativePath",
                         "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                         "required": [ "Elements" ],
                         "properties": {
                           "Elements": {
@@ -1492,7 +1492,7 @@
                             "items": {
                               "title": "RelativePathElement",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                              "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                               "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                               "properties": {
                                 "ReferenceTypeId": {
@@ -1532,7 +1532,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1554,7 +1554,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1590,7 +1590,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1617,7 +1617,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1643,7 +1643,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1665,7 +1665,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1704,7 +1704,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1731,7 +1731,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1757,7 +1757,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1779,7 +1779,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1818,7 +1818,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1845,7 +1845,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1871,7 +1871,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1893,7 +1893,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1932,7 +1932,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1970,7 +1970,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1996,7 +1996,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2018,7 +2018,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2072,7 +2072,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6016",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderState" ],
           "properties": {
             "JobOrderState": {
@@ -2082,14 +2082,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -2097,7 +2097,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -2134,7 +2134,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6017",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponses", "ReturnStatus" ],
           "properties": {
             "JobResponses": {
@@ -2144,7 +2144,7 @@
                 "title": "ISA95JobResponseDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
                 "required": [ "JobResponseID", "JobOrderID", "JobState" ],
                 "properties": {
                   "JobResponseID": {
@@ -2176,14 +2176,14 @@
                       "title": "ISA95StateDataType",
                       "description": "Defines the information needed to schedule and execute a job.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                       "required": [ "BrowsePath", "StateText", "StateNumber" ],
                       "properties": {
                         "BrowsePath": {
                           "title": "RelativePath",
                           "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                           "required": [ "Elements" ],
                           "properties": {
                             "Elements": {
@@ -2191,7 +2191,7 @@
                               "items": {
                                 "title": "RelativePathElement",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                                "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                                 "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                                 "properties": {
                                   "ReferenceTypeId": {
@@ -2231,7 +2231,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -2253,7 +2253,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2289,7 +2289,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2316,7 +2316,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2342,7 +2342,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2364,7 +2364,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2403,7 +2403,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2430,7 +2430,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2456,7 +2456,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2478,7 +2478,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2517,7 +2517,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2544,7 +2544,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2570,7 +2570,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2592,7 +2592,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2631,7 +2631,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2669,7 +2669,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2695,7 +2695,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2717,7 +2717,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2777,7 +2777,7 @@
           "title": "ISA95JobResponseDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
           "required": [ "JobResponseID", "JobOrderID", "JobState" ],
           "properties": {
             "JobResponseID": {
@@ -2809,14 +2809,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -2824,7 +2824,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -2864,7 +2864,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -2886,7 +2886,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2922,7 +2922,7 @@
                 "title": "ISA95PersonnelDataType",
                 "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -2949,7 +2949,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2975,7 +2975,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -2997,7 +2997,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3036,7 +3036,7 @@
                 "title": "ISA95EquipmentDataType",
                 "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -3063,7 +3063,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3089,7 +3089,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3111,7 +3111,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3150,7 +3150,7 @@
                 "title": "ISA95PhysicalAssetDataType",
                 "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -3177,7 +3177,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3203,7 +3203,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3225,7 +3225,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3264,7 +3264,7 @@
                 "title": "ISA95MaterialDataType",
                 "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                 "properties": {
                   "MaterialClassID": {
                     "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3302,7 +3302,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3328,7 +3328,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3350,7 +3350,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3408,7 +3408,7 @@
             "title": "ISA95JobResponseDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
             "required": [ "JobResponseID", "JobOrderID", "JobState" ],
             "properties": {
               "JobResponseID": {
@@ -3440,14 +3440,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -3455,7 +3455,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -3495,7 +3495,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -3517,7 +3517,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3553,7 +3553,7 @@
                   "title": "ISA95PersonnelDataType",
                   "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3580,7 +3580,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3606,7 +3606,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3628,7 +3628,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3667,7 +3667,7 @@
                   "title": "ISA95EquipmentDataType",
                   "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3694,7 +3694,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3720,7 +3720,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3742,7 +3742,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3781,7 +3781,7 @@
                   "title": "ISA95PhysicalAssetDataType",
                   "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3808,7 +3808,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3834,7 +3834,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3856,7 +3856,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3895,7 +3895,7 @@
                   "title": "ISA95MaterialDataType",
                   "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                   "properties": {
                     "MaterialClassID": {
                       "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3933,7 +3933,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3959,7 +3959,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3981,7 +3981,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -4035,7 +4035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobResponseReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4051,14 +4051,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6044",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobResponse" ],
           "properties": {
             "JobResponse": {
               "title": "ISA95JobResponseDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
               "required": [ "JobResponseID", "JobOrderID", "JobState" ],
               "properties": {
                 "JobResponseID": {
@@ -4090,14 +4090,14 @@
                     "title": "ISA95StateDataType",
                     "description": "Defines the information needed to schedule and execute a job.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                     "required": [ "BrowsePath", "StateText", "StateNumber" ],
                     "properties": {
                       "BrowsePath": {
                         "title": "RelativePath",
                         "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                         "required": [ "Elements" ],
                         "properties": {
                           "Elements": {
@@ -4105,7 +4105,7 @@
                             "items": {
                               "title": "RelativePathElement",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                              "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                               "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                               "properties": {
                                 "ReferenceTypeId": {
@@ -4145,7 +4145,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -4167,7 +4167,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4203,7 +4203,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4230,7 +4230,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4256,7 +4256,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4278,7 +4278,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4317,7 +4317,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4344,7 +4344,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4370,7 +4370,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4392,7 +4392,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4431,7 +4431,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4458,7 +4458,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4484,7 +4484,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4506,7 +4506,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4545,7 +4545,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -4583,7 +4583,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4609,7 +4609,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4631,7 +4631,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4669,7 +4669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6045",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4703,7 +4703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95EndedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EndedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4747,7 +4747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95InterruptedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95InterruptedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4797,7 +4797,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4939,7 +4939,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4957,7 +4957,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4980,7 +4980,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4998,7 +4998,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5021,7 +5021,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5039,7 +5039,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5062,7 +5062,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5080,7 +5080,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5103,7 +5103,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5121,7 +5121,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5144,7 +5144,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5162,7 +5162,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5185,7 +5185,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5203,7 +5203,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5226,7 +5226,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5244,7 +5244,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5267,14 +5267,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5295,7 +5295,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5313,7 +5313,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5335,7 +5335,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5390,7 +5390,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -5412,7 +5412,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5448,7 +5448,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5475,7 +5475,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5501,7 +5501,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5523,7 +5523,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5562,7 +5562,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5589,7 +5589,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5615,7 +5615,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5637,7 +5637,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5676,7 +5676,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5703,7 +5703,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5729,7 +5729,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5751,7 +5751,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5790,7 +5790,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -5828,7 +5828,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5854,7 +5854,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5876,7 +5876,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5921,7 +5921,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5944,14 +5944,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5972,7 +5972,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5990,7 +5990,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6012,7 +6012,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6067,7 +6067,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6089,7 +6089,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6125,7 +6125,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6152,7 +6152,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6178,7 +6178,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6200,7 +6200,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6239,7 +6239,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6266,7 +6266,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6292,7 +6292,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6314,7 +6314,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6353,7 +6353,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6380,7 +6380,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6406,7 +6406,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6428,7 +6428,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6467,7 +6467,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -6505,7 +6505,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6531,7 +6531,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6553,7 +6553,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6598,7 +6598,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -6621,14 +6621,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -6649,7 +6649,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6667,7 +6667,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6689,7 +6689,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6744,7 +6744,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6766,7 +6766,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6802,7 +6802,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6829,7 +6829,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6855,7 +6855,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6877,7 +6877,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6916,7 +6916,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6943,7 +6943,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6969,7 +6969,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6991,7 +6991,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7030,7 +7030,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7057,7 +7057,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7083,7 +7083,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7105,7 +7105,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7144,7 +7144,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7182,7 +7182,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7208,7 +7208,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7230,7 +7230,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7275,7 +7275,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -7320,14 +7320,14 @@
           "title": "ISA95JobOrderAndStateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
           "required": [ "JobOrder", "State" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -7348,7 +7348,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7366,7 +7366,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7388,7 +7388,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7443,7 +7443,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -7465,7 +7465,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7501,7 +7501,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7528,7 +7528,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7554,7 +7554,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7576,7 +7576,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7615,7 +7615,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7642,7 +7642,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7668,7 +7668,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7690,7 +7690,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7729,7 +7729,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7756,7 +7756,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7782,7 +7782,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7804,7 +7804,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7843,7 +7843,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7881,7 +7881,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7907,7 +7907,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7929,7 +7929,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7970,14 +7970,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -7985,7 +7985,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -8115,7 +8115,7 @@
           "title": "ISA95WorkMasterDataType",
           "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -8133,7 +8133,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -8155,7 +8155,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -8223,14 +8223,14 @@
             "title": "ISA95JobOrderAndStateDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
             "required": [ "JobOrder", "State" ],
             "properties": {
               "JobOrder": {
                 "title": "ISA95JobOrderDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
                 "required": [ "JobOrderID" ],
                 "properties": {
                   "JobOrderID": {
@@ -8251,7 +8251,7 @@
                       "title": "ISA95WorkMasterDataType",
                       "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8269,7 +8269,7 @@
                             "title": "ISA95ParameterDataType",
                             "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8291,7 +8291,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8346,7 +8346,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -8368,7 +8368,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8404,7 +8404,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8431,7 +8431,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8457,7 +8457,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8479,7 +8479,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8518,7 +8518,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8545,7 +8545,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8571,7 +8571,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8593,7 +8593,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8632,7 +8632,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8659,7 +8659,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8685,7 +8685,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8707,7 +8707,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8746,7 +8746,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -8784,7 +8784,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8810,7 +8810,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8832,7 +8832,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8873,14 +8873,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -8888,7 +8888,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -9009,7 +9009,7 @@
             "title": "ISA95WorkMasterDataType",
             "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
             "required": [ "ID" ],
             "properties": {
               "ID": {
@@ -9027,7 +9027,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -9049,7 +9049,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -9100,7 +9100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverSubStatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverSubStatesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9265,7 +9265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95PrepareStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PrepareStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9339,7 +9339,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9435,7 +9435,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -9539,7 +9539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -9560,7 +9560,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9702,7 +9702,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9787,7 +9787,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9833,7 +9833,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-integrated/sercos.TM.json
+++ b/wot-codegen/opc-output-integrated/sercos.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6012",
+    "dov:typeRef": "org.sercos.UA.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosProfileType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1002",
+    "dov:typeRef": "org.sercos.UA.SercosProfileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosClassType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1003",
+    "dov:typeRef": "org.sercos.UA.SercosClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosFunctionGroupType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1004",
+    "dov:typeRef": "org.sercos.UA.SercosFunctionGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosDeviceType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1001",
+    "dov:typeRef": "org.sercos.UA.SercosDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -163,7 +163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_ProfileSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6075",
+    "dov:typeRef": "org.sercos.UA.ProfileSet",
     "dov:isComposite": true,
     "links": [
       {
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_ClassSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6077",
+    "dov:typeRef": "org.sercos.UA.ClassSet",
     "dov:isComposite": true,
     "links": [
       {
@@ -229,7 +229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_FunctionGroupSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6079",
+    "dov:typeRef": "org.sercos.UA.FunctionGroupSet",
     "dov:isComposite": true,
     "links": [
       {
@@ -262,7 +262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -288,7 +288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -309,7 +309,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -356,7 +356,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -418,7 +418,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -571,7 +571,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -595,7 +595,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -798,7 +798,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -854,7 +854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -925,7 +925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -947,7 +947,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -969,7 +969,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -991,7 +991,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -1001,7 +1001,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -1023,7 +1023,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -1116,7 +1116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1161,7 +1161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1187,7 +1187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/ADI.TM.json
+++ b/wot-codegen/opc-output-simple/ADI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -88,7 +88,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserDeviceStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserDeviceStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -204,7 +204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelOperatingStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelOperatingStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -304,7 +304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelLocalStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelLocalStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -330,7 +330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelMaintenanceStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelMaintenanceStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -356,7 +356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -484,7 +484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannelOperatingExecuteStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=8964",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannelOperatingExecuteStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -510,7 +510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannel_OperatingModeSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannel_OperatingModeSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -968,7 +968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AnalyserChannel_OperatingModeExecuteSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AnalyserChannel_OperatingModeExecuteSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1342,7 +1342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_StreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.StreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1422,7 +1422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1485,7 +1485,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MassSpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MassSpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1512,7 +1512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ParticleSizeMonitorDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ParticleSizeMonitorDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1551,7 +1551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AcousticSpectrometerDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AcousticSpectrometerDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1578,7 +1578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ChromatographDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ChromatographDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1605,7 +1605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MNRDeviceStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MNRDeviceStreamType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1632,7 +1632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1671,7 +1671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ParticleSizeMonitorDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ParticleSizeMonitorDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1698,7 +1698,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_ChromatographDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.ChromatographDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1725,7 +1725,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_MassSpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.MassSpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1752,7 +1752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AcousticSpectrometerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AcousticSpectrometerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1779,7 +1779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_NMRDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.NMRDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1806,7 +1806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessorySlotType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessorySlotType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1877,7 +1877,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessorySlotStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessorySlotStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2011,7 +2011,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_AccessoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.AccessoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2088,7 +2088,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_DetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9350",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.DetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2115,7 +2115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SmartSamplingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9359",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SmartSamplingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2142,7 +2142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_SourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=9368",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.SourceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2169,7 +2169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ADI_GcOvenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ADI/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.ADI.GcOvenType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/AMB.TM.json
+++ b/wot-codegen/opc-output-simple/AMB.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_CalibrationDueConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.CalibrationDueConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ExternalCheckConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ExternalCheckConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_FlashUpdateInProgressConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.FlashUpdateInProgressConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ImprovementConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ImprovementConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_InspectionConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.InspectionConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_RepairConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.RepairConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ServicingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ServicingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_BadConfigurationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.BadConfigurationConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_ConnectionFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.ConnectionFailureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_FlashUpdateFailedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.FlashUpdateFailedConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -268,7 +268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OutOfResourcesConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OutOfResourcesConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -294,7 +294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OutOfMemoryConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OutOfMemoryConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -320,7 +320,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_OverTemperatureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.OverTemperatureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -346,7 +346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_SelfTestFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.SelfTestFailureConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -372,7 +372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_IMaintenanceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.IMaintenanceEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -389,7 +389,7 @@
     "schemaDefinitions": {
       "MaintenanceMethodEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceMethodEnum",
         "const": {
           "Local": 0,
           "Remote": 1
@@ -462,7 +462,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AMB/",
         "title": "MaintenanceMethodEnum",
         "description": "Information about the planned or used maintenance method. The content may change during the different MaintenanceStates. By accessing the history of Events a Client can distinguish between the planned and actual used maintenance method during the maintenance activity.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceMethodEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -485,7 +485,7 @@
         "title": "NameNodeIdDataType",
         "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
         "required": [ "Name", "NodeId" ],
         "properties": {
           "Name": {
@@ -519,7 +519,7 @@
           "title": "NameNodeIdDataType",
           "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
           "required": [ "Name", "NodeId" ],
           "properties": {
             "Name": {
@@ -554,7 +554,7 @@
           "title": "NameNodeIdDataType",
           "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
           "required": [ "Name", "NodeId" ],
           "properties": {
             "Name": {
@@ -605,7 +605,7 @@
         "title": "NameNodeIdDataType",
         "description": "A human-readable name of something plus optionally the NodeId in case the something is represented in the AddressSpace",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AMB.NameNodeIdDataType",
         "required": [ "Name", "NodeId" ],
         "properties": {
           "Name": {
@@ -644,7 +644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_IRootCauseIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.IRootCauseIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -677,7 +677,7 @@
           "title": "RootCauseDataType",
           "description": "Root cause of an alarm",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.AMB.RootCauseDataType",
           "required": [ "RootCauseId", "RootCause" ],
           "properties": {
             "RootCauseId": {
@@ -717,7 +717,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_DocumentationLinksType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.DocumentationLinksType",
     "dov:isComposite": true,
     "links": [
       {
@@ -751,7 +751,7 @@
         "description": "Method to add an end-user specific link that is stored persistently in the server.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LinkToExternalSource", "BrowseName", "DisplayName", "Description" ],
           "properties": {
             "LinkToExternalSource": {
@@ -774,7 +774,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LinkVariable" ],
           "properties": {
             "LinkVariable": {
@@ -796,7 +796,7 @@
         "description": "Method to remove an end-user specific link that is managed in the server.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariableToBeDeleted" ],
           "properties": {
             "VariableToBeDeleted": {
@@ -878,7 +878,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMB_MaintenanceEventStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.AMB.MaintenanceEventStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/AMLBaseTypes.TM.json
+++ b/wot-codegen/opc-output-simple/AMLBaseTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXBasicObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXBasicObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -54,7 +54,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -105,7 +105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_CAEXObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AML.CAEXObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -151,7 +151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -178,7 +178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseRole",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseRole",
     "dov:isComposite": true,
     "links": [
       {
@@ -205,7 +205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLBaseTypes_AutomationMLBaseSystemUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AML/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AML.AutomationMLBaseSystemUnit",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/AMLLibs.TM.json
+++ b/wot-codegen/opc-output-simple/AMLLibs.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AutomationMLBaseInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.AutomationMLBaseInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Order",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=25",
+    "dov:typeRef": "org.opcfoundation.UA.Order",
     "dov:isComposite": true,
     "links": [
       {
@@ -154,7 +154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PortConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.PortConnector",
     "links": [
       {
         "rel": "tm:extends",
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_InterlockingConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.InterlockingConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -269,7 +269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PPRConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.PPRConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -327,7 +327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ExternalDataConnector",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.ExternalDataConnector",
     "dov:isComposite": true,
     "links": [
       {
@@ -415,7 +415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Communication_1",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.Communication",
     "dov:isComposite": true,
     "links": [
       {
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AttachmentInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.AttachmentInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_COLLADAInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.COLLADAInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -589,7 +589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLCopenXMLInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.PLCopenXMLInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -647,7 +647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_LogicInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.LogicInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -705,7 +705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_VariableInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.VariableInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -763,7 +763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_InterlockingVariableInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=64",
+    "dov:typeRef": "org.opcfoundation.UA.InterlockingVariableInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -851,7 +851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_SignalInterface",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=71",
+    "dov:typeRef": "org.opcfoundation.UA.SignalInterface",
     "dov:isComposite": true,
     "links": [
       {
@@ -909,7 +909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AutomationMLBaseRole",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=74",
+    "dov:typeRef": "org.opcfoundation.UA.AutomationMLBaseRole",
     "dov:isComposite": true,
     "links": [
       {
@@ -967,7 +967,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Group",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=77",
+    "dov:typeRef": "org.opcfoundation.UA.Group",
     "dov:isComposite": true,
     "links": [
       {
@@ -1055,7 +1055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Facet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=80",
+    "dov:typeRef": "org.opcfoundation.UA.Facet",
     "dov:isComposite": true,
     "links": [
       {
@@ -1113,7 +1113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Port",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=83",
+    "dov:typeRef": "org.opcfoundation.UA.Port",
     "dov:isComposite": true,
     "links": [
       {
@@ -1321,7 +1321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Resource",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=86",
+    "dov:typeRef": "org.opcfoundation.UA.Resource",
     "dov:isComposite": true,
     "links": [
       {
@@ -1379,7 +1379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Product",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=89",
+    "dov:typeRef": "org.opcfoundation.UA.Product",
     "dov:isComposite": true,
     "links": [
       {
@@ -1437,7 +1437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Process",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=92",
+    "dov:typeRef": "org.opcfoundation.UA.Process",
     "dov:isComposite": true,
     "links": [
       {
@@ -1495,7 +1495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Structure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=95",
+    "dov:typeRef": "org.opcfoundation.UA.Structure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1553,7 +1553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PropertySet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=98",
+    "dov:typeRef": "org.opcfoundation.UA.PropertySet",
     "dov:isComposite": true,
     "links": [
       {
@@ -1611,7 +1611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Frame",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=101",
+    "dov:typeRef": "org.opcfoundation.UA.Frame",
     "dov:isComposite": true,
     "links": [
       {
@@ -1669,7 +1669,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_SignalGroup",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=107",
+    "dov:typeRef": "org.opcfoundation.UA.SignalGroup",
     "dov:isComposite": true,
     "links": [
       {
@@ -1727,7 +1727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ComponentGroup",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=110",
+    "dov:typeRef": "org.opcfoundation.UA.ComponentGroup",
     "dov:isComposite": true,
     "links": [
       {
@@ -1785,7 +1785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=131",
+    "dov:typeRef": "org.opcfoundation.UA.ProductStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1843,7 +1843,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=134",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1901,7 +1901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ResourceStructure",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=137",
+    "dov:typeRef": "org.opcfoundation.UA.ResourceStructure",
     "dov:isComposite": true,
     "links": [
       {
@@ -1959,7 +1959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BatchManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=140",
+    "dov:typeRef": "org.opcfoundation.UA.BatchManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2017,7 +2017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ContManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=143",
+    "dov:typeRef": "org.opcfoundation.UA.ContManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2075,7 +2075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_DiscManufacturingEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=146",
+    "dov:typeRef": "org.opcfoundation.UA.DiscManufacturingEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2133,7 +2133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Transport",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=149",
+    "dov:typeRef": "org.opcfoundation.UA.Transport",
     "dov:isComposite": true,
     "links": [
       {
@@ -2191,7 +2191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Storage",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=152",
+    "dov:typeRef": "org.opcfoundation.UA.Storage",
     "dov:isComposite": true,
     "links": [
       {
@@ -2249,7 +2249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Fixture",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=155",
+    "dov:typeRef": "org.opcfoundation.UA.Fixture",
     "dov:isComposite": true,
     "links": [
       {
@@ -2307,7 +2307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Gate",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=158",
+    "dov:typeRef": "org.opcfoundation.UA.Gate",
     "dov:isComposite": true,
     "links": [
       {
@@ -2365,7 +2365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Robot",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=161",
+    "dov:typeRef": "org.opcfoundation.UA.Robot",
     "dov:isComposite": true,
     "links": [
       {
@@ -2423,7 +2423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Tool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=164",
+    "dov:typeRef": "org.opcfoundation.UA.Tool",
     "dov:isComposite": true,
     "links": [
       {
@@ -2481,7 +2481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Carrier",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=167",
+    "dov:typeRef": "org.opcfoundation.UA.Carrier",
     "dov:isComposite": true,
     "links": [
       {
@@ -2539,7 +2539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Machine",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=170",
+    "dov:typeRef": "org.opcfoundation.UA.Machine",
     "dov:isComposite": true,
     "links": [
       {
@@ -2597,7 +2597,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StaticObject",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=173",
+    "dov:typeRef": "org.opcfoundation.UA.StaticObject",
     "dov:isComposite": true,
     "links": [
       {
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=176",
+    "dov:typeRef": "org.opcfoundation.UA.ControlEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -2713,7 +2713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Communication_2",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=179",
+    "dov:typeRef": "org.opcfoundation.UA.Communication",
     "dov:isComposite": true,
     "links": [
       {
@@ -2771,7 +2771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlHardware",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=182",
+    "dov:typeRef": "org.opcfoundation.UA.ControlHardware",
     "dov:isComposite": true,
     "links": [
       {
@@ -2829,7 +2829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Sensor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=185",
+    "dov:typeRef": "org.opcfoundation.UA.Sensor",
     "dov:isComposite": true,
     "links": [
       {
@@ -2887,7 +2887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Actuator",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=188",
+    "dov:typeRef": "org.opcfoundation.UA.Actuator",
     "dov:isComposite": true,
     "links": [
       {
@@ -2945,7 +2945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Controller",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=191",
+    "dov:typeRef": "org.opcfoundation.UA.Controller",
     "dov:isComposite": true,
     "links": [
       {
@@ -3003,7 +3003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=194",
+    "dov:typeRef": "org.opcfoundation.UA.PC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3061,7 +3061,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_IPC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=197",
+    "dov:typeRef": "org.opcfoundation.UA.IPC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3119,7 +3119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_EmbeddedDevice",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=200",
+    "dov:typeRef": "org.opcfoundation.UA.EmbeddedDevice",
     "dov:isComposite": true,
     "links": [
       {
@@ -3177,7 +3177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Handheld",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=203",
+    "dov:typeRef": "org.opcfoundation.UA.Handheld",
     "dov:isComposite": true,
     "links": [
       {
@@ -3235,7 +3235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=206",
+    "dov:typeRef": "org.opcfoundation.UA.PLC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3293,7 +3293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_NC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=209",
+    "dov:typeRef": "org.opcfoundation.UA.NC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3351,7 +3351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_RC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=212",
+    "dov:typeRef": "org.opcfoundation.UA.RC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3409,7 +3409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PAC",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=215",
+    "dov:typeRef": "org.opcfoundation.UA.PAC",
     "dov:isComposite": true,
     "links": [
       {
@@ -3467,7 +3467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PLCFacet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=218",
+    "dov:typeRef": "org.opcfoundation.UA.PLCFacet",
     "dov:isComposite": true,
     "links": [
       {
@@ -3525,7 +3525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_HMIFacet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=221",
+    "dov:typeRef": "org.opcfoundation.UA.HMIFacet",
     "dov:isComposite": true,
     "links": [
       {
@@ -3583,7 +3583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Enterprise",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=224",
+    "dov:typeRef": "org.opcfoundation.UA.Enterprise",
     "dov:isComposite": true,
     "links": [
       {
@@ -3641,7 +3641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Site",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=227",
+    "dov:typeRef": "org.opcfoundation.UA.Site",
     "dov:isComposite": true,
     "links": [
       {
@@ -3699,7 +3699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Area",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=230",
+    "dov:typeRef": "org.opcfoundation.UA.Area",
     "dov:isComposite": true,
     "links": [
       {
@@ -3757,7 +3757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductionLine",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=233",
+    "dov:typeRef": "org.opcfoundation.UA.ProductionLine",
     "dov:isComposite": true,
     "links": [
       {
@@ -3815,7 +3815,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_WorkCell",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=236",
+    "dov:typeRef": "org.opcfoundation.UA.WorkCell",
     "dov:isComposite": true,
     "links": [
       {
@@ -3873,7 +3873,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessCell",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=239",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessCell",
     "dov:isComposite": true,
     "links": [
       {
@@ -3931,7 +3931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Unit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=242",
+    "dov:typeRef": "org.opcfoundation.UA.Unit",
     "dov:isComposite": true,
     "links": [
       {
@@ -3989,7 +3989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProductionUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=245",
+    "dov:typeRef": "org.opcfoundation.UA.ProductionUnit",
     "dov:isComposite": true,
     "links": [
       {
@@ -4047,7 +4047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StorageZone",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=248",
+    "dov:typeRef": "org.opcfoundation.UA.StorageZone",
     "dov:isComposite": true,
     "links": [
       {
@@ -4105,7 +4105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StorageUnit",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=251",
+    "dov:typeRef": "org.opcfoundation.UA.StorageUnit",
     "dov:isComposite": true,
     "links": [
       {
@@ -4163,7 +4163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Turntable",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=254",
+    "dov:typeRef": "org.opcfoundation.UA.Turntable",
     "dov:isComposite": true,
     "links": [
       {
@@ -4221,7 +4221,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Conveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=257",
+    "dov:typeRef": "org.opcfoundation.UA.Conveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -4279,7 +4279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_LiftingTable",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=260",
+    "dov:typeRef": "org.opcfoundation.UA.LiftingTable",
     "dov:isComposite": true,
     "links": [
       {
@@ -4337,7 +4337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_AGV",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=263",
+    "dov:typeRef": "org.opcfoundation.UA.AGV",
     "dov:isComposite": true,
     "links": [
       {
@@ -4395,7 +4395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Transposer",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=266",
+    "dov:typeRef": "org.opcfoundation.UA.Transposer",
     "dov:isComposite": true,
     "links": [
       {
@@ -4453,7 +4453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_CarrierHandlingSystem",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=269",
+    "dov:typeRef": "org.opcfoundation.UA.CarrierHandlingSystem",
     "dov:isComposite": true,
     "links": [
       {
@@ -4511,7 +4511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BodyStore",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=272",
+    "dov:typeRef": "org.opcfoundation.UA.BodyStore",
     "dov:isComposite": true,
     "links": [
       {
@@ -4569,7 +4569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Lift",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=275",
+    "dov:typeRef": "org.opcfoundation.UA.Lift",
     "dov:isComposite": true,
     "links": [
       {
@@ -4627,7 +4627,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Rollerbed",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=278",
+    "dov:typeRef": "org.opcfoundation.UA.Rollerbed",
     "dov:isComposite": true,
     "links": [
       {
@@ -4685,7 +4685,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_StationaryTool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=281",
+    "dov:typeRef": "org.opcfoundation.UA.StationaryTool",
     "dov:isComposite": true,
     "links": [
       {
@@ -4743,7 +4743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MovableTool",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=284",
+    "dov:typeRef": "org.opcfoundation.UA.MovableTool",
     "dov:isComposite": true,
     "links": [
       {
@@ -4801,7 +4801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ControlCabinet",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=287",
+    "dov:typeRef": "org.opcfoundation.UA.ControlCabinet",
     "dov:isComposite": true,
     "links": [
       {
@@ -4859,7 +4859,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_IODevice",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=290",
+    "dov:typeRef": "org.opcfoundation.UA.IODevice",
     "dov:isComposite": true,
     "links": [
       {
@@ -4917,7 +4917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_HMI",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=293",
+    "dov:typeRef": "org.opcfoundation.UA.HMI",
     "dov:isComposite": true,
     "links": [
       {
@@ -4975,7 +4975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ActuatingDrive",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=296",
+    "dov:typeRef": "org.opcfoundation.UA.ActuatingDrive",
     "dov:isComposite": true,
     "links": [
       {
@@ -5033,7 +5033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MotionController",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=299",
+    "dov:typeRef": "org.opcfoundation.UA.MotionController",
     "dov:isComposite": true,
     "links": [
       {
@@ -5091,7 +5091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Panel",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=302",
+    "dov:typeRef": "org.opcfoundation.UA.Panel",
     "dov:isComposite": true,
     "links": [
       {
@@ -5149,7 +5149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_MeasuringEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=305",
+    "dov:typeRef": "org.opcfoundation.UA.MeasuringEquipment",
     "dov:isComposite": true,
     "links": [
       {
@@ -5207,7 +5207,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Clamp",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=308",
+    "dov:typeRef": "org.opcfoundation.UA.Clamp",
     "dov:isComposite": true,
     "links": [
       {
@@ -5265,7 +5265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ProcessController",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=311",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessController",
     "dov:isComposite": true,
     "links": [
       {
@@ -5323,7 +5323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Loader",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=314",
+    "dov:typeRef": "org.opcfoundation.UA.Loader",
     "dov:isComposite": true,
     "links": [
       {
@@ -5381,7 +5381,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_Unloader",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=317",
+    "dov:typeRef": "org.opcfoundation.UA.Unloader",
     "dov:isComposite": true,
     "links": [
       {
@@ -5439,7 +5439,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_BeltConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=320",
+    "dov:typeRef": "org.opcfoundation.UA.BeltConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5497,7 +5497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_RollConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=323",
+    "dov:typeRef": "org.opcfoundation.UA.RollConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5555,7 +5555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_ChainConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=326",
+    "dov:typeRef": "org.opcfoundation.UA.ChainConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5613,7 +5613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_PalletConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=329",
+    "dov:typeRef": "org.opcfoundation.UA.PalletConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5671,7 +5671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_OverheadConveyor",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=332",
+    "dov:typeRef": "org.opcfoundation.UA.OverheadConveyor",
     "dov:isComposite": true,
     "links": [
       {
@@ -5729,7 +5729,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AMLLibs_WarningEquipment",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMLLibs/;i=335",
+    "dov:typeRef": "org.opcfoundation.UA.WarningEquipment",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/AdditiveManufacturing.TM.json
+++ b/wot-codegen/opc-output-simple/AdditiveManufacturing.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_EquipmentAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.EquipmentAMType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,7 +40,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_FeedstockListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -90,7 +90,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_FeedstockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockType",
     "links": [
       {
         "rel": "tm:extends",
@@ -101,7 +101,7 @@
     "schemaDefinitions": {
       "FeedstockFunction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
         "const": {
           "Undefined": 0,
           "Main": 1,
@@ -188,7 +188,7 @@
       "Function": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "FeedstockFunction",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -312,7 +312,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "data": {
           "title": "FeedstockFunction",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3000",
+          "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.FeedstockFunction",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_MachineIdentificationAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.MachineIdentificationAMType",
     "links": [
       {
         "rel": "tm:extends",
@@ -417,7 +417,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_AdditiveManufacturingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.AdditiveManufacturingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -462,7 +462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AdditiveManufacturing_ProcessValueAMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.ProcessValueAMType",
     "dov:isComposite": true,
     "links": [
       {
@@ -474,7 +474,7 @@
     "schemaDefinitions": {
       "SensorCategory": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorCategory",
         "const": {
           "MachineHealth": 0,
           "MaintenanceTracking": 1,
@@ -498,7 +498,7 @@
       },
       "SensorSeverity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorSeverity",
         "const": {
           "Info": 0,
           "Critical": 1
@@ -534,7 +534,7 @@
       "Category": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "SensorCategory",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorCategory",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -555,7 +555,7 @@
       "Severity": {
         "dov:namespace": "http://opcfoundation.org/UA/AdditiveManufacturing/",
         "title": "SensorSeverity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AdditiveManufacturing/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.AdditiveManufacturing.SensorSeverity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,

--- a/wot-codegen/opc-output-simple/AutoID.TM.json
+++ b/wot-codegen/opc-output-simple/AutoID.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdDiagnosticsEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdDiagnosticsEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -55,7 +55,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdAccessEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdAccessEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -84,7 +84,7 @@
           "title": "AccessResult",
           "description": "Result values of an AutoID Identifier access.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.AccessResult",
           "properties": {
             "CodeType": {
               "description": "Defines the format of Identifier as string.",
@@ -94,7 +94,7 @@
               "title": "ScanData",
               "description": "The AutoID Identifier (e.g. a code or a transponder) which was accessed by a command.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -106,7 +106,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -191,7 +191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidAccessEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidAccessEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -220,7 +220,7 @@
           "title": "RfidAccessResult",
           "description": "Additional result values of an Rfid Transponder access.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidAccessResult",
           "properties": {
             "CodeTypeRWData": {
               "description": "Defines the format of RWData as string.",
@@ -230,7 +230,7 @@
               "title": "ScanData",
               "description": "The user data which was written to / was read from the Rfid Transponder by the command.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -242,7 +242,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -324,7 +324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdLogEntryEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdLogEntryEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -351,7 +351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdPresenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdPresenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -400,7 +400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -439,7 +439,7 @@
         "items": {
           "title": "ScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3001",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanResult",
           "required": [ "CodeType", "ScanData", "Timestamp" ],
           "properties": {
             "CodeType": {
@@ -450,7 +450,7 @@
               "title": "ScanData",
               "description": "Holds the information about the detected objects e.g. the detected transponders.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -462,7 +462,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -501,7 +501,7 @@
               "title": "Location",
               "description": "Returns the location of the object detection.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
               "properties": {
                 "NMEA": {
                   "type": "string"
@@ -509,7 +509,7 @@
                 "Local": {
                   "title": "LocalCoordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                   "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                   "properties": {
                     "X": {
@@ -549,7 +549,7 @@
                 "WGS84": {
                   "title": "WGS84Coordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                   "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                   "properties": {
                     "N/S Hemisphere": {
@@ -623,7 +623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OcrScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -650,7 +650,7 @@
         "items": {
           "title": "OcrScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanResult",
           "required": [ "ImageId", "Quality", "Position" ],
           "properties": {
             "ImageId": {
@@ -667,7 +667,7 @@
               "title": "Position",
               "description": "Returns the position of the text within the image.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
               "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
               "properties": {
                 "PositionX": {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -757,7 +757,7 @@
         "items": {
           "title": "OpticalScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanResult",
           "properties": {
             "Grade": {
               "description": "Returns the quality of the 1D/2D code.",
@@ -769,7 +769,7 @@
               "title": "Position",
               "description": "Returns the position of the text within the image.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
               "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
               "properties": {
                 "PositionX": {
@@ -829,7 +829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalVerifierScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -856,7 +856,7 @@
         "items": {
           "title": "OpticalVerifierScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierScanResult",
           "required": [ "IsoGrade", "RMin", "SymbolContrast", "ECMin", "Modulation", "Defects", "Decodability", "Decode", "PrintGain" ],
           "properties": {
             "IsoGrade": {
@@ -926,7 +926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidScanEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -953,7 +953,7 @@
         "items": {
           "title": "RfidScanResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanResult",
           "required": [ "Sighting" ],
           "properties": {
             "Sighting": {
@@ -962,7 +962,7 @@
               "items": {
                 "title": "RfidSighting",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidSighting",
                 "required": [ "Antenna", "Strength", "Timestamp", "CurrentPowerLevel" ],
                 "properties": {
                   "Antenna": {
@@ -1015,7 +1015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RtlsLocationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1042,7 +1042,7 @@
         "items": {
           "title": "RtlsLocationResult",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
           "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
           "properties": {
             "Speed": {
@@ -1058,7 +1058,7 @@
             "Rotation": {
               "title": "Rotation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
               "required": [ "Yaw", "Pitch", "Roll" ],
               "properties": {
                 "Yaw": {
@@ -1106,7 +1106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_AutoIdDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1135,7 +1135,7 @@
     "schemaDefinitions": {
       "DeviceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
         "const": {
           "Idle": 0,
           "Error": 1,
@@ -1159,7 +1159,7 @@
       },
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -1183,7 +1183,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -1322,12 +1322,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6130",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LocationType" ],
           "properties": {
             "LocationType": {
               "title": "LocationTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1336,14 +1336,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6129",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Location" ],
           "properties": {
             "Location": {
               "title": "Location",
               "description": "Union of GPS, UTM or Local",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
               "properties": {
                 "NMEA": {
                   "type": "string"
@@ -1351,7 +1351,7 @@
                 "Local": {
                   "title": "LocalCoordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                   "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                   "properties": {
                     "X": {
@@ -1391,7 +1391,7 @@
                 "WGS84": {
                   "title": "WGS84Coordinate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                   "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                   "properties": {
                     "N/S Hemisphere": {
@@ -1455,13 +1455,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -1478,7 +1478,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1489,7 +1489,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6001",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -1497,7 +1497,7 @@
               "items": {
                 "title": "ScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3001",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanResult",
                 "required": [ "CodeType", "ScanData", "Timestamp" ],
                 "properties": {
                   "CodeType": {
@@ -1508,7 +1508,7 @@
                     "title": "ScanData",
                     "description": "Holds the information about the detected objects e.g. the detected transponders.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
                     "properties": {
                       "ByteString": {
                         "type": "string",
@@ -1520,7 +1520,7 @@
                       "Epc": {
                         "title": "ScanDataEpc",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                         "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                         "properties": {
                           "PC": {
@@ -1559,7 +1559,7 @@
                     "title": "Location",
                     "description": "Returns the location of the object detection.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
                     "properties": {
                       "NMEA": {
                         "type": "string"
@@ -1567,7 +1567,7 @@
                       "Local": {
                         "title": "LocalCoordinate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
                         "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
                         "properties": {
                           "X": {
@@ -1607,7 +1607,7 @@
                       "WGS84": {
                         "title": "WGS84Coordinate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                        "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                         "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                         "properties": {
                           "N/S Hemisphere": {
@@ -1662,7 +1662,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1681,13 +1681,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -1704,7 +1704,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1715,12 +1715,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6208",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1787,7 +1787,7 @@
         "title": "Location",
         "description": "Union of GPS, UTM, Local.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
         "properties": {
           "NMEA": {
             "type": "string"
@@ -1795,7 +1795,7 @@
           "Local": {
             "title": "LocalCoordinate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
             "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
             "properties": {
               "X": {
@@ -1835,7 +1835,7 @@
           "WGS84": {
             "title": "WGS84Coordinate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+            "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
             "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
             "properties": {
               "N/S Hemisphere": {
@@ -1937,7 +1937,7 @@
       "DeviceStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "DeviceStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2013,7 +2013,7 @@
           "title": "Location",
           "description": "Union of GPS, UTM, Local.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.Location",
           "properties": {
             "NMEA": {
               "type": "string"
@@ -2021,7 +2021,7 @@
             "Local": {
               "title": "LocalCoordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocalCoordinate",
               "required": [ "X", "Y", "Z", "Timestamp", "DilutionOfPrecision", "UsefulPrecision" ],
               "properties": {
                 "X": {
@@ -2061,7 +2061,7 @@
             "WGS84": {
               "title": "WGS84Coordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
               "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
               "properties": {
                 "N/S Hemisphere": {
@@ -2123,7 +2123,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "data": {
           "title": "DeviceStatusEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.DeviceStatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2190,7 +2190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OcrReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2214,7 +2214,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2238,7 +2238,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2360,13 +2360,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6027",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2383,7 +2383,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2394,7 +2394,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6015",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2402,7 +2402,7 @@
               "items": {
                 "title": "OcrScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.OcrScanResult",
                 "required": [ "ImageId", "Quality", "Position" ],
                 "properties": {
                   "ImageId": {
@@ -2419,7 +2419,7 @@
                     "title": "Position",
                     "description": "Returns the position of the text within the image.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
                     "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
                     "properties": {
                       "PositionX": {
@@ -2463,7 +2463,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2493,7 +2493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2517,7 +2517,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2541,7 +2541,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2663,13 +2663,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2686,7 +2686,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2697,7 +2697,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2705,7 +2705,7 @@
               "items": {
                 "title": "OpticalScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalScanResult",
                 "properties": {
                   "Grade": {
                     "description": "Returns the quality of the 1D/2D code.",
@@ -2717,7 +2717,7 @@
                     "title": "Position",
                     "description": "Returns the position of the text within the image.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Position",
                     "required": [ "PositionX", "PositionY", "SizeX", "SizeY", "Rotation" ],
                     "properties": {
                       "PositionX": {
@@ -2758,7 +2758,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2788,7 +2788,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_OpticalVerifierDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.OpticalVerifierDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2800,7 +2800,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -2824,7 +2824,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -2946,13 +2946,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6031",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -2969,7 +2969,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2980,7 +2980,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6076",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -2988,7 +2988,7 @@
               "items": {
                 "title": "WGS84Coordinate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3027",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.WGS84Coordinate",
                 "required": [ "N/S Hemisphere", "Latitude", "E/W Hemisphere", "Longitude", "Altitude", "Timestamp", "DilutionOfPrecision", "UsefulPrecisionLatLon", "UsefulPrecisionAlt" ],
                 "properties": {
                   "N/S Hemisphere": {
@@ -3036,7 +3036,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3066,7 +3066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RfidReaderDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidReaderDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3090,7 +3090,7 @@
     "schemaDefinitions": {
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -3208,7 +3208,7 @@
       },
       "RfidLockRegionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockRegionEnumeration",
         "const": {
           "Kill": 0,
           "Access": 1,
@@ -3236,7 +3236,7 @@
       },
       "RfidLockOperationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockOperationEnumeration",
         "const": {
           "Lock": 0,
           "Unlock": 1,
@@ -3260,7 +3260,7 @@
       },
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -3284,7 +3284,7 @@
       },
       "RfidPasswordTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidPasswordTypeEnumeration",
         "const": {
           "Access": 0,
           "Kill": 1,
@@ -3329,13 +3329,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "KillPassword" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3347,7 +3347,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3388,12 +3388,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3412,13 +3412,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Password", "Region", "Lock", "Offset", "Length" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3430,7 +3430,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3469,14 +3469,14 @@
             },
             "Region": {
               "title": "RfidLockRegionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockRegionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Lock": {
               "title": "RfidLockOperationEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidLockOperationEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3495,12 +3495,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3519,13 +3519,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Region", "Offset", "Length", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3537,7 +3537,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3593,7 +3593,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultData", "Status" ],
           "properties": {
             "ResultData": {
@@ -3602,7 +3602,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3621,13 +3621,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Setting" ],
           "properties": {
             "Setting": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -3644,7 +3644,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -3655,7 +3655,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -3663,7 +3663,7 @@
               "items": {
                 "title": "RfidScanResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3007",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidScanResult",
                 "required": [ "Sighting" ],
                 "properties": {
                   "Sighting": {
@@ -3672,7 +3672,7 @@
                     "items": {
                       "title": "RfidSighting",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidSighting",
                       "required": [ "Antenna", "Strength", "Timestamp", "CurrentPowerLevel" ],
                       "properties": {
                         "Antenna": {
@@ -3706,7 +3706,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3725,13 +3725,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "PasswordType", "AccessPassword", "NewPassword" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3743,7 +3743,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3778,7 +3778,7 @@
             },
             "PasswordType": {
               "title": "RfidPasswordTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RfidPasswordTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3795,12 +3795,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3819,13 +3819,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "Region", "Offset", "Data", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3837,7 +3837,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3892,12 +3892,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3916,13 +3916,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6137",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "CodeType", "NewUId", "AFI", "Toggle", "Password" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -3934,7 +3934,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -3987,12 +3987,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6140",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4015,7 +4015,7 @@
         "items": {
           "title": "AntennaNameIdPair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.AutoID.AntennaNameIdPair",
           "required": [ "AntennaId", "AntennaName" ],
           "properties": {
             "AntennaId": {
@@ -4127,7 +4127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "AutoID_RtlsDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4139,7 +4139,7 @@
     "schemaDefinitions": {
       "LocationTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
         "const": {
           "NMEA": 0,
           "LOCAL": 1,
@@ -4163,7 +4163,7 @@
       },
       "AutoIdOperationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
         "const": {
           "SUCCESS": 0,
           "MISC_ERROR_TOTAL": 1,
@@ -4297,13 +4297,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6224",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "LocationType", "CodeType" ],
           "properties": {
             "Identifier": {
               "title": "ScanData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanData",
               "properties": {
                 "ByteString": {
                   "type": "string",
@@ -4315,7 +4315,7 @@
                 "Epc": {
                   "title": "ScanDataEpc",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanDataEpc",
                   "required": [ "PC", "UId", "XPC_W1", "XPC_W2" ],
                   "properties": {
                     "PC": {
@@ -4347,7 +4347,7 @@
             },
             "LocationType": {
               "title": "LocationTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4359,13 +4359,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6225",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Result" ],
           "properties": {
             "Result": {
               "title": "RtlsLocationResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
               "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
               "properties": {
                 "Speed": {
@@ -4381,7 +4381,7 @@
                 "Rotation": {
                   "title": "Rotation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
                   "required": [ "Yaw", "Pitch", "Roll" ],
                   "properties": {
                     "Yaw": {
@@ -4421,14 +4421,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6226",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SupportedLocationTypes" ],
           "properties": {
             "SupportedLocationTypes": {
               "type": "array",
               "items": {
                 "title": "LocationTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4458,13 +4458,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Settings" ],
           "properties": {
             "Settings": {
               "title": "ScanSettings",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.ScanSettings",
               "required": [ "Duration", "Cycles", "DataAvailable" ],
               "properties": {
                 "Duration": {
@@ -4481,7 +4481,7 @@
                 },
                 "LocationType": {
                   "title": "LocationTypeEnumeration",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3009",
+                  "dov:typeRef": "org.opcfoundation.UA.AutoID.LocationTypeEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -4492,7 +4492,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=6219",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "Status" ],
           "properties": {
             "Results": {
@@ -4500,7 +4500,7 @@
               "items": {
                 "title": "RtlsLocationResult",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.AutoID.RtlsLocationResult",
                 "required": [ "Speed", "Heading", "Rotation", "ReceiveTime" ],
                 "properties": {
                   "Speed": {
@@ -4516,7 +4516,7 @@
                   "Rotation": {
                     "title": "Rotation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3029",
+                    "dov:typeRef": "org.opcfoundation.UA.AutoID.Rotation",
                     "required": [ "Yaw", "Pitch", "Roll" ],
                     "properties": {
                       "Yaw": {
@@ -4545,7 +4545,7 @@
             },
             "Status": {
               "title": "AutoIdOperationStatusEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/AutoID/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.AutoID.AutoIdOperationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4566,7 +4566,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4602,7 +4602,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4638,7 +4638,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4674,7 +4674,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/AutoID/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {

--- a/wot-codegen/opc-output-simple/BACnet_V2.TM.json
+++ b/wot-codegen/opc-output-simple/BACnet_V2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBackupRestoreType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101020",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupRestoreType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "BACnetBackupState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103016",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupState",
         "const": {
           "Idle": 0,
           "Preparing_For_Backup": 1,
@@ -55,7 +55,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -1611,7 +1611,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -1679,7 +1679,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -1827,7 +1827,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -1904,7 +1904,7 @@
       "Backup_And_Restore_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetBackupState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103016",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBackupState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1966,7 +1966,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -1976,7 +1976,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2011,12 +2011,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTimeStamp",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
         "properties": {
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -2049,13 +2049,13 @@
           "DateTime": {
             "title": "BACnetDateTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
             "required": [ "Date", "Time" ],
             "properties": {
               "Date": {
                 "title": "BACnetDate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                 "properties": {
                   "Year": {
@@ -2065,21 +2065,21 @@
                   },
                   "Month": {
                     "title": "BACnetMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfMonth": {
                     "title": "BACnetDayOfMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfWeek": {
                     "title": "BACnetDayOfWeek",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2089,7 +2089,7 @@
               "Time": {
                 "title": "BACnetTime",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                 "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                 "properties": {
                   "Hour": {
@@ -2182,7 +2182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateCountType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateCountType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2193,7 +2193,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -2261,7 +2261,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -2409,7 +2409,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -2496,13 +2496,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -2512,21 +2512,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2536,7 +2536,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -2607,7 +2607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDeviceRestartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101022",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceRestartType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2618,7 +2618,7 @@
     "schemaDefinitions": {
       "BACnetRestartReason": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRestartReason",
         "const": {
           "unknown": 0,
           "coldstart": 1,
@@ -2658,7 +2658,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -2726,7 +2726,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -2874,7 +2874,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -2930,7 +2930,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RestartNotificationRecipients" ],
           "properties": {
             "RestartNotificationRecipients": {
@@ -2938,7 +2938,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -2948,7 +2948,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -2971,7 +2971,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6137",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -2993,7 +2993,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6147",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RestartNotificationRecipients" ],
           "properties": {
             "RestartNotificationRecipients": {
@@ -3001,7 +3001,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -3011,7 +3011,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -3034,7 +3034,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -3057,7 +3057,7 @@
       "Last_Restart_Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetRestartReason",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRestartReason",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3081,7 +3081,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -3091,7 +3091,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -3127,12 +3127,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTimeStamp",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
         "properties": {
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -3165,13 +3165,13 @@
           "DateTime": {
             "title": "BACnetDateTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
             "required": [ "Date", "Time" ],
             "properties": {
               "Date": {
                 "title": "BACnetDate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                 "properties": {
                   "Year": {
@@ -3181,21 +3181,21 @@
                   },
                   "Month": {
                     "title": "BACnetMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfMonth": {
                     "title": "BACnetDayOfMonth",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "DayOfWeek": {
                     "title": "BACnetDayOfWeek",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3205,7 +3205,7 @@
               "Time": {
                 "title": "BACnetTime",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                 "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                 "properties": {
                   "Hour": {
@@ -3260,7 +3260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetElapsedActiveTimeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetElapsedActiveTimeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3345,7 +3345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3421,7 +3421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBufferReadyAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101005",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBufferReadyAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3497,7 +3497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfBitStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101003",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfBitStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3527,7 +3527,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -3566,7 +3566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfCharacterStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101034",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfCharacterStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3625,7 +3625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfLifeSafetyAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101028",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfLifeSafetyAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3637,7 +3637,7 @@
     "schemaDefinitions": {
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -3765,7 +3765,7 @@
         "type": "array",
         "items": {
           "title": "BACnetLifeSafetyState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3789,7 +3789,7 @@
         "type": "array",
         "items": {
           "title": "BACnetLifeSafetyState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3816,7 +3816,7 @@
           "type": "array",
           "items": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3836,7 +3836,7 @@
           "type": "array",
           "items": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3861,7 +3861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3917,7 +3917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStatusFlagsAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101030",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStatusFlagsAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3929,7 +3929,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -3970,7 +3970,7 @@
       "SelectedFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4001,7 +4001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfValueAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101004",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfValueAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4031,7 +4031,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -4089,7 +4089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCommandFailureAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCommandFailureAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4100,7 +4100,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -5674,7 +5674,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -5684,7 +5684,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5727,7 +5727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDoubleOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101031",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDoubleOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5739,7 +5739,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -5810,7 +5810,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5860,7 +5860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFloatingLimitAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101002",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFloatingLimitAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5871,7 +5871,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -7502,7 +7502,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -7512,7 +7512,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -7555,7 +7555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetOutOfRangeAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7566,7 +7566,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7637,7 +7637,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7687,7 +7687,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSignedOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101032",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSignedOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7699,7 +7699,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7766,7 +7766,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7814,7 +7814,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedOutOfRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101033",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedOutOfRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7826,7 +7826,7 @@
     "schemaDefinitions": {
       "BACnetLimitEnable": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "const": {
           "lowLimitEnable": 0,
           "highLimitEnable": 1
@@ -7895,7 +7895,7 @@
       "LimitEnable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLimitEnable",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3062",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLimitEnable",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7944,7 +7944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedRangeAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101029",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedRangeAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8019,7 +8019,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventReportingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventReportingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8036,7 +8036,7 @@
     "schemaDefinitions": {
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -8056,7 +8056,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -9612,7 +9612,7 @@
       },
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -9644,7 +9644,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -9712,7 +9712,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -9860,7 +9860,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -9900,7 +9900,7 @@
       },
       "BACnetNotifyType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "const": {
           "Alarm": 0,
           "Event": 1,
@@ -9937,7 +9937,7 @@
       "Acked_Transitions": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9976,7 +9976,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -9986,7 +9986,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -10036,7 +10036,7 @@
       "Event_Enable": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10097,7 +10097,7 @@
       "Event_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10121,12 +10121,12 @@
         "items": {
           "title": "BACnetTimeStamp",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3056",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeStamp",
           "properties": {
             "Time": {
               "title": "BACnetTime",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
               "required": [ "Hour", "Minute", "Second", "Hundredths" ],
               "properties": {
                 "Hour": {
@@ -10159,13 +10159,13 @@
             "DateTime": {
               "title": "BACnetDateTime",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
               "required": [ "Date", "Time" ],
               "properties": {
                 "Date": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -10175,21 +10175,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -10199,7 +10199,7 @@
                 "Time": {
                   "title": "BACnetTime",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                   "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                   "properties": {
                     "Hour": {
@@ -10264,7 +10264,7 @@
       "Notify_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNotifyType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10295,7 +10295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetIntrinsicReportingTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101016",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetIntrinsicReportingTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10353,7 +10353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101025",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10379,7 +10379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultCharacterStringAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101009",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultCharacterStringAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10438,7 +10438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultStateAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101011",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultStateAlgorithmType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10497,7 +10497,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultStatusFlagsAlgorithmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101012",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultStatusFlagsAlgorithmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10524,7 +10524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultEvaluationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultEvaluationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10541,7 +10541,7 @@
     "schemaDefinitions": {
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -10641,7 +10641,7 @@
       "Reliability": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetReliability",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10689,7 +10689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetInternetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetInternetworkType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10707,7 +10707,7 @@
     "schemaDefinitions": {
       "BACnetSegmentation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "const": {
           "segmented_both": 0,
           "segmented_transmit": 1,
@@ -10731,7 +10731,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -12291,7 +12291,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6252",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Address" ],
           "properties": {
             "Address": {
@@ -12311,7 +12311,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6248",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObject" ],
           "properties": {
             "DeviceObject": {
@@ -12331,7 +12331,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6247",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BACnetDeviceIds", "OpcUaObjectIds" ],
           "properties": {
             "BACnetDeviceIds": {
@@ -12362,7 +12362,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6660",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "WaitTimeInSeconds", "ApplyRange", "DeviceRangeLow", "DeviceRangeHigh" ],
           "properties": {
             "WaitTimeInSeconds": {
@@ -12387,7 +12387,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6661",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeviceAddressBindings", "MaxAPDULengthAccepted", "SegmentationSupported", "VendorIdentifier" ],
           "properties": {
             "DeviceAddressBindings": {
@@ -12408,7 +12408,7 @@
               "type": "array",
               "items": {
                 "title": "BACnetSegmentation",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -12436,7 +12436,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6662",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Time" ],
           "properties": {
             "Time": {
@@ -12457,7 +12457,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6245",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "BACnetIds" ],
           "properties": {
             "BACnetIds": {
@@ -12465,7 +12465,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -12475,7 +12475,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -12497,7 +12497,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "OpcUaIds" ],
           "properties": {
             "OpcUaIds": {
@@ -12531,7 +12531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMstpMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101021",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMstpMasterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12579,7 +12579,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -12590,7 +12590,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -12665,7 +12665,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -12676,7 +12676,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -12738,7 +12738,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12812,7 +12812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12835,7 +12835,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -12955,7 +12955,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13001,7 +13001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13057,7 +13057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13106,7 +13106,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -13181,7 +13181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAnalogValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAnalogValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13213,7 +13213,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -13288,7 +13288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13323,7 +13323,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -13403,7 +13403,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13447,7 +13447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13465,7 +13465,7 @@
     "schemaDefinitions": {
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -13515,7 +13515,7 @@
       "Polarity": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPolarity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13546,7 +13546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13564,7 +13564,7 @@
     "schemaDefinitions": {
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -13669,7 +13669,7 @@
       "Polarity": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPolarity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13693,7 +13693,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -13766,7 +13766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBinaryValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13842,7 +13842,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -13915,7 +13915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCalendarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13927,7 +13927,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -13995,7 +13995,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -14143,7 +14143,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -14183,7 +14183,7 @@
       },
       "BACnetDay": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
         "const": {
           "days_numbered_1_7": 1,
           "days_numbered_8_14": 2,
@@ -14240,7 +14240,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -14248,12 +14248,12 @@
               "items": {
                 "title": "BACnetCalendarEntry",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                 "properties": {
                   "Date": {
                     "title": "BACnetDate",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -14263,21 +14263,21 @@
                       },
                       "Month": {
                         "title": "BACnetMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "BACnetDayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14287,13 +14287,13 @@
                   "DateRange": {
                     "title": "BACnetDateRange",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                     "required": [ "StartDate", "EndTime" ],
                     "properties": {
                       "StartDate": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -14303,21 +14303,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -14327,7 +14327,7 @@
                       "EndTime": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -14337,21 +14337,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -14363,13 +14363,13 @@
                   "WeekNDay": {
                     "title": "BACnetWeekNDay",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                     "required": [ "Month", "Day", "DayOfWeek" ],
                     "properties": {
                       "Month": {
                         "title": "BACnetMonth",
                         "description": "January = 1, 0xFF = Any Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14377,7 +14377,7 @@
                       "Day": {
                         "title": "BACnetDay",
                         "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14385,7 +14385,7 @@
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
                         "description": "1 = Monday, 0xFF = Any day of week",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14399,7 +14399,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=106294",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -14422,7 +14422,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6084",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -14430,12 +14430,12 @@
               "items": {
                 "title": "BACnetCalendarEntry",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                 "properties": {
                   "Date": {
                     "title": "BACnetDate",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -14445,21 +14445,21 @@
                       },
                       "Month": {
                         "title": "BACnetMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "BACnetDayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14469,13 +14469,13 @@
                   "DateRange": {
                     "title": "BACnetDateRange",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                     "required": [ "StartDate", "EndTime" ],
                     "properties": {
                       "StartDate": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -14485,21 +14485,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -14509,7 +14509,7 @@
                       "EndTime": {
                         "title": "BACnetDate",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -14519,21 +14519,21 @@
                           },
                           "Month": {
                             "title": "BACnetMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "BACnetDayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "BACnetDayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -14545,13 +14545,13 @@
                   "WeekNDay": {
                     "title": "BACnetWeekNDay",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                     "required": [ "Month", "Day", "DayOfWeek" ],
                     "properties": {
                       "Month": {
                         "title": "BACnetMonth",
                         "description": "January = 1, 0xFF = Any Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14559,7 +14559,7 @@
                       "Day": {
                         "title": "BACnetDay",
                         "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14567,7 +14567,7 @@
                       "DayOfWeek": {
                         "title": "BACnetDayOfWeek",
                         "description": "1 = Monday, 0xFF = Any day of week",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14581,7 +14581,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=106295",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -14607,12 +14607,12 @@
         "items": {
           "title": "BACnetCalendarEntry",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
           "properties": {
             "Date": {
               "title": "BACnetDate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
               "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
               "properties": {
                 "Year": {
@@ -14622,21 +14622,21 @@
                 },
                 "Month": {
                   "title": "BACnetMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfMonth": {
                   "title": "BACnetDayOfMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfWeek": {
                   "title": "BACnetDayOfWeek",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -14646,13 +14646,13 @@
             "DateRange": {
               "title": "BACnetDateRange",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
               "required": [ "StartDate", "EndTime" ],
               "properties": {
                 "StartDate": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -14662,21 +14662,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -14686,7 +14686,7 @@
                 "EndTime": {
                   "title": "BACnetDate",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -14696,21 +14696,21 @@
                     },
                     "Month": {
                       "title": "BACnetMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "BACnetDayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "BACnetDayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -14722,13 +14722,13 @@
             "WeekNDay": {
               "title": "BACnetWeekNDay",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
               "required": [ "Month", "Day", "DayOfWeek" ],
               "properties": {
                 "Month": {
                   "title": "BACnetMonth",
                   "description": "January = 1, 0xFF = Any Month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -14736,7 +14736,7 @@
                 "Day": {
                   "title": "BACnetDay",
                   "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -14744,7 +14744,7 @@
                 "DayOfWeek": {
                   "title": "BACnetDayOfWeek",
                   "description": "1 = Monday, 0xFF = Any day of week",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -14810,7 +14810,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14857,7 +14857,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -16413,7 +16413,7 @@
       },
       "BACnetObjectTypeSupportedBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3063",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeSupportedBits",
         "const": {
           "analog_input": 0,
           "analog_output": 1,
@@ -16641,7 +16641,7 @@
       },
       "BACnetServicesSupportedBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3064",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetServicesSupportedBits",
         "const": {
           "acknowledgeAlarm": 0,
           "confirmedCOVNotification": 1,
@@ -16809,7 +16809,7 @@
       },
       "BACnetSegmentation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "const": {
           "segmented_both": 0,
           "segmented_transmit": 1,
@@ -16833,7 +16833,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -16865,7 +16865,7 @@
       },
       "BACnetDeviceCommunicationEnabled": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceCommunicationEnabled",
         "const": {
           "Enable": 0,
           "Disable": 1,
@@ -16885,7 +16885,7 @@
       },
       "BACnetReinitializedStateofDevice": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3049",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReinitializedStateofDevice",
         "const": {
           "Coldstart": 0,
           "Warmstart": 1,
@@ -16921,7 +16921,7 @@
       },
       "BACnetMessagePriority": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3057",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessagePriority",
         "const": {
           "normal": 0,
           "urgent": 1
@@ -16953,7 +16953,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6271",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddressBindings" ],
           "properties": {
             "AddressBindings": {
@@ -16961,7 +16961,7 @@
               "items": {
                 "title": "BACnetAddressBinding",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
                 "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
                 "properties": {
                   "DeviceObjectIdentifier": {
@@ -16972,7 +16972,7 @@
                   "DeviceAddress": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -16995,7 +16995,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6272",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -17017,7 +17017,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6254",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectSpecifier", "ListOfInitialValues" ],
           "properties": {
             "ObjectSpecifier": {
@@ -17030,7 +17030,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -17057,7 +17057,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6256",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -17080,7 +17080,7 @@
         "description": "ToDo",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6266",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TimeDurationInMinutes", "EnableDisable", "Password" ],
           "properties": {
             "TimeDurationInMinutes": {
@@ -17090,7 +17090,7 @@
             },
             "EnableDisable": {
               "title": "BACnetDeviceCommunicationEnabled",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceCommunicationEnabled",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -17112,12 +17112,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6255",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReinitializedStateofDevice", "Password" ],
           "properties": {
             "ReinitializedStateofDevice": {
               "title": "BACnetReinitializedStateofDevice",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3049",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReinitializedStateofDevice",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -17139,7 +17139,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6273",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddressBindings" ],
           "properties": {
             "AddressBindings": {
@@ -17147,7 +17147,7 @@
               "items": {
                 "title": "BACnetAddressBinding",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
                 "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
                 "properties": {
                   "DeviceObjectIdentifier": {
@@ -17158,7 +17158,7 @@
                   "DeviceAddress": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -17181,7 +17181,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6274",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -17203,7 +17203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6267",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SendUnconfirmed", "TextMessageSourceDevice", "MessageClass", "MessagePriority", "Message" ],
           "properties": {
             "SendUnconfirmed": {
@@ -17217,7 +17217,7 @@
             "MessageClass": {
               "title": "BACnetMessageClass",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3052",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessageClass",
               "properties": {
                 "Unsigned": {
                   "type": "integer",
@@ -17230,7 +17230,7 @@
             },
             "MessagePriority": {
               "title": "BACnetMessagePriority",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3057",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMessagePriority",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -17256,19 +17256,19 @@
         "items": {
           "title": "BACnetCOVSubscription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103017",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCOVSubscription",
           "required": [ "Recipient", "MonitoredPropertyReference", "IssueConfirmedNotifications", "TimeRemaining" ],
           "properties": {
             "Recipient": {
               "title": "BACnetRecipientProcess",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103018",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipientProcess",
               "required": [ "Recipient", "ProcessIdentifier" ],
               "properties": {
                 "Recipient": {
                   "title": "BACnetRecipient",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                   "properties": {
                     "Device": {
                       "type": "integer",
@@ -17278,7 +17278,7 @@
                     "Address": {
                       "title": "BACnetAddress",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                       "required": [ "NetworkNumber", "MacAddress" ],
                       "properties": {
                         "NetworkNumber": {
@@ -17306,7 +17306,7 @@
             "MonitoredPropertyReference": {
               "title": "BACnetDeviceObjectPropertyReference",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
               "required": [ "ObjectIdentifier" ],
               "properties": {
                 "ObjectIdentifier": {
@@ -17316,7 +17316,7 @@
                 },
                 "PropertyIdentifier": {
                   "title": "BACnetPropertyIdentifier",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -17439,7 +17439,7 @@
         "items": {
           "title": "BACnetAddressBinding",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103015",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddressBinding",
           "required": [ "DeviceObjectIdentifier", "DeviceAddress" ],
           "properties": {
             "DeviceObjectIdentifier": {
@@ -17450,7 +17450,7 @@
             "DeviceAddress": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -17590,7 +17590,7 @@
       "Protocol_Object_Types_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetObjectTypeSupportedBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3063",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeSupportedBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17629,7 +17629,7 @@
       "Protocol_Services_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetServicesSupportedBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3064",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetServicesSupportedBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17668,7 +17668,7 @@
       "Segmentation_Supported": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetSegmentation",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103011",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSegmentation",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17706,7 +17706,7 @@
       "System_Status": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17773,7 +17773,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventEnrollmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101006",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnrollmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17797,7 +17797,7 @@
     "schemaDefinitions": {
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -17829,7 +17829,7 @@
       },
       "BACnetEventType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103054",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventType",
         "const": {
           "change_of_bitstring": 0,
           "change_of_state": 1,
@@ -17901,7 +17901,7 @@
       },
       "BACnetFaultType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultType",
         "const": {
           "none": 0,
           "fault_characterstring": 1,
@@ -17933,7 +17933,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -19489,7 +19489,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -19513,7 +19513,7 @@
       },
       "BACnetBinaryPV": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
         "const": {
           "Inactive": 0,
           "Active": 1
@@ -19529,7 +19529,7 @@
       },
       "BACnetEventEnumType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
         "const": {
           "ChangeOfBitstring": 0,
           "ChangeOfState": 1,
@@ -19577,7 +19577,7 @@
       },
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -19593,7 +19593,7 @@
       },
       "BACnetProgramRequest": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
         "const": {
           "Ready": 0,
           "Load": 1,
@@ -19625,7 +19625,7 @@
       },
       "BACnetProgramStates": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
         "const": {
           "Idle": 0,
           "Loading": 1,
@@ -19657,7 +19657,7 @@
       },
       "BACnetProgramError": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
         "const": {
           "Normal": 0,
           "LoadFailed": 1,
@@ -19685,7 +19685,7 @@
       },
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -19768,7 +19768,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -19800,7 +19800,7 @@
       },
       "BACnetLifeSafetyMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
         "const": {
           "Off": 0,
           "On": 1,
@@ -19868,7 +19868,7 @@
       },
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -19972,7 +19972,7 @@
       },
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -20040,7 +20040,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -20188,7 +20188,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -20228,7 +20228,7 @@
       },
       "BACnetLifeSafetyOperation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3044",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyOperation",
         "const": {
           "None": 0,
           "Silence": 1,
@@ -20292,18 +20292,18 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventParameters" ],
           "properties": {
             "EventParameters": {
               "title": "BACnetEventParameter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3050",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameter",
               "properties": {
                 "Change-of-bitstring": {
                   "title": "BACnetEventParameterChangeOfBitstring",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103005",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfBitstring",
                   "required": [ "Time-delay", "Bitmask", "List-of-bitstring-values" ],
                   "properties": {
                     "Time-delay": {
@@ -20314,7 +20314,7 @@
                     "Bitmask": {
                       "title": "OptionSet",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                      "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                       "required": [ "Value", "ValidBits" ],
                       "properties": {
                         "Value": {
@@ -20332,7 +20332,7 @@
                       "items": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -20351,7 +20351,7 @@
                 "Change-of-state": {
                   "title": "BACnetEventParameterChangeOfState",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103009",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfState",
                   "required": [ "Time-delay", "List-of-values" ],
                   "properties": {
                     "Time-delay": {
@@ -20364,7 +20364,7 @@
                       "items": {
                         "title": "BACnetPropertyStates",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3028",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyStates",
                         "required": [ "BooleanValue", "BinaryValue", "EventType", "Polarity", "ProgramChange", "ProgramState", "ProgramError", "Reliability", "State", "SystemStatus", "Units", "UnsignedValue", "LifeSafetyMode", "LifeSafetyState" ],
                         "properties": {
                           "BooleanValue": {
@@ -20372,63 +20372,63 @@
                           },
                           "BinaryValue": {
                             "title": "BACnetBinaryPV",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "EventType": {
                             "title": "BACnetEventEnumType",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "Polarity": {
                             "title": "BACnetPolarity",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramChange": {
                             "title": "BACnetProgramRequest",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramState": {
                             "title": "BACnetProgramStates",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "ProgramError": {
                             "title": "BACnetProgramError",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "Reliability": {
                             "title": "BACnetReliability",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "State": {
                             "title": "BACnetEventState",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "SystemStatus": {
                             "title": "BACnetDeviceStatus",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -20436,7 +20436,7 @@
                           "Units": {
                             "title": "EUInformation",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -20462,14 +20462,14 @@
                           },
                           "LifeSafetyMode": {
                             "title": "BACnetLifeSafetyMode",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "LifeSafetyState": {
                             "title": "BACnetLifeSafetyState",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -20482,7 +20482,7 @@
                 "Change-of-value": {
                   "title": "BACnetEventParameterChangeOfValue",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103037",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfValue",
                   "required": [ "Time-delay", "Cov-criteria-bitmask", "Cov-criteria-referenced-property-increment" ],
                   "properties": {
                     "Time-delay": {
@@ -20493,7 +20493,7 @@
                     "Cov-criteria-bitmask": {
                       "title": "OptionSet",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                      "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                       "required": [ "Value", "ValidBits" ],
                       "properties": {
                         "Value": {
@@ -20516,7 +20516,7 @@
                 "Command-failure": {
                   "title": "BACnetEventParameterCommandFailure",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103039",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterCommandFailure",
                   "required": [ "Time-delay", "Feedback-property-reference" ],
                   "properties": {
                     "Time-delay": {
@@ -20527,7 +20527,7 @@
                     "Feedback-property-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -20537,7 +20537,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -20559,7 +20559,7 @@
                 "Floating-limit": {
                   "title": "BACnetEventParameterFloatingLimit",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103040",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterFloatingLimit",
                   "required": [ "Time-delay", "Setpoint-reference", "Low-diff-limit", "High-diff-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -20570,7 +20570,7 @@
                     "Setpoint-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -20580,7 +20580,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -20617,7 +20617,7 @@
                 "Out-of-range": {
                   "title": "BACnetEventParameterOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103041",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -20645,7 +20645,7 @@
                 "Extended": {
                   "title": "BACnetEventFaultParameterExtended",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103031",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventFaultParameterExtended",
                   "required": [ "VendorId", "Extended-fault-type", "Parameters" ],
                   "properties": {
                     "VendorId": {
@@ -20662,7 +20662,7 @@
                       "items": {
                         "title": "BACnetEventParameterExtendedParameters",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3068",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterExtendedParameters",
                         "properties": {
                           "Real": {
                             "type": "number",
@@ -20696,7 +20696,7 @@
                           "BitString": {
                             "title": "OptionSet",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                            "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                             "required": [ "Value", "ValidBits" ],
                             "properties": {
                               "Value": {
@@ -20717,7 +20717,7 @@
                           "Date": {
                             "title": "BACnetDate",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -20727,21 +20727,21 @@
                               },
                               "Month": {
                                 "title": "BACnetMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "BACnetDayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "BACnetDayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -20751,7 +20751,7 @@
                           "Time": {
                             "title": "BACnetTime",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                             "properties": {
                               "Hour": {
@@ -20784,7 +20784,7 @@
                           "Reference": {
                             "title": "BACnetDeviceObjectPropertyReference",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                             "required": [ "ObjectIdentifier" ],
                             "properties": {
                               "ObjectIdentifier": {
@@ -20794,7 +20794,7 @@
                               },
                               "PropertyIdentifier": {
                                 "title": "BACnetPropertyIdentifier",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -20824,7 +20824,7 @@
                 "Buffer-ready": {
                   "title": "BACnetEventParameterBufferReady",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103042",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterBufferReady",
                   "required": [ "Notification-threshold", "Previous-notification-count" ],
                   "properties": {
                     "Notification-threshold": {
@@ -20842,7 +20842,7 @@
                 "Unsigned-range": {
                   "title": "BACnetEventParameterUnsignedRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3067",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterUnsignedRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit" ],
                   "properties": {
                     "Time-delay": {
@@ -20865,7 +20865,7 @@
                 "Double-out-of-range": {
                   "title": "BACnetEventParameterDoubleOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3058",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterDoubleOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -20893,7 +20893,7 @@
                 "Signed-out-of-range": {
                   "title": "BACnetEventParameterSignedOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3059",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterSignedOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -20921,7 +20921,7 @@
                 "Unsigned-out-of-range": {
                   "title": "BACnetEventParameterUnsignedOutOfRange",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103043",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterUnsignedOutOfRange",
                   "required": [ "Time-delay", "Low-limit", "High-limit", "Deadband" ],
                   "properties": {
                     "Time-delay": {
@@ -20949,7 +20949,7 @@
                 "Change-of-characterstring": {
                   "title": "BACnetEventParameterChangeOfCharacterString",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3066",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfCharacterString",
                   "required": [ "Time-delay", "AlarmValues" ],
                   "properties": {
                     "Time-delay": {
@@ -20968,26 +20968,26 @@
                 "Change-of-life-safety": {
                   "title": "BACnetEventParameterChangeOfLifeSafety",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3027",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterChangeOfLifeSafety",
                   "required": [ "NewState", "NewMode", "OperationExtended" ],
                   "properties": {
                     "NewState": {
                       "title": "BACnetLifeSafetyState",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "NewMode": {
                       "title": "BACnetLifeSafetyMode",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "OperationExtended": {
                       "title": "BACnetLifeSafetyOperation",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3044",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyOperation",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -21010,18 +21010,18 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6332",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FaultParameters" ],
           "properties": {
             "FaultParameters": {
               "title": "BACnetFaultParameter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3051",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameter",
               "properties": {
                 "Fault-characterstring": {
                   "title": "BACnetFaultParameterFaultCharacterstring",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103030",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultCharacterstring",
                   "required": [ "Fault-characterstring" ],
                   "properties": {
                     "Fault-characterstring": {
@@ -21032,14 +21032,14 @@
                 "Fault-life-safety": {
                   "title": "BACnetFaultParameterFaultLifeSafety",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103032",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultLifeSafety",
                   "required": [ "List-of-fault-values", "Mode-property-reference" ],
                   "properties": {
                     "List-of-fault-values": {
                       "type": "array",
                       "items": {
                         "title": "BACnetLifeSafetyState",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -21048,7 +21048,7 @@
                     "Mode-property-reference": {
                       "title": "BACnetDeviceObjectPropertyReference",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                       "required": [ "ObjectIdentifier" ],
                       "properties": {
                         "ObjectIdentifier": {
@@ -21058,7 +21058,7 @@
                         },
                         "PropertyIdentifier": {
                           "title": "BACnetPropertyIdentifier",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -21080,14 +21080,14 @@
                 "Fault-state": {
                   "title": "BACnetFaultParameterFaultState",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103033",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultState",
                   "required": [ "List-of-fault-values" ],
                   "properties": {
                     "List-of-fault-values": {
                       "type": "array",
                       "items": {
                         "title": "BACnetProgramStates",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -21098,7 +21098,7 @@
                 "Fault-status-flags": {
                   "title": "BACnetFaultParameterFaultStatusFlags",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103034",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultParameterFaultStatusFlags",
                   "required": [ "Status-flags-reference" ],
                   "properties": {
                     "Status-flags-reference": {
@@ -21106,7 +21106,7 @@
                       "items": {
                         "title": "BACnetDeviceObjectPropertyReference",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                         "required": [ "ObjectIdentifier" ],
                         "properties": {
                           "ObjectIdentifier": {
@@ -21116,7 +21116,7 @@
                           },
                           "PropertyIdentifier": {
                             "title": "BACnetPropertyIdentifier",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -21139,7 +21139,7 @@
                 "Fault-extended": {
                   "title": "BACnetEventFaultParameterExtended",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103031",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventFaultParameterExtended",
                   "required": [ "VendorId", "Extended-fault-type", "Parameters" ],
                   "properties": {
                     "VendorId": {
@@ -21156,7 +21156,7 @@
                       "items": {
                         "title": "BACnetEventParameterExtendedParameters",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3068",
+                        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventParameterExtendedParameters",
                         "properties": {
                           "Real": {
                             "type": "number",
@@ -21190,7 +21190,7 @@
                           "BitString": {
                             "title": "OptionSet",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                            "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                             "required": [ "Value", "ValidBits" ],
                             "properties": {
                               "Value": {
@@ -21211,7 +21211,7 @@
                           "Date": {
                             "title": "BACnetDate",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -21221,21 +21221,21 @@
                               },
                               "Month": {
                                 "title": "BACnetMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "BACnetDayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "BACnetDayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21245,7 +21245,7 @@
                           "Time": {
                             "title": "BACnetTime",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                             "properties": {
                               "Hour": {
@@ -21278,7 +21278,7 @@
                           "Reference": {
                             "title": "BACnetDeviceObjectPropertyReference",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                             "required": [ "ObjectIdentifier" ],
                             "properties": {
                               "ObjectIdentifier": {
@@ -21288,7 +21288,7 @@
                               },
                               "PropertyIdentifier": {
                                 "title": "BACnetPropertyIdentifier",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -21332,7 +21332,7 @@
       "Event_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21353,7 +21353,7 @@
       "Event_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103054",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21374,7 +21374,7 @@
       "Fault_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetFaultType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21396,7 +21396,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -21406,7 +21406,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -21439,7 +21439,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21470,7 +21470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101014",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21493,7 +21493,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -21561,7 +21561,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -21709,7 +21709,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -21749,7 +21749,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -21860,13 +21860,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -21876,21 +21876,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -21900,7 +21900,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -21943,7 +21943,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21965,13 +21965,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateTime",
         "required": [ "Date", "Time" ],
         "properties": {
           "Date": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -21981,21 +21981,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -22005,7 +22005,7 @@
           "Time": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -22084,7 +22084,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101018",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22111,7 +22111,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogBaseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101026",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogBaseType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22122,7 +22122,7 @@
     "schemaDefinitions": {
       "BACnetLoggingType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103048",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoggingType",
         "const": {
           "Polled": 0,
           "COV": 1,
@@ -22212,7 +22212,7 @@
       "Logging_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetLoggingType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103048",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoggingType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22260,7 +22260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogMultipleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101027",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogMultipleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22272,7 +22272,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -23874,7 +23874,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -23884,7 +23884,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -23945,7 +23945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101017",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23957,7 +23957,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -25536,7 +25536,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetClientCOV",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetClientCOV",
         "properties": {
           "Real-increment": {
             "type": "number",
@@ -25593,7 +25593,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -25603,7 +25603,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -25660,7 +25660,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetClockAlignedTrendLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101015",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetClockAlignedTrendLogType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25747,7 +25747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLoopType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101001",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoopType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25771,7 +25771,7 @@
     "schemaDefinitions": {
       "BACnetAction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAction",
         "const": {
           "direct": 0,
           "reverse": 1
@@ -25787,7 +25787,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -27343,7 +27343,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -27389,7 +27389,7 @@
       "Action": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetAction",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -27430,7 +27430,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -27440,7 +27440,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -27550,7 +27550,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -27560,7 +27560,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -27687,7 +27687,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -27697,7 +27697,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -27730,7 +27730,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -27866,7 +27866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27889,7 +27889,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -27970,7 +27970,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28015,7 +28015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateInputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28083,7 +28083,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateOutputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateOutputType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28156,7 +28156,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -28230,7 +28230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetMultiStateValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMultiStateValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28274,7 +28274,7 @@
         "items": {
           "title": "BACnetPriorityValue",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPriorityValue",
           "properties": {
             "Real": {
               "type": "number",
@@ -28348,7 +28348,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28359,7 +28359,7 @@
     "schemaDefinitions": {
       "BACnetDaysOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3060",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDaysOfWeek",
         "const": {
           "monday": 0,
           "tuesday": 1,
@@ -28395,7 +28395,7 @@
       },
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -28433,13 +28433,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDestination",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103020",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDestination",
         "required": [ "ValidDays", "FromTime", "ToTime", "Recipient", "ProcessIdentifier", "IssueConfirmedNotifications", "Transitions" ],
         "properties": {
           "ValidDays": {
             "title": "BACnetDaysOfWeek",
             "description": "BACnetDaysOfWeek BitField",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3060",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDaysOfWeek",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -28447,7 +28447,7 @@
           "FromTime": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -28475,7 +28475,7 @@
           "ToTime": {
             "title": "BACnetTime",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
             "required": [ "Hour", "Minute", "Second", "Hundredths" ],
             "properties": {
               "Hour": {
@@ -28503,7 +28503,7 @@
           "Recipient": {
             "title": "BACnetRecipient",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
             "properties": {
               "Device": {
                 "type": "integer",
@@ -28513,7 +28513,7 @@
               "Address": {
                 "title": "BACnetAddress",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                 "required": [ "NetworkNumber", "MacAddress" ],
                 "properties": {
                   "NetworkNumber": {
@@ -28542,7 +28542,7 @@
           "Transitions": {
             "title": "BACnetEventTransitionBits",
             "description": "BACnetEventTransitionsBits BitField",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -28575,7 +28575,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotificationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotificationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -28587,7 +28587,7 @@
     "schemaDefinitions": {
       "BACnetEventTransitionBits": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "const": {
           "to_offnormal": 0,
           "to_fault": 1,
@@ -28624,7 +28624,7 @@
       "Ack_Required": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventTransitionBits",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3061",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventTransitionBits",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28696,7 +28696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetObjectTypeUnknown",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101024",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeUnknown",
     "dov:isComposite": true,
     "links": [
       {
@@ -28708,7 +28708,7 @@
     "schemaDefinitions": {
       "BACnetObjectTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
         "const": {
           "analog_input": 0,
           "analog_output": 1,
@@ -28958,7 +28958,7 @@
       "Object_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetObjectTypeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28982,7 +28982,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "data": {
           "title": "BACnetObjectTypeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103053",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetObjectTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -29006,7 +29006,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetScheduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetScheduleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -29030,7 +29030,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -29098,7 +29098,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -29246,7 +29246,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -29286,7 +29286,7 @@
       },
       "BACnetDay": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
         "const": {
           "days_numbered_1_7": 1,
           "days_numbered_8_14": 2,
@@ -29322,7 +29322,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -30878,7 +30878,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -30923,7 +30923,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObjectPropertyReferences" ],
           "properties": {
             "DeviceObjectPropertyReferences": {
@@ -30931,7 +30931,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -30941,7 +30941,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -30963,7 +30963,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6324",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -30985,7 +30985,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeviceObjectPropertyReferences" ],
           "properties": {
             "DeviceObjectPropertyReferences": {
@@ -30993,7 +30993,7 @@
               "items": {
                 "title": "BACnetDeviceObjectPropertyReference",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
                 "required": [ "ObjectIdentifier" ],
                 "properties": {
                   "ObjectIdentifier": {
@@ -31003,7 +31003,7 @@
                   },
                   "PropertyIdentifier": {
                     "title": "BACnetPropertyIdentifier",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -31025,7 +31025,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6326",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -31049,13 +31049,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDateRange",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
         "required": [ "StartDate", "EndTime" ],
         "properties": {
           "StartDate": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -31065,21 +31065,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -31089,7 +31089,7 @@
           "EndTime": {
             "title": "BACnetDate",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -31099,21 +31099,21 @@
               },
               "Month": {
                 "title": "BACnetMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "BACnetDayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "BACnetDayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -31141,23 +31141,23 @@
         "items": {
           "title": "BACnetSpecialEvent",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103003",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSpecialEvent",
           "required": [ "Period", "ListOfTimeValues", "EventPriority" ],
           "properties": {
             "Period": {
               "title": "BACnetSpecialEventPeriod",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3055",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSpecialEventPeriod",
               "properties": {
                 "CalendarEntry": {
                   "title": "BACnetCalendarEntry",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCalendarEntry",
                   "properties": {
                     "Date": {
                       "title": "BACnetDate",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                       "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                       "properties": {
                         "Year": {
@@ -31167,21 +31167,21 @@
                         },
                         "Month": {
                           "title": "BACnetMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfMonth": {
                           "title": "BACnetDayOfMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfWeek": {
                           "title": "BACnetDayOfWeek",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31191,13 +31191,13 @@
                     "DateRange": {
                       "title": "BACnetDateRange",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3009",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDateRange",
                       "required": [ "StartDate", "EndTime" ],
                       "properties": {
                         "StartDate": {
                           "title": "BACnetDate",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -31207,21 +31207,21 @@
                             },
                             "Month": {
                               "title": "BACnetMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "BACnetDayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "BACnetDayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -31231,7 +31231,7 @@
                         "EndTime": {
                           "title": "BACnetDate",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -31241,21 +31241,21 @@
                             },
                             "Month": {
                               "title": "BACnetMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "BACnetDayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "BACnetDayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -31267,13 +31267,13 @@
                     "WeekNDay": {
                       "title": "BACnetWeekNDay",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3024",
+                      "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetWeekNDay",
                       "required": [ "Month", "Day", "DayOfWeek" ],
                       "properties": {
                         "Month": {
                           "title": "BACnetMonth",
                           "description": "January = 1, 0xFF = Any Month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31281,7 +31281,7 @@
                         "Day": {
                           "title": "BACnetDay",
                           "description": "1 = Days numbered 1-7, 2 = Day numbered 8-14, 3 = Days numbered 15-21, 4 = Days numbered 22-28, 5 = Days numbered 29-31, 6 = Last 7 days of this month, 0xFF = Any Week of this month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3021",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDay",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31289,7 +31289,7 @@
                         "DayOfWeek": {
                           "title": "BACnetDayOfWeek",
                           "description": "1 = Monday, 0xFF = Any day of week",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+                          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -31310,13 +31310,13 @@
               "items": {
                 "title": "BACnetTimeValue",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103004",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValue",
                 "required": [ "Time", "Value" ],
                 "properties": {
                   "Time": {
                     "title": "BACnetTime",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                     "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                     "properties": {
                       "Hour": {
@@ -31344,7 +31344,7 @@
                   "Value": {
                     "title": "BACnetTimeValueValue",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103010",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValueValue",
                     "required": [ "BooleanValue", "UnsignedValue", "SignedValue", "OctedStringValue", "CharStringValue", "ObjectIdentifierValue", "EnumerationValue", "BitStringValue" ],
                     "properties": {
                       "BooleanValue": {
@@ -31377,7 +31377,7 @@
                       "BitStringValue": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -31422,7 +31422,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -31432,7 +31432,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -31538,7 +31538,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31562,7 +31562,7 @@
         "items": {
           "title": "BACnetDailySchedule",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103001",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDailySchedule",
           "required": [ "Day-schedule" ],
           "properties": {
             "Day-schedule": {
@@ -31570,13 +31570,13 @@
               "items": {
                 "title": "BACnetTimeValue",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103004",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValue",
                 "required": [ "Time", "Value" ],
                 "properties": {
                   "Time": {
                     "title": "BACnetTime",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
                     "required": [ "Hour", "Minute", "Second", "Hundredths" ],
                     "properties": {
                       "Hour": {
@@ -31604,7 +31604,7 @@
                   "Value": {
                     "title": "BACnetTimeValueValue",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103010",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeValueValue",
                     "required": [ "BooleanValue", "UnsignedValue", "SignedValue", "OctedStringValue", "CharStringValue", "ObjectIdentifierValue", "EnumerationValue", "BitStringValue" ],
                     "properties": {
                       "BooleanValue": {
@@ -31637,7 +31637,7 @@
                       "BitStringValue": {
                         "title": "OptionSet",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+                        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
                         "required": [ "Value", "ValidBits" ],
                         "properties": {
                           "Value": {
@@ -31712,7 +31712,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetStructuredViewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStructuredViewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31735,7 +31735,7 @@
     "schemaDefinitions": {
       "BACnetNodeType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3045",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNodeType",
         "const": {
           "UNKNOWN": 0,
           "SYSTEM": 1,
@@ -31791,7 +31791,7 @@
       },
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -33381,7 +33381,7 @@
       "Node_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNodeType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3045",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNodeType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33425,7 +33425,7 @@
         "items": {
           "title": "BACnetDeviceObjectPropertyReference",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
           "required": [ "ObjectIdentifier" ],
           "properties": {
             "ObjectIdentifier": {
@@ -33435,7 +33435,7 @@
             },
             "PropertyIdentifier": {
               "title": "BACnetPropertyIdentifier",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33479,7 +33479,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetTimeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=101019",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTimeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33490,7 +33490,7 @@
     "schemaDefinitions": {
       "BACnetMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
         "const": {
           "January": 1,
           "February": 2,
@@ -33558,7 +33558,7 @@
       },
       "BACnetDayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
         "const": {
           "S1": 1,
           "S2": 2,
@@ -33706,7 +33706,7 @@
       },
       "BACnetDayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
         "const": {
           "Monday": 1,
           "Tuesday": 2,
@@ -33762,7 +33762,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6346",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Time" ],
           "properties": {
             "Time": {
@@ -33802,7 +33802,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDate",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDate",
         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
         "properties": {
           "Year": {
@@ -33812,21 +33812,21 @@
           },
           "Month": {
             "title": "BACnetMonth",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3014",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetMonth",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "DayOfMonth": {
             "title": "BACnetDayOfMonth",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfMonth",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "DayOfWeek": {
             "title": "BACnetDayOfWeek",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDayOfWeek",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -33850,7 +33850,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetTime",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetTime",
         "required": [ "Hour", "Minute", "Second", "Hundredths" ],
         "properties": {
           "Hour": {
@@ -33920,7 +33920,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetAutomaticTimeSynchronizationMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAutomaticTimeSynchronizationMasterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33948,7 +33948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6353",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AddToUtcList", "TimeSynchronizationRecipients" ],
           "properties": {
             "AddToUtcList": {
@@ -33959,7 +33959,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -33969,7 +33969,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -33992,7 +33992,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6354",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -34014,7 +34014,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6355",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RemoveFromUtcList", "TimeSynchronizationRecipients" ],
           "properties": {
             "RemoveFromUtcList": {
@@ -34025,7 +34025,7 @@
               "items": {
                 "title": "BACnetRecipient",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+                "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
                 "properties": {
                   "Device": {
                     "type": "integer",
@@ -34035,7 +34035,7 @@
                   "Address": {
                     "title": "BACnetAddress",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+                    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
                     "required": [ "NetworkNumber", "MacAddress" ],
                     "properties": {
                       "NetworkNumber": {
@@ -34058,7 +34058,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=6356",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FirstFailedElementNumber" ],
           "properties": {
             "FirstFailedElementNumber": {
@@ -34137,7 +34137,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -34147,7 +34147,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -34185,7 +34185,7 @@
         "items": {
           "title": "BACnetRecipient",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3054",
+          "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetRecipient",
           "properties": {
             "Device": {
               "type": "integer",
@@ -34195,7 +34195,7 @@
             "Address": {
               "title": "BACnetAddress",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetAddress",
               "required": [ "NetworkNumber", "MacAddress" ],
               "properties": {
                 "NetworkNumber": {
@@ -34240,7 +34240,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34252,7 +34252,7 @@
     "schemaDefinitions": {
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -34284,7 +34284,7 @@
       },
       "BACnetNotifyType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "const": {
           "Alarm": 0,
           "Event": 1,
@@ -34321,7 +34321,7 @@
       "From_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34361,7 +34361,7 @@
       "Notify_Type": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetNotifyType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetNotifyType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34382,7 +34382,7 @@
       "To_State": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetEventState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34413,7 +34413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34473,7 +34473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetBufferReadyNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBufferReadyNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -34485,7 +34485,7 @@
     "schemaDefinitions": {
       "BACnetPropertyIdentifier": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
         "const": {
           "AckedTransitions": 0,
           "AckRequired": 1,
@@ -36059,7 +36059,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetDeviceObjectPropertyReference",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=103002",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceObjectPropertyReference",
         "required": [ "ObjectIdentifier" ],
         "properties": {
           "ObjectIdentifier": {
@@ -36069,7 +36069,7 @@
           },
           "PropertyIdentifier": {
             "title": "BACnetPropertyIdentifier",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3046",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyIdentifier",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -36150,7 +36150,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfBitStringNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfBitStringNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36162,7 +36162,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36223,7 +36223,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36254,7 +36254,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfCharacterStringNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfCharacterStringNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36266,7 +36266,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36341,7 +36341,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36372,7 +36372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfRealValueNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfRealValueNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36384,7 +36384,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -36444,7 +36444,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36475,7 +36475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfStateNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfStateNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -36487,7 +36487,7 @@
     "schemaDefinitions": {
       "BACnetBinaryPV": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
         "const": {
           "Inactive": 0,
           "Active": 1
@@ -36503,7 +36503,7 @@
       },
       "BACnetEventEnumType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
         "const": {
           "ChangeOfBitstring": 0,
           "ChangeOfState": 1,
@@ -36551,7 +36551,7 @@
       },
       "BACnetPolarity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
         "const": {
           "Normal": 0,
           "Reverse": 1
@@ -36567,7 +36567,7 @@
       },
       "BACnetProgramRequest": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
         "const": {
           "Ready": 0,
           "Load": 1,
@@ -36599,7 +36599,7 @@
       },
       "BACnetProgramStates": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
         "const": {
           "Idle": 0,
           "Loading": 1,
@@ -36631,7 +36631,7 @@
       },
       "BACnetProgramError": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
         "const": {
           "Normal": 0,
           "LoadFailed": 1,
@@ -36659,7 +36659,7 @@
       },
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -36742,7 +36742,7 @@
       },
       "BACnetEventState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
         "const": {
           "Normal": 0,
           "Fault": 1,
@@ -36774,7 +36774,7 @@
       },
       "BACnetDeviceStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
         "const": {
           "Operational": 0,
           "OperationalReadOnly": 1,
@@ -36806,7 +36806,7 @@
       },
       "BACnetLifeSafetyMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
         "const": {
           "Off": 0,
           "On": 1,
@@ -36874,7 +36874,7 @@
       },
       "BACnetLifeSafetyState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
         "const": {
           "Quiet": 0,
           "PreAlarm": 1,
@@ -36978,7 +36978,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37020,7 +37020,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetPropertyStates",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3028",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPropertyStates",
         "required": [ "BooleanValue", "BinaryValue", "EventType", "Polarity", "ProgramChange", "ProgramState", "ProgramError", "Reliability", "State", "SystemStatus", "Units", "UnsignedValue", "LifeSafetyMode", "LifeSafetyState" ],
         "properties": {
           "BooleanValue": {
@@ -37028,63 +37028,63 @@
           },
           "BinaryValue": {
             "title": "BACnetBinaryPV",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetBinaryPV",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "EventType": {
             "title": "BACnetEventEnumType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3029",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnumType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "Polarity": {
             "title": "BACnetPolarity",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetPolarity",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramChange": {
             "title": "BACnetProgramRequest",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3030",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramRequest",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramState": {
             "title": "BACnetProgramStates",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3031",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramStates",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "ProgramError": {
             "title": "BACnetProgramError",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3032",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetProgramError",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "Reliability": {
             "title": "BACnetReliability",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "State": {
             "title": "BACnetEventState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "SystemStatus": {
             "title": "BACnetDeviceStatus",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3033",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDeviceStatus",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -37092,7 +37092,7 @@
           "Units": {
             "title": "EUInformation",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -37118,14 +37118,14 @@
           },
           "LifeSafetyMode": {
             "title": "BACnetLifeSafetyMode",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3035",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyMode",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "LifeSafetyState": {
             "title": "BACnetLifeSafetyState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3036",
+            "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLifeSafetyState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -37148,7 +37148,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37179,7 +37179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfValueNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfValueNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37191,7 +37191,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37233,7 +37233,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "OptionSet",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12755",
+        "dov:typeRef": "org.opcfoundation.UA.OptionSet",
         "required": [ "Value", "ValidBits" ],
         "properties": {
           "Value": {
@@ -37262,7 +37262,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37293,7 +37293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetCommandFailureNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetCommandFailureNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37305,7 +37305,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37382,7 +37382,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37413,7 +37413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetDoubleOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetDoubleOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37425,7 +37425,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37523,7 +37523,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37554,7 +37554,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFloatingLimitNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFloatingLimitNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37566,7 +37566,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37664,7 +37664,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37695,7 +37695,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37707,7 +37707,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37805,7 +37805,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37836,7 +37836,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSignedOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSignedOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37848,7 +37848,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -37940,7 +37940,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37971,7 +37971,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedOutOfRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedOutOfRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37983,7 +37983,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38078,7 +38078,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38109,7 +38109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetUnsignedRangeNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetUnsignedRangeNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38121,7 +38121,7 @@
     "schemaDefinitions": {
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38198,7 +38198,7 @@
       "StatusFlags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38229,7 +38229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFaultNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFaultNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38241,7 +38241,7 @@
     "schemaDefinitions": {
       "BACnetReliability": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "const": {
           "NoFaultDetected": 0,
           "NoSensor": 1,
@@ -38324,7 +38324,7 @@
       },
       "BACnetStatusFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "const": {
           "InAlarm": 0,
           "Fault": 1,
@@ -38365,7 +38365,7 @@
       "Reliability": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetReliability",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetReliability",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38386,7 +38386,7 @@
       "Status_Flags": {
         "dov:namespace": "http://opcfoundation.org/UA/BACnet_V2/",
         "title": "BACnetStatusFlags",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=3065",
+        "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetStatusFlags",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -38417,7 +38417,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetChangeOfReliabilityNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetChangeOfReliabilityNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38477,7 +38477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetEventEnrollmentNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetEventEnrollmentNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38504,7 +38504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetFeedbackNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetFeedbackNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38531,7 +38531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetLoopNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetLoopNotificationType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38558,7 +38558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "BACnet_V2_BACnetSimpleNotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/BACnet_V2/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.BACnet_V2.BACnetSimpleNotificationType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/CAS.TM.json
+++ b/wot-codegen/opc-output-simple/CAS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AnalysisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AnalysisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -51,7 +51,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASType",
     "dov:isComposite": true,
     "links": [
       {
@@ -102,7 +102,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CommunicationSettingsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CommunicationSettingsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -113,7 +113,7 @@
     "schemaDefinitions": {
       "IpVersionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.IpVersionEnum",
         "const": {
           "IPv4": 0,
           "IPv6": 1
@@ -227,7 +227,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "IpVersionEnum",
         "description": "Version of the internet protocol used for the MCS.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.IpVersionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -307,7 +307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ElectricalCircuitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ElectricalCircuitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -357,7 +357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ElectricalQuantitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ElectricalQuantitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -575,7 +575,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FluidCircuitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FluidCircuitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -610,7 +610,7 @@
     "schemaDefinitions": {
       "FluidTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
         "const": {
           "Air": 0,
           "Condensate": 1,
@@ -657,7 +657,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "FluidTypeEnum",
         "description": "Enumeration of possible fluid types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -677,7 +677,7 @@
         "data": {
           "title": "FluidTypeEnum",
           "description": "Enumeration of possible fluid types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FluidTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -701,7 +701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FluidQuantitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FluidQuantitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1109,7 +1109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetComponentsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1213,7 +1213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AnalysesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AnalysesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1257,7 +1257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1425,7 +1425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1451,7 +1451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1566,7 +1566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MCSConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MCSConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1626,7 +1626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1691,7 +1691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1702,7 +1702,7 @@
     "schemaDefinitions": {
       "CompressorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
         "const": {
           "Other": 0,
           "AxialTurboCompressor": 1,
@@ -1776,7 +1776,7 @@
       },
       "DisplacementTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
         "const": {
           "PositiveDisplacement": 0,
           "DynamicDisplacement": 1
@@ -1795,7 +1795,7 @@
       },
       "LubricationTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
         "const": {
           "NoLubrication": 0,
           "OilLubricated": 1,
@@ -1837,7 +1837,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "CompressorTypeEnum",
         "description": "Enumeration of possible compressor types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1854,7 +1854,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DisplacementTypeEnum",
         "description": "Enumeration of possible displacement types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1871,7 +1871,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "LubricationTypeEnum",
         "description": "Enumeration of possible lubrication types for the compression process of a compressor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1919,7 +1919,7 @@
         "data": {
           "title": "CompressorTypeEnum",
           "description": "Enumeration of possible compressor types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1937,7 +1937,7 @@
         "data": {
           "title": "DisplacementTypeEnum",
           "description": "Enumeration of possible displacement types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DisplacementTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1955,7 +1955,7 @@
         "data": {
           "title": "LubricationTypeEnum",
           "description": "Enumeration of possible lubrication types for the compression process of a compressor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.LubricationTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2009,7 +2009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2020,7 +2020,7 @@
     "schemaDefinitions": {
       "ConverterTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
         "const": {
           "Other": 0,
           "CatalyticHCConverter": 1
@@ -2057,7 +2057,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ConverterTypeEnum",
         "description": "Enumeration of possible converter types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2077,7 +2077,7 @@
         "data": {
           "title": "ConverterTypeEnum",
           "description": "Enumeration of possible converter types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2101,7 +2101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2112,7 +2112,7 @@
     "schemaDefinitions": {
       "DrainTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
         "const": {
           "Other": 0,
           "CapacitiveDrain": 1,
@@ -2159,7 +2159,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DrainTypeEnum",
         "description": "Enumeration of possible condensate drain types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2179,7 +2179,7 @@
         "data": {
           "title": "DrainTypeEnum",
           "description": "Enumeration of possible condensate drain types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DrainTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2203,7 +2203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2214,7 +2214,7 @@
     "schemaDefinitions": {
       "DryerTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
         "const": {
           "Other": 0,
           "AbsorptionDryer": 1,
@@ -2266,7 +2266,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DryerTypeEnum",
         "description": "Enumeration of possible dryer types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2301,7 +2301,7 @@
         "data": {
           "title": "DryerTypeEnum",
           "description": "Enumeration of possible dryer types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DryerTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2341,7 +2341,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FilterDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FilterDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2352,7 +2352,7 @@
     "schemaDefinitions": {
       "FilterTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
         "const": {
           "Other": 0,
           "ActivatedCarbonFilter": 1,
@@ -2396,7 +2396,7 @@
       },
       "FilterClassEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
         "const": {
           "S0": 0,
           "S1": 1,
@@ -2478,7 +2478,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "FilterTypeEnum",
         "description": "Enumeration of possible filter types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2496,13 +2496,13 @@
         "title": "FilterClassDataType",
         "description": "information about the used filter class according to ISO 8573-1 of a filter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
             "title": "FilterClassEnum",
             "description": "Class for particles",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2510,7 +2510,7 @@
           "B": {
             "title": "FilterClassEnum",
             "description": "Class for water and humidity",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2518,7 +2518,7 @@
           "C": {
             "title": "FilterClassEnum",
             "description": "Class for oil",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2540,7 +2540,7 @@
         "data": {
           "title": "FilterTypeEnum",
           "description": "Enumeration of possible filter types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FilterTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2559,13 +2559,13 @@
           "title": "FilterClassDataType",
           "description": "information about the used filter class according to ISO 8573-1 of a filter",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
               "title": "FilterClassEnum",
               "description": "Class for particles",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2573,7 +2573,7 @@
             "B": {
               "title": "FilterClassEnum",
               "description": "Class for water and humidity",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2581,7 +2581,7 @@
             "C": {
               "title": "FilterClassEnum",
               "description": "Class for oil",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.CAS.FilterClassEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2607,7 +2607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ReceiverDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2618,7 +2618,7 @@
     "schemaDefinitions": {
       "ReceiverTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
         "const": {
           "Other": 0,
           "DryReceiver": 1,
@@ -2660,7 +2660,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ReceiverTypeEnum",
         "description": "Enumeration of possible receiver types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2695,7 +2695,7 @@
         "data": {
           "title": "ReceiverTypeEnum",
           "description": "Enumeration of possible receiver types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2735,7 +2735,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SensorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SensorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2746,7 +2746,7 @@
     "schemaDefinitions": {
       "SensorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
         "const": {
           "Other": 0,
           "Ammeter": 1,
@@ -2820,7 +2820,7 @@
       },
       "SensorTechnologyOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
         "const": {
           "CapacitiveSensor": 0,
           "ElectronTube": 1,
@@ -2907,7 +2907,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SensorTypeEnum",
         "description": "Enumeration of possible sensor types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2924,7 +2924,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SensorTechnologyOptionSet",
         "description": "Selection of sensor technologies this sensor uses.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2957,7 +2957,7 @@
         "data": {
           "title": "SensorTypeEnum",
           "description": "Enumeration of possible sensor types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2975,7 +2975,7 @@
         "data": {
           "title": "SensorTechnologyOptionSet",
           "description": "Selection of sensor technologies this sensor uses.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SensorTechnologyOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3013,7 +3013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SeparatorDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3024,7 +3024,7 @@
     "schemaDefinitions": {
       "SeparatorTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
         "const": {
           "Other": 0,
           "CentrifugalOilyWaterSeparator": 1,
@@ -3081,7 +3081,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "SeparatorTypeEnum",
         "description": "Enumeration of possible condensate separator types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3101,7 +3101,7 @@
         "data": {
           "title": "SeparatorTypeEnum",
           "description": "Enumeration of possible condensate separator types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3125,7 +3125,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3136,7 +3136,7 @@
     "schemaDefinitions": {
       "ValveTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
         "const": {
           "Other": 0,
           "CheckValve": 1,
@@ -3193,7 +3193,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "ValveTypeEnum",
         "description": "Enumeration of possible valve types.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3228,7 +3228,7 @@
         "data": {
           "title": "ValveTypeEnum",
           "description": "Enumeration of possible valve types.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.ValveTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3268,7 +3268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_EventsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.EventsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3324,7 +3324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3424,7 +3424,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_OperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.OperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3570,7 +3570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3581,7 +3581,7 @@
     "schemaDefinitions": {
       "AirnetHealthStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
         "const": {
           "OK": 0,
           "Warning": 1,
@@ -3609,7 +3609,7 @@
       },
       "AirnetIntegratedStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
         "const": {
           "FullyIntegrated": 0,
           "PartiallyIntegrated": 1,
@@ -3632,7 +3632,7 @@
       },
       "AirnetOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -3758,7 +3758,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetHealthStateEnum",
         "description": "Actual health state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3775,7 +3775,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetIntegratedStateEnum",
         "description": "Actual integrated state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3792,7 +3792,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "AirnetOperatingStateEnum",
         "description": "Actual operating state of the airnet.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3952,7 +3952,7 @@
         "data": {
           "title": "AirnetHealthStateEnum",
           "description": "Actual health state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetHealthStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3970,7 +3970,7 @@
         "data": {
           "title": "AirnetIntegratedStateEnum",
           "description": "Actual integrated state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetIntegratedStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3988,7 +3988,7 @@
         "data": {
           "title": "AirnetOperatingStateEnum",
           "description": "Actual operating state of the airnet.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4076,7 +4076,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4087,7 +4087,7 @@
     "schemaDefinitions": {
       "CompressorOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -4198,7 +4198,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "CompressorOperatingStateEnum",
         "description": "Actual operating state of the compressor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4281,7 +4281,7 @@
         "data": {
           "title": "CompressorOperatingStateEnum",
           "description": "Actual operating state of the compressor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4321,7 +4321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4390,7 +4390,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4427,7 +4427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4438,7 +4438,7 @@
     "schemaDefinitions": {
       "DryerOperatingStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
         "const": {
           "Other": 0,
           "Stopped": 1,
@@ -4542,7 +4542,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CAS/",
         "title": "DryerOperatingStateEnum",
         "description": "Actual operating state of the dryer.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4591,7 +4591,7 @@
         "data": {
           "title": "DryerOperatingStateEnum",
           "description": "Actual operating state of the dryer.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.CAS.DryerOperatingStateEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4631,7 +4631,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveOperationalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveOperationalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4731,7 +4731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_StatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.StatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4931,7 +4931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5031,7 +5031,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5092,7 +5092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ComponentsGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ComponentsGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5196,7 +5196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ParticleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ParticleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5327,7 +5327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_AirnetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.AirnetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5395,7 +5395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CASComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CASComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5511,7 +5511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ChargingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ChargingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5538,7 +5538,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5589,7 +5589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5628,7 +5628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_CoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.CoolingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5655,7 +5655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DrainType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5700,7 +5700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_DryerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.DryerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5739,7 +5739,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_FilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.FilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5772,7 +5772,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_HeatRecoverySystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.HeatRecoverySystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5799,7 +5799,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ReceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ReceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5832,7 +5832,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5883,7 +5883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_SeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.SeparatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5922,7 +5922,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_ValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.ValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5961,7 +5961,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CAS_MCSType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CAS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.CAS.MCSType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/CSPPlusForMachine.TM.json
+++ b/wot-codegen/opc-output-simple/CSPPlusForMachine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CSPPlusForMachine_CsppMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CSPPlusForMachine/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.CSPPlusForMachine.CsppMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/CommercialKitchenEquipment.TM.json
+++ b/wot-codegen/opc-output-simple/CommercialKitchenEquipment.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_BatchInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BatchInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -54,7 +54,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -128,7 +128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_KitchenDeviceHAConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.KitchenDeviceHAConfigType",
     "dov:isComposite": true,
     "links": [
       {
@@ -203,7 +203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_KitchenDeviceParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.KitchenDeviceParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -343,7 +343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_ChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -354,7 +354,7 @@
     "schemaDefinitions": {
       "ChamberModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
         "const": {
           "NoSpecialMode": 0,
           "Off": 1,
@@ -610,7 +610,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "ChamberModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1130,7 +1130,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "ChamberModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ChamberModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1308,7 +1308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1319,7 +1319,7 @@
     "schemaDefinitions": {
       "CoffeeMachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -1425,7 +1425,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CoffeeMachineModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1608,7 +1608,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CoffeeMachineModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1696,7 +1696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineRecipeParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineRecipeParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1707,7 +1707,7 @@
     "schemaDefinitions": {
       "BeverageSMLEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
         "const": {
           "Inactive": 0,
           "Small": 1,
@@ -1774,7 +1774,7 @@
       "BeverageSML": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "BeverageSMLEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2044,7 +2044,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "BeverageSMLEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.BeverageSMLEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2199,7 +2199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CombiSteamerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2210,7 +2210,7 @@
     "schemaDefinitions": {
       "CombiSteamerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
         "const": {
           "Off": 0,
           "On": 1,
@@ -2262,7 +2262,7 @@
       },
       "SpecialCookingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
         "const": {
           "NoSpecialMode": 0,
           "Baking": 1,
@@ -2399,7 +2399,7 @@
       "CombiSteamerMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CombiSteamerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2564,7 +2564,7 @@
       "SpecialCookingMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SpecialCookingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2830,7 +2830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CombiSteamerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3001,7 +3001,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SpecialCookingModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialCookingModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3060,7 +3060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingKettleParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3071,7 +3071,7 @@
     "schemaDefinitions": {
       "CookingKettleModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -3115,7 +3115,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -3198,7 +3198,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CookingKettleModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3262,7 +3262,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3418,7 +3418,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CookingKettleModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3486,7 +3486,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3528,7 +3528,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingZoneParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingZoneParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3539,7 +3539,7 @@
     "schemaDefinitions": {
       "CurrentStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -3638,7 +3638,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "CurrentStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3839,7 +3839,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "CurrentStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CurrentStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3928,7 +3928,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_DishWashingMachineProgramParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.DishWashingMachineProgramParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3939,7 +3939,7 @@
     "schemaDefinitions": {
       "HygieneModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
         "const": {
           "HygieneOperationOFF": 0,
           "HygieneA0": 1,
@@ -3971,7 +3971,7 @@
       },
       "OperationModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
         "const": {
           "Init": 0,
           "MachineOff": 1,
@@ -4043,7 +4043,7 @@
       },
       "ProgramModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
         "const": {
           "OperationOFF": 0,
           "PreWash": 1,
@@ -4277,7 +4277,7 @@
       "HygieneMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "HygieneModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4338,7 +4338,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "OperationModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4411,7 +4411,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "ProgramModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4737,7 +4737,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "HygieneModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.HygieneModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4802,7 +4802,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "OperationModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperationModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4852,7 +4852,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "ProgramModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ProgramModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4910,7 +4910,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4921,7 +4921,7 @@
     "schemaDefinitions": {
       "FryerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -4957,7 +4957,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -5022,7 +5022,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "FryerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5070,7 +5070,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5183,7 +5183,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "FryerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5234,7 +5234,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5276,7 +5276,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingAndGrillingParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingAndGrillingParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5287,7 +5287,7 @@
     "schemaDefinitions": {
       "GrillingZoneStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
         "const": {
           "Off": 0,
           "Standby": 1,
@@ -5311,7 +5311,7 @@
       },
       "PlatenPositionStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
         "const": {
           "Home": 0,
           "Cooking": 1,
@@ -5386,7 +5386,7 @@
       "CurrentState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "GrillingZoneStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5426,7 +5426,7 @@
       "PlatenPositionState": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PlatenPositionStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5619,7 +5619,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "GrillingZoneStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.GrillingZoneStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5662,7 +5662,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PlatenPositionStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PlatenPositionStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5757,7 +5757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingPanParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5768,7 +5768,7 @@
     "schemaDefinitions": {
       "FryingPanModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -5816,7 +5816,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -5927,7 +5927,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "FryingPanModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5991,7 +5991,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6189,7 +6189,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "FryingPanModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6257,7 +6257,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6299,7 +6299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_IceMachineParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.IceMachineParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6310,7 +6310,7 @@
     "schemaDefinitions": {
       "StatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
         "const": {
           "INIT": 0,
           "WATER_PURGE": 1,
@@ -6443,7 +6443,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "StatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6577,7 +6577,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "StatusEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.StatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6637,7 +6637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MicrowaveCombiOvenParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MicrowaveCombiOvenParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6648,7 +6648,7 @@
     "schemaDefinitions": {
       "OperatingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
         "const": {
           "Preheat": 0,
           "CoolDown": 1,
@@ -6793,7 +6793,7 @@
       "OperatingMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "OperatingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7039,7 +7039,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "OperatingModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OperatingModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7132,7 +7132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MultiFunctionPanParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7143,7 +7143,7 @@
     "schemaDefinitions": {
       "MultiFunctionPanModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
         "const": {
           "Off": 0,
           "On": 1,
@@ -7215,7 +7215,7 @@
       },
       "SpecialFunctionModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
         "const": {
           "LidUpDown": 0,
           "PanTilt": 1,
@@ -7421,7 +7421,7 @@
       "MultiFunctionPanMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "MultiFunctionPanModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7518,7 +7518,7 @@
       "SpecialFunctionMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SpecialFunctionModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7878,7 +7878,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "MultiFunctionPanModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7981,7 +7981,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SpecialFunctionModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SpecialFunctionModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8040,7 +8040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PastaCookerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8051,7 +8051,7 @@
     "schemaDefinitions": {
       "PastaCookerModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -8091,7 +8091,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -8158,7 +8158,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PastaCookerModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8206,7 +8206,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8321,7 +8321,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PastaCookerModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8372,7 +8372,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8414,7 +8414,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PressureCookingKettleParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8425,7 +8425,7 @@
     "schemaDefinitions": {
       "PressureCookingKettleModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
         "const": {
           "Off": 0,
           "Preheat": 1,
@@ -8469,7 +8469,7 @@
       },
       "SignalModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "const": {
           "SignalOff": 0,
           "SignalOn": 1,
@@ -8620,7 +8620,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "PressureCookingKettleModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8684,7 +8684,7 @@
       "SignalMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "SignalModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8937,7 +8937,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "PressureCookingKettleModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9005,7 +9005,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "SignalModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.SignalModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9047,7 +9047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_TrayType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9058,7 +9058,7 @@
     "schemaDefinitions": {
       "TrayModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
         "const": {
           "Off": 0,
           "PreHeat": 1,
@@ -9090,7 +9090,7 @@
       },
       "TrayTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
         "const": {
           "Generic": 0,
           "HeaterPlate": 1,
@@ -9225,7 +9225,7 @@
       "ProgramMode": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TrayModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9267,7 +9267,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "TrayTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9385,7 +9385,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "TrayModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9419,7 +9419,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "data": {
           "title": "TrayTypeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.TrayTypeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9443,7 +9443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CommercialKitchenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CommercialKitchenDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9525,7 +9525,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CoffeeMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CoffeeMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9564,7 +9564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CombiSteamerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CombiSteamerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9582,7 +9582,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9614,7 +9614,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9688,7 +9688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingKettleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingKettleDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9706,7 +9706,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9738,7 +9738,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9789,7 +9789,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_CookingZoneDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.CookingZoneDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9807,7 +9807,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -9844,7 +9844,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9941,7 +9941,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_DishWashingMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.DishWashingMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9974,7 +9974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9992,7 +9992,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10024,7 +10024,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10062,7 +10062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingAndGrillingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingAndGrillingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10080,7 +10080,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10112,7 +10112,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10138,7 +10138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_FryingPanDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.FryingPanDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10156,7 +10156,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10188,7 +10188,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10226,7 +10226,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_IceMachineDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.IceMachineDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10259,7 +10259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MicrowaveCombiOvenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MicrowaveCombiOvenDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10292,7 +10292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_MultiFunctionPanDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.MultiFunctionPanDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10310,7 +10310,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10342,7 +10342,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10368,7 +10368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_OvenDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.OvenDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10401,7 +10401,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PastaCookerDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PastaCookerDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10419,7 +10419,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10451,7 +10451,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10489,7 +10489,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_PressureCookingKettleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.PressureCookingKettleDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10507,7 +10507,7 @@
     "schemaDefinitions": {
       "EnergySourceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "const": {
           "Electric": 0,
           "Gas": 1,
@@ -10539,7 +10539,7 @@
       "EnergySource": {
         "dov:namespace": "http://opcfoundation.org/UA/CommercialKitchenEquipment/",
         "title": "EnergySourceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.EnergySourceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10565,7 +10565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CommercialKitchenEquipment_ServeryCounterDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CommercialKitchenEquipment/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.CommercialKitchenEquipment.ServeryCounterDeviceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/CranesHoists.TM.json
+++ b/wot-codegen/opc-output-simple/CranesHoists.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_BrakeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1556",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.BrakeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1369",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -61,7 +61,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1392",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotionDeviceSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=2112",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotionDeviceSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -114,7 +114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_CraneMotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1262",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.CraneMotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -147,7 +147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CranesHoists_ProtectiveFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CranesHoists/;i=1462",
+    "dov:typeRef": "org.opcfoundation.UA.CranesHoists.ProtectiveFunctionType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/CuttingTool.TM.json
+++ b/wot-codegen/opc-output-simple/CuttingTool.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_CuttingToolFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.CuttingToolFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -38,7 +38,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/CuttingTool/",
         "title": "FileFormatDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.CuttingTool.FileFormatDataType",
         "required": [ "Name", "FileExtension", "Version" ],
         "properties": {
           "Name": {
@@ -78,7 +78,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_ToolMeasuringMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.ToolMeasuringMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -117,7 +117,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "CuttingTool_ToolManufacturingMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/CuttingTool/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.CuttingTool.ToolManufacturingMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/DEXPI.TM.json
+++ b/wot-codegen/opc-output-simple/DEXPI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DEXPISupplementaryDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DEXPISupplementaryDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BaseDEXPIObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BaseDEXPIObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -156,7 +156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantModelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantModelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantType",
     "links": [
       {
         "rel": "tm:extends",
@@ -263,7 +263,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MetaDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MetaDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -274,7 +274,7 @@
     "schemaDefinitions": {
       "ConfidentialityClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
         "const": {
           "ConfidentialInformation": 0,
           "NonConfidentialInformation": 1
@@ -496,7 +496,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ConfidentialityClassification",
         "description": "The confidentiality of the drawing.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1131,7 +1131,7 @@
         "data": {
           "title": "ConfidentialityClassification",
           "description": "The confidentiality of the drawing.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1012",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConfidentialityClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1521,7 +1521,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SensingLocationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1117",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SensingLocationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1547,7 +1547,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessSignalGeneratingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1118",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessSignalGeneratingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1666,7 +1666,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PositionerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1127",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PositionerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1773,7 +1773,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessInstrumentationFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1130",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessInstrumentationFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1802,7 +1802,7 @@
     "schemaDefinitions": {
       "GmpRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "const": {
           "GmpRelevantFunction": 0,
           "NonGmpRelevantFunction": 1
@@ -1821,7 +1821,7 @@
       },
       "GuaranteedSupplyFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "const": {
           "GuaranteedSupplyFunction": 0,
           "NonGuaranteedSupplyFunction": 1
@@ -1840,7 +1840,7 @@
       },
       "LocationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "const": {
           "CentralLocation": 0,
           "ControlPanel": 1,
@@ -1864,7 +1864,7 @@
       },
       "QualityRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "const": {
           "NonQualityRelevantFunction": 0,
           "QualityRelevantFunction": 1
@@ -1924,7 +1924,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GmpRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1946,7 +1946,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GuaranteedSupplyFunctionClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1968,7 +1968,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "LocationClassification",
         "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2080,7 +2080,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "QualityRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2191,7 +2191,7 @@
         "data": {
           "title": "GmpRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2209,7 +2209,7 @@
         "data": {
           "title": "GuaranteedSupplyFunctionClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2227,7 +2227,7 @@
         "data": {
           "title": "LocationClassification",
           "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2315,7 +2315,7 @@
         "data": {
           "title": "QualityRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2395,7 +2395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1152",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2425,7 +2425,7 @@
     "schemaDefinitions": {
       "GmpRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "const": {
           "GmpRelevantFunction": 0,
           "NonGmpRelevantFunction": 1
@@ -2444,7 +2444,7 @@
       },
       "GuaranteedSupplyFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "const": {
           "GuaranteedSupplyFunction": 0,
           "NonGuaranteedSupplyFunction": 1
@@ -2463,7 +2463,7 @@
       },
       "LocationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "const": {
           "CentralLocation": 0,
           "ControlPanel": 1,
@@ -2487,7 +2487,7 @@
       },
       "QualityRelevanceClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "const": {
           "NonQualityRelevantFunction": 0,
           "QualityRelevantFunction": 1
@@ -2547,7 +2547,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GmpRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2569,7 +2569,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "GuaranteedSupplyFunctionClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2591,7 +2591,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "LocationClassification",
         "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2703,7 +2703,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "QualityRelevanceClassification",
         "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2814,7 +2814,7 @@
         "data": {
           "title": "GmpRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is relevant for GMP (good manufacturing practise).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1020",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GmpRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2832,7 +2832,7 @@
         "data": {
           "title": "GuaranteedSupplyFunctionClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is a guaranteed supply function.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1004",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.GuaranteedSupplyFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2850,7 +2850,7 @@
         "data": {
           "title": "LocationClassification",
           "description": "A specialization indicating the location of the ProcessInstrumentationFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1054",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.LocationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2938,7 +2938,7 @@
         "data": {
           "title": "QualityRelevanceClassification",
           "description": "A classification indicating if the ProcessInstrumentationFunction is quality relevant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1010",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.QualityRelevanceClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3018,7 +3018,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalLineFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1174",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalLineFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3030,7 +3030,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -3069,7 +3069,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -3126,7 +3126,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3148,7 +3148,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3209,7 +3209,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3227,7 +3227,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3279,7 +3279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MeasuringLineFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1181",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MeasuringLineFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3291,7 +3291,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -3330,7 +3330,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -3387,7 +3387,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3409,7 +3409,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3470,7 +3470,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3488,7 +3488,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3540,7 +3540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InstrumentationLoopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1188",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InstrumentationLoopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3615,7 +3615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1195",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimaryElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3690,7 +3690,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShutOffValveReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1197",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShutOffValveReferenceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3765,7 +3765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ActuatingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1200",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ActuatingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3890,7 +3890,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessSignalGeneratingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1210",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessSignalGeneratingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3997,7 +3997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1219",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionTargetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4023,7 +4023,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_OfflinePrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1220",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.OfflinePrimaryElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4035,7 +4035,7 @@
     "schemaDefinitions": {
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -4369,7 +4369,7 @@
       },
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -4462,7 +4462,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the device connection of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4538,7 +4538,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the OfflinePrimaryElement.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4634,7 +4634,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the location of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4725,7 +4725,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the device connection of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4785,7 +4785,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the OfflinePrimaryElement.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4861,7 +4861,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the location of the OfflinePrimaryElement, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4915,7 +4915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ActuatingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1239",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ActuatingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4990,7 +4990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TransmitterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1247",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TransmitterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5097,7 +5097,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionSourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1250",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionSourceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5123,7 +5123,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SignalConveyingFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1251",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5134,7 +5134,7 @@
     "schemaDefinitions": {
       "PortStatusClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "const": {
           "StatusHighHighHighPort": 0,
           "StatusHighHighPort": 1,
@@ -5173,7 +5173,7 @@
       },
       "SignalConveyingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "const": {
           "CapillarySignalConveying": 0,
           "ConductedRadiationSignalConveying": 1,
@@ -5230,7 +5230,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PortStatusClassification",
         "description": "A classification indicating the port status of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5252,7 +5252,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SignalConveyingTypeClassification",
         "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5313,7 +5313,7 @@
         "data": {
           "title": "PortStatusClassification",
           "description": "A classification indicating the port status of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1056",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PortStatusClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5331,7 +5331,7 @@
         "data": {
           "title": "SignalConveyingTypeClassification",
           "description": "A classification indicating the signal conveying type of the SignalConveyingFunction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1040",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SignalConveyingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5383,7 +5383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ControlledActuatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1258",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ControlledActuatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5394,7 +5394,7 @@
     "schemaDefinitions": {
       "FailActionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
         "const": {
           "FailClose": 0,
           "FailOpen": 1,
@@ -5477,7 +5477,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "FailActionClassification",
         "description": "The fail action of the ControlledActuator.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5548,7 +5548,7 @@
         "data": {
           "title": "FailActionClassification",
           "description": "The fail action of the ControlledActuator.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1050",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.FailActionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5586,7 +5586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InlinePrimaryElementReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1263",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InlinePrimaryElementReferenceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5613,7 +5613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSectionIso10209_2012Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1265",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSectionIso10209-2012Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -5721,7 +5721,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaIsa95LocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1270",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaIsa95LocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5747,7 +5747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IndustrialComplexIso10209_2012Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1272",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IndustrialComplexIso10209-2012Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -5855,7 +5855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantTrainLocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1277",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantTrainLocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5881,7 +5881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessPlantParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1279",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessPlantParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5907,7 +5907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SiteIsa95Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1280",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiteIsa95Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -6015,7 +6015,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IndustrialComplexIso10209_2012ParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1284",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IndustrialComplexIso10209-2012ParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6041,7 +6041,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TechnicalItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1285",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TechnicalItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6067,7 +6067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaIsa95Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1290",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaIsa95Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -6175,7 +6175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSystemLocatedStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1293",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSystemLocatedStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6201,7 +6201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TechnicalItemParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1295",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TechnicalItemParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6227,7 +6227,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSectionIso10209_2012ParentStructureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1296",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSectionIso10209-2012ParentStructureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6253,7 +6253,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1297",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6361,7 +6361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessPlantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1300",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessPlantType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6469,7 +6469,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_Isa95EnterpriseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1305",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.Isa95EnterpriseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6577,7 +6577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantStructureItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1308",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantStructureItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6603,7 +6603,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlantTrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1309",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlantTrainType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6711,7 +6711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_EjectorPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1312",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.EjectorPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6791,7 +6791,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_KneaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1316",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.KneaderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6943,7 +6943,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1326",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7095,7 +7095,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TaggedPlantItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1337",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TaggedPlantItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7266,7 +7266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1342",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7388,7 +7388,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ThinFilmEvaporatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1350",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ThinFilmEvaporatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7546,7 +7546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NozzleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1361",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NozzleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7563,7 +7563,7 @@
     "schemaDefinitions": {
       "NominalPressureStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
         "const": {
           "Class10000PsiArtefact": 0,
           "Class1000KpaArtefact": 1,
@@ -7851,7 +7851,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalPressureStandardClassification",
         "description": "The nominal pressure of the Nozzle, given as a reference to a nominal pressure standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7940,7 +7940,7 @@
         "data": {
           "title": "NominalPressureStandardClassification",
           "description": "The nominal pressure of the Nozzle, given as a reference to a nominal pressure standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1018",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalPressureStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7992,7 +7992,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpiralHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1369",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpiralHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8019,7 +8019,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnPackingsArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1370",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnPackingsArrangementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8199,7 +8199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ChamberOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1377",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8231,7 +8231,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ReciprocatingCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1379",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ReciprocatingCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8353,7 +8353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1387",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8543,7 +8543,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SubTaggedColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1399",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SubTaggedColumnSectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8696,7 +8696,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1408",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8812,7 +8812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1415",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8964,7 +8964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1425",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9044,7 +9044,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GasFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1431",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GasFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9238,7 +9238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PressureVesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1445",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PressureVesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9318,7 +9318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialVesselType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1449",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialVesselType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9430,7 +9430,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1454",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9463,7 +9463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FilterUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1456",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FilterUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9790,7 +9790,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AirCoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1478",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AirCoolingSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9948,7 +9948,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnInternalsArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1489",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnInternalsArrangementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9974,7 +9974,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SiloType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1490",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiloType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10001,7 +10001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatExchangerRotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1491",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatExchangerRotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10076,7 +10076,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1494",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnSectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10197,7 +10197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PumpEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1502",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PumpEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10223,7 +10223,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ReciprocatingPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1503",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ReciprocatingPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10345,7 +10345,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TaggedColumnSectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1511",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TaggedColumnSectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10595,7 +10595,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1523",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10606,7 +10606,7 @@
     "schemaDefinitions": {
       "ChamberFunctionClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
         "const": {
           "Cooling": 0,
           "Heating": 1,
@@ -10694,7 +10694,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ChamberFunctionClassification",
         "description": "A specialization indicating the function of the Chamber.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10981,7 +10981,7 @@
         "data": {
           "title": "ChamberFunctionClassification",
           "description": "A specialization indicating the function of the Chamber.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1044",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ChamberFunctionClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -11191,7 +11191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ElectricHeaterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1557",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ElectricHeaterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11277,7 +11277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MixingElementAssemblyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1562",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MixingElementAssemblyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11388,7 +11388,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CentrifugalCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1566",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CentrifugalCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11510,7 +11510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NozzleOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1574",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NozzleOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11542,7 +11542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlateAndShellHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1576",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlateAndShellHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11694,7 +11694,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CentrifugalPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1584",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CentrifugalPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11816,7 +11816,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TubeBundleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1592",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TubeBundleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11827,7 +11827,7 @@
     "schemaDefinitions": {
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -12278,7 +12278,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the tubes, given as a reference to a nominal diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -12395,7 +12395,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the tubes, given as a reference to a nominal diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -12433,7 +12433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ColumnTraysArrangementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1603",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ColumnTraysArrangementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12577,7 +12577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpecialPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1607",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpecialPumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12767,7 +12767,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1619",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12794,7 +12794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AirEjectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1620",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AirEjectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12880,7 +12880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StaticMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1625",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StaticMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12960,7 +12960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ImpellerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1629",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ImpellerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13103,7 +13103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompressorEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1636",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompressorEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13129,7 +13129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AgitatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1637",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AgitatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13251,7 +13251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AxialCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1645",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AxialCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13373,7 +13373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShellAndTubeHeatExchangerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1653",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShellAndTubeHeatExchangerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13455,7 +13455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DisplacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1656",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DisplacerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13598,7 +13598,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TankType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1663",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TankType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13678,7 +13678,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ProcessColumnType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1667",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ProcessColumnType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13764,7 +13764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AgitatorRotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1672",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AgitatorRotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13943,7 +13943,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1682",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14158,7 +14158,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LiquidFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1694",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LiquidFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14352,7 +14352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotaryCompressorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1708",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotaryCompressorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14474,7 +14474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1716",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PumpType",
     "dov:isComposite": true,
     "links": [
       {
@@ -14626,7 +14626,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1726",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -14649,7 +14649,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -14683,7 +14683,7 @@
       },
       "JacketedPipeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "const": {
           "JacketedPipe": 0,
           "UnjacketedPipe": 1
@@ -14702,7 +14702,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -15036,7 +15036,7 @@
       },
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -15114,7 +15114,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipingNetworkSystem.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15192,7 +15192,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "JacketedPipeClassification",
         "description": "A specialization indicating whether the PipingNetworkSystem is jacketed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15306,7 +15306,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNetworkSystem, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15346,7 +15346,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingNetworkSystem is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15435,7 +15435,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipingNetworkSystem.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15497,7 +15497,7 @@
         "data": {
           "title": "JacketedPipeClassification",
           "description": "A specialization indicating whether the PipingNetworkSystem is jacketed.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15587,7 +15587,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNetworkSystem, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15619,7 +15619,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingNetworkSystem is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -15671,7 +15671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSegmentItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1754",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15697,7 +15697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TurbineFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1755",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TurbineFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15724,7 +15724,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1756",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15751,7 +15751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StrainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1757",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StrainerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15763,7 +15763,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -15838,7 +15838,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15989,7 +15989,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16101,7 +16101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FunnelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1770",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FunnelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16128,7 +16128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_NeedleValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1771",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.NeedleValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16155,7 +16155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InLineMixerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1772",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InLineMixerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16182,7 +16182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1773",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16194,7 +16194,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -16269,7 +16269,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the CheckValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16420,7 +16420,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the CheckValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16532,7 +16532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1786",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeConnectorSymbolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16564,7 +16564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1788",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16591,7 +16591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleBallValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1789",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleBallValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16618,7 +16618,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BallValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1790",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BallValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16645,7 +16645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PlugValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1791",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PlugValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16672,7 +16672,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_CompensatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1792",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompensatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16699,7 +16699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_InlinePrimaryElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1793",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.InlinePrimaryElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -16711,7 +16711,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -16786,7 +16786,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the InlinePrimaryElement.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16919,7 +16919,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the InlinePrimaryElement.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -17017,7 +17017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlangedConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1805",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlangedConnectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17044,7 +17044,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HoseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1806",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HoseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17071,7 +17071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingSourceItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1807",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingSourceItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17097,7 +17097,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleGlobeValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1808",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleGlobeValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17124,7 +17124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PositiveDisplacementFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1809",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PositiveDisplacementFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17151,7 +17151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VariableAreaFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1810",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VariableAreaFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17178,7 +17178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ElectromagneticFlowMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1811",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ElectromagneticFlowMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17205,7 +17205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SteamTrapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1812",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SteamTrapType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17217,7 +17217,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -17292,7 +17292,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17443,7 +17443,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -17555,7 +17555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_IlluminatedSightGlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1825",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.IlluminatedSightGlassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17582,7 +17582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingTargetItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1826",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingTargetItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17608,7 +17608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowInPipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1827",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowInPipeConnectorSymbolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17641,7 +17641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowOutPipeConnectorSymbolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1829",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowOutPipeConnectorSymbolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17674,7 +17674,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpringLoadedGlobeSafetyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1831",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpringLoadedGlobeSafetyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17701,7 +17701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SilencerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1832",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SilencerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17713,7 +17713,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -17788,7 +17788,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17939,7 +17939,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18051,7 +18051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ShutOffValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1845",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ShutOffValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18063,7 +18063,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -18097,7 +18097,7 @@
       },
       "NumberOfPortsClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
         "const": {
           "FourPortValve": 0,
           "ThreePortValve": 1,
@@ -18121,7 +18121,7 @@
       },
       "OperationClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
         "const": {
           "ContinuousOperation": 0,
           "IntermittentOperation": 1
@@ -18181,7 +18181,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18261,7 +18261,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NumberOfPortsClassification",
         "description": "A specialization indicating the number of ports of the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18283,7 +18283,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OperationClassification",
         "description": "A specialization indicating the operation of the ShutOffValve.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18376,7 +18376,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18440,7 +18440,7 @@
         "data": {
           "title": "NumberOfPortsClassification",
           "description": "A specialization indicating the number of ports of the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1022",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NumberOfPortsClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18458,7 +18458,7 @@
         "data": {
           "title": "OperationClassification",
           "description": "A specialization indicating the operation of the ShutOffValve.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1046",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OperationClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -18524,7 +18524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_DirectPipingConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1860",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.DirectPipingConnectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18551,7 +18551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1865",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18578,7 +18578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ConicalStrainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1866",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ConicalStrainerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18605,7 +18605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SightGlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1867",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SightGlassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18632,7 +18632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BreatherValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1868",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BreatherValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18659,7 +18659,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GlobeValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1869",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GlobeValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18686,7 +18686,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFlangeSpacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1870",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFlangeSpacerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18713,7 +18713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_BlindFlangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1871",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.BlindFlangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18740,7 +18740,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RuptureDiscType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1872",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RuptureDiscType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18767,7 +18767,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_StraightwayValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1873",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.StraightwayValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18794,7 +18794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GlobeCheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1874",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GlobeCheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18821,7 +18821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeTeeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1875",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeTeeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18848,7 +18848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SpringLoadedAngleGlobeSafetyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1876",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SpringLoadedAngleGlobeSafetyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18875,7 +18875,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFittingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1877",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFittingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18887,7 +18887,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -18962,7 +18962,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19113,7 +19113,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -19225,7 +19225,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1890",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19252,7 +19252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumetricFlowDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1895",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumetricFlowDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19279,7 +19279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeFlangeSpadeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1896",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeFlangeSpadeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19306,7 +19306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ClampedFlangeCouplingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1897",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ClampedFlangeCouplingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -19333,7 +19333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNetworkSegmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1898",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19356,7 +19356,7 @@
     "schemaDefinitions": {
       "PipingNetworkSegmentFlowClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
         "const": {
           "DualFlowPipingNetworkSegment": 0,
           "SingleFlowPipingNetworkSegment": 1
@@ -19375,7 +19375,7 @@
       },
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -19409,7 +19409,7 @@
       },
       "JacketedPipeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "const": {
           "JacketedPipe": 0,
           "UnjacketedPipe": 1
@@ -19428,7 +19428,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -19762,7 +19762,7 @@
       },
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -19781,7 +19781,7 @@
       },
       "PrimarySecondaryPipingNetworkSegmentClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
         "const": {
           "PrimaryPipingNetworkSegment": 0,
           "SecondaryPipingNetworkSegment": 1
@@ -19800,7 +19800,7 @@
       },
       "SiphonClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
         "const": {
           "NoSiphon": 0,
           "Siphon": 1
@@ -19819,7 +19819,7 @@
       },
       "PipingNetworkSegmentSlopeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
         "const": {
           "SlopedPipingNetworkSegment": 0,
           "UnslopedPipingNetworkSegment": 1
@@ -19897,7 +19897,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingNetworkSegmentFlowClassification",
         "description": "A specialization indicating if the PipingNetworkSegment enables dual flow or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19955,7 +19955,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipingNetworkSegment.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20035,7 +20035,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "JacketedPipeClassification",
         "description": "A specialization indicating whether the PipingNetworkSegment is jacketed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20113,7 +20113,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNetworkSegment, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20153,7 +20153,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20231,7 +20231,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PrimarySecondaryPipingNetworkSegmentClassification",
         "description": "A specialization indicating whether the PipingNetworkSegment is a primary or secondary PipingNetworkSegment.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20271,7 +20271,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "SiphonClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is a siphon or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20293,7 +20293,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingNetworkSegmentSlopeClassification",
         "description": "A specialization indicating if the PipingNetworkSegment is sloped or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20346,7 +20346,7 @@
         "data": {
           "title": "PipingNetworkSegmentFlowClassification",
           "description": "A specialization indicating if the PipingNetworkSegment enables dual flow or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1002",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentFlowClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20392,7 +20392,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipingNetworkSegment.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20456,7 +20456,7 @@
         "data": {
           "title": "JacketedPipeClassification",
           "description": "A specialization indicating whether the PipingNetworkSegment is jacketed.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1052",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.JacketedPipeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20518,7 +20518,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNetworkSegment, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20550,7 +20550,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20612,7 +20612,7 @@
         "data": {
           "title": "PrimarySecondaryPipingNetworkSegmentClassification",
           "description": "A specialization indicating whether the PipingNetworkSegment is a primary or secondary PipingNetworkSegment.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1042",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PrimarySecondaryPipingNetworkSegmentClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20644,7 +20644,7 @@
         "data": {
           "title": "SiphonClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is a siphon or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1000",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.SiphonClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20662,7 +20662,7 @@
         "data": {
           "title": "PipingNetworkSegmentSlopeClassification",
           "description": "A specialization indicating if the PipingNetworkSegment is sloped or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1034",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNetworkSegmentSlopeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20686,7 +20686,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PenetrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1936",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PenetrationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20713,7 +20713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SwingCheckValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1937",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SwingCheckValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20740,7 +20740,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PropertyBreakType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1938",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PropertyBreakType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20757,7 +20757,7 @@
     "schemaDefinitions": {
       "CompositionBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
         "const": {
           "CompositionBreak": 0,
           "NoCompositionBreak": 1
@@ -20776,7 +20776,7 @@
       },
       "InsulationBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
         "const": {
           "InsulationBreak": 0,
           "NoInsulationBreak": 1
@@ -20795,7 +20795,7 @@
       },
       "NominalDiameterBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
         "const": {
           "NoNominalDiameterBreak": 0,
           "NominalDiameterBreak": 1
@@ -20814,7 +20814,7 @@
       },
       "PipingClassBreakClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
         "const": {
           "NoPipingClassBreak": 0,
           "PipingClassBreak": 1
@@ -20856,7 +20856,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "CompositionBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20878,7 +20878,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "InsulationBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is an insulation break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20900,7 +20900,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a nominal diameter break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20922,7 +20922,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingClassBreakClassification",
         "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20947,7 +20947,7 @@
         "data": {
           "title": "CompositionBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1026",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.CompositionBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20965,7 +20965,7 @@
         "data": {
           "title": "InsulationBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is an insulation break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.InsulationBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -20983,7 +20983,7 @@
         "data": {
           "title": "NominalDiameterBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a nominal diameter break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1048",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21001,7 +21001,7 @@
         "data": {
           "title": "PipingClassBreakClassification",
           "description": "A specialization indicating if the PropertyBreak is a composition break or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1016",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassBreakClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21025,7 +21025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_SafetyValveOrFittingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1944",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.SafetyValveOrFittingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21269,7 +21269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VenturiTubeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1955",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VenturiTubeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21296,7 +21296,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlowNozzleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1956",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlowNozzleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21323,7 +21323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AnglePlugValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1957",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AnglePlugValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21350,7 +21350,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VentilationDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1958",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VentilationDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21362,7 +21362,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -21437,7 +21437,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21588,7 +21588,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21700,7 +21700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeCouplingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1971",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeCouplingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21727,7 +21727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_FlameArrestorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1972",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.FlameArrestorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21739,7 +21739,7 @@
     "schemaDefinitions": {
       "DetonationProofArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
         "const": {
           "DetonationProofArtefact": 0,
           "NonDetonationProofArtefact": 1
@@ -21758,7 +21758,7 @@
       },
       "ExplosionProofArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
         "const": {
           "ExplosionProofArtefact": 0,
           "NonExplosionProofArtefact": 1
@@ -21777,7 +21777,7 @@
       },
       "FireResistantArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
         "const": {
           "FireResistantArtefact": 0,
           "NonFireResistantArtefact": 1
@@ -21819,7 +21819,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "DetonationProofArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is detonation-proof.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21841,7 +21841,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "ExplosionProofArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is explosion-proof.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21863,7 +21863,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "FireResistantArtefactClassification",
         "description": "A specialization indicating if the FlameArrestor is fire-resistant.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21888,7 +21888,7 @@
         "data": {
           "title": "DetonationProofArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is detonation-proof.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1024",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.DetonationProofArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21906,7 +21906,7 @@
         "data": {
           "title": "ExplosionProofArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is explosion-proof.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1014",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.ExplosionProofArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21924,7 +21924,7 @@
         "data": {
           "title": "FireResistantArtefactClassification",
           "description": "A specialization indicating if the FlameArrestor is fire-resistant.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1006",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.FireResistantArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -21948,7 +21948,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_OrificePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1976",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.OrificePlateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21960,7 +21960,7 @@
     "schemaDefinitions": {
       "HeatTracingTypeClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "const": {
           "ElectricalHeatTracingSystem": 0,
           "HeatTracingSystem": 1,
@@ -22035,7 +22035,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "HeatTracingTypeClassification",
         "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22186,7 +22186,7 @@
         "data": {
           "title": "HeatTracingTypeClassification",
           "description": "A specialization indicating the heat tracing type related to the PipeFitting.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1038",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTracingTypeClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22298,7 +22298,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1989",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22324,7 +22324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_ButterflyValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1994",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.ButterflyValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22351,7 +22351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1995",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22368,7 +22368,7 @@
     "schemaDefinitions": {
       "OnHoldClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "const": {
           "NotOnHold": 0,
           "OnHold": 1
@@ -22387,7 +22387,7 @@
       },
       "PipingClassArtefactClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
         "const": {
           "NonPipingClassArtefact": 0,
           "PipingClassArtefact": 1
@@ -22483,7 +22483,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "OnHoldClassification",
         "description": "A specialization indicating if the PipingComponent is on hold or not.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22505,7 +22505,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "PipingClassArtefactClassification",
         "description": "A specialization indicating if the PipingComponent is an artefact that is         described by a piping class.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22590,7 +22590,7 @@
         "data": {
           "title": "OnHoldClassification",
           "description": "A specialization indicating if the PipingComponent is on hold or not.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1008",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.OnHoldClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22608,7 +22608,7 @@
         "data": {
           "title": "PipingClassArtefactClassification",
           "description": "A specialization indicating if the PipingComponent is an artefact that is         described by a piping class.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1036",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingClassArtefactClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22646,7 +22646,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_GateValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2003",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.GateValveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22673,7 +22673,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipeReducerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2004",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipeReducerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22700,7 +22700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LineBlindType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2005",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LineBlindType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22727,7 +22727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNodeOwnerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2006",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNodeOwnerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22759,7 +22759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PipingNodeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2008",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PipingNodeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22770,7 +22770,7 @@
     "schemaDefinitions": {
       "NodeFlowClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
         "const": {
           "MainFlowInNode": 0,
           "MainFlowOutNode": 1
@@ -22789,7 +22789,7 @@
       },
       "NominalDiameterStandardClassification": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "const": {
           "Din2448ObjectDn100": 0,
           "Din2448ObjectDn125": 1,
@@ -23146,7 +23146,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NodeFlowClassification",
         "description": "A classification of the flow direction in the PipingNode with respect to its PipingNodeOwner.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23204,7 +23204,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DEXPI/",
         "title": "NominalDiameterStandardClassification",
         "description": "The nominal diameter of the PipingNode, given as a reference to a nominal  diameter standard and value.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+        "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23247,7 +23247,7 @@
         "data": {
           "title": "NodeFlowClassification",
           "description": "A classification of the flow direction in the PipingNode with respect to its PipingNodeOwner.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1028",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NodeFlowClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23293,7 +23293,7 @@
         "data": {
           "title": "NominalDiameterStandardClassification",
           "description": "The nominal diameter of the PipingNode, given as a reference to a nominal  diameter standard and value.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=1032",
+          "dov:typeRef": "org.opcfoundation.UA.DEXPI.NominalDiameterStandardClassification",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23331,7 +23331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_RotationalSpeedType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2014",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.RotationalSpeedType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23443,7 +23443,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_HeatTransferCoefficientType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2018",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.HeatTransferCoefficientType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23555,7 +23555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_TemperatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2022",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.TemperatureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23667,7 +23667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PhysicalQuantityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2026",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PhysicalQuantityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23746,7 +23746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AreaType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2029",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AreaType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23858,7 +23858,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumeFlowRateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2033",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumeFlowRateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23970,7 +23970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PowerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2037",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PowerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24082,7 +24082,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_LengthType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.LengthType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24194,7 +24194,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PercentageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2045",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PercentageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24306,7 +24306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_VolumeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2049",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.VolumeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24418,7 +24418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_MassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2053",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.MassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24530,7 +24530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_PressureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2057",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.PressureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -24642,7 +24642,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DEXPI_AngleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DEXPI/;i=2061",
+    "dov:typeRef": "org.opcfoundation.UA.DEXPI.AngleType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/DI.TM.json
+++ b/wot-codegen/opc-output-simple/DI.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TopologyElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TopologyElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15035",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -271,7 +271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ITagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15048",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ITagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -328,7 +328,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IDeviceHealthType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15051",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IDeviceHealthType",
     "links": [
       {
         "rel": "tm:extends",
@@ -345,7 +345,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -395,7 +395,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -414,7 +414,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -438,7 +438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ISupportInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15054",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ISupportInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -494,7 +494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IAssetLocationIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=118",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IAssetLocationIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -505,7 +505,7 @@
     "schemaDefinitions": {
       "LocationIndicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "const": {
           "Visual": 0,
           "Audible": 1
@@ -534,7 +534,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=413",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IndicationDuration" ],
           "properties": {
             "IndicationDuration": {
@@ -578,7 +578,7 @@
       "SupportedIndicationTypes": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "LocationIndicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -594,7 +594,7 @@
       "UsedIndicationType": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "LocationIndicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=410",
+        "dov:typeRef": "org.opcfoundation.UA.DI.LocationIndicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -620,7 +620,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15063",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -823,7 +823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -870,7 +870,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -932,7 +932,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1085,7 +1085,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1109,7 +1109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15106",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1179,7 +1179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_BlockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.DI.BlockType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1283,7 +1283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DeviceHealthDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15143",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1310,7 +1310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FailureAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15292",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FailureAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1337,7 +1337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_CheckFunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15441",
+    "dov:typeRef": "org.opcfoundation.UA.DI.CheckFunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1364,7 +1364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_OffSpecAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15590",
+    "dov:typeRef": "org.opcfoundation.UA.DI.OffSpecAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1391,7 +1391,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_MaintenanceRequiredAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=15739",
+    "dov:typeRef": "org.opcfoundation.UA.DI.MaintenanceRequiredAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1418,7 +1418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfigurableObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfigurableObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1457,7 +1457,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_BaseLifetimeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=473",
+    "dov:typeRef": "org.opcfoundation.UA.DI.BaseLifetimeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1483,7 +1483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TimeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=474",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TimeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1509,7 +1509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NumberOfPartsIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=475",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NumberOfPartsIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1535,7 +1535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NumberOfUsagesIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=476",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NumberOfUsagesIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1561,7 +1561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LengthIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=477",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LengthIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1587,7 +1587,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DiameterIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=478",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DiameterIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1613,7 +1613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SubstanceVolumeIndicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=479",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SubstanceVolumeIndicationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1639,7 +1639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1710,7 +1710,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1736,7 +1736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_IOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=480",
+    "dov:typeRef": "org.opcfoundation.UA.DI.IOperationCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1811,7 +1811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_NetworkType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6247",
+    "dov:typeRef": "org.opcfoundation.UA.DI.NetworkType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1856,7 +1856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6308",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1901,7 +1901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_TransferServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6526",
+    "dov:typeRef": "org.opcfoundation.UA.DI.TransferServicesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1917,7 +1917,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6532",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TransferID", "SequenceNumber", "MaxParameterResultsToReturn", "OmitGoodResults" ],
           "properties": {
             "TransferID": {
@@ -1942,7 +1942,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6533",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FetchResultData" ],
           "properties": {
             "FetchResultData": {
@@ -1962,7 +1962,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6530",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferID", "InitTransferStatus" ],
           "properties": {
             "TransferID": {
@@ -1989,7 +1989,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6528",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferID", "InitTransferStatus" ],
           "properties": {
             "TransferID": {
@@ -2027,7 +2027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_LockingServicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6388",
+    "dov:typeRef": "org.opcfoundation.UA.DI.LockingServicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2049,7 +2049,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "BreakLockStatus" ],
           "properties": {
             "BreakLockStatus": {
@@ -2071,7 +2071,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExitLockStatus" ],
           "properties": {
             "ExitLockStatus": {
@@ -2093,7 +2093,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -2103,7 +2103,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6395",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitLockStatus" ],
           "properties": {
             "InitLockStatus": {
@@ -2125,7 +2125,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RenewLockStatus" ],
           "properties": {
             "RenewLockStatus": {
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareUpdateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareUpdateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2266,7 +2266,7 @@
     "schemaDefinitions": {
       "SoftwareClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "const": {
           "Firmware": 0,
           "Application": 1,
@@ -2322,7 +2322,7 @@
       "SoftwareClass": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "SoftwareClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2438,7 +2438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=135",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareLoadingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2501,7 +2501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PackageLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=137",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PackageLoadingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2590,7 +2590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_DirectLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=153",
+    "dov:typeRef": "org.opcfoundation.UA.DI.DirectLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2602,7 +2602,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -2652,7 +2652,7 @@
       "UpdateBehavior": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "UpdateBehavior",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2684,7 +2684,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "UpdateBehavior",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+          "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2708,7 +2708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_CachedLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=171",
+    "dov:typeRef": "org.opcfoundation.UA.DI.CachedLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2732,7 +2732,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -2769,7 +2769,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=190",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManufacturerUri", "SoftwareRevision", "PatchIdentifiers" ],
           "properties": {
             "ManufacturerUri": {
@@ -2788,12 +2788,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateBehavior" ],
           "properties": {
             "UpdateBehavior": {
               "title": "UpdateBehavior",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+              "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2823,7 +2823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_FileSystemLoadingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=192",
+    "dov:typeRef": "org.opcfoundation.UA.DI.FileSystemLoadingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2841,7 +2841,7 @@
     "schemaDefinitions": {
       "UpdateBehavior": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+        "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
         "const": {
           "KeepsParameters": 0,
           "WillDisconnect": 1,
@@ -2878,7 +2878,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=207",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -2891,12 +2891,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=208",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateBehavior" ],
           "properties": {
             "UpdateBehavior": {
               "title": "UpdateBehavior",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=333",
+              "dov:typeRef": "org.opcfoundation.UA.DI.UpdateBehavior",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2915,7 +2915,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=210",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -2928,7 +2928,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=211",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorCode", "ErrorMessage" ],
           "properties": {
             "ErrorCode": {
@@ -2964,7 +2964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareVersionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=212",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareVersionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3096,7 +3096,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_SoftwareFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=364",
+    "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3108,7 +3108,7 @@
     "schemaDefinitions": {
       "SoftwareClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "const": {
           "Firmware": 0,
           "Application": 1,
@@ -3147,7 +3147,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=404",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Subclass", "Name" ],
           "properties": {
             "Subclass": {
@@ -3170,7 +3170,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=406",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -3191,7 +3191,7 @@
       "SoftwareClass": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "SoftwareClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=408",
+        "dov:typeRef": "org.opcfoundation.UA.DI.SoftwareClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3217,7 +3217,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PrepareForUpdateStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=213",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PrepareForUpdateStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3368,7 +3368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_InstallationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=249",
+    "dov:typeRef": "org.opcfoundation.UA.DI.InstallationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3437,7 +3437,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=269",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NodeIds" ],
           "properties": {
             "NodeIds": {
@@ -3460,7 +3460,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=266",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManufacturerUri", "SoftwareRevision", "PatchIdentifiers", "Hash" ],
           "properties": {
             "ManufacturerUri": {
@@ -3580,7 +3580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_PowerCycleStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=285",
+    "dov:typeRef": "org.opcfoundation.UA.DI.PowerCycleStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3630,7 +3630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "DI_ConfirmationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=307",
+    "dov:typeRef": "org.opcfoundation.UA.DI.ConfirmationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/ECM.TM.json
+++ b/wot-codegen/opc-output-simple/ECM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_AccuracyDomainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.AccuracyDomainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -38,7 +38,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileD0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileD0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -245,7 +245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileD1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileD1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -646,7 +646,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -680,7 +680,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -773,7 +773,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -851,7 +851,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1014,7 +1014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE2Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE2Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1177,7 +1177,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_IEnergyProfileE3Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.IEnergyProfileE3Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -1211,7 +1211,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1289,7 +1289,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1367,7 +1367,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1443,7 +1443,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1521,7 +1521,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
         "required": [ "L1", "L2", "L3" ],
         "properties": {
           "L1": {
@@ -1599,7 +1599,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "AcPpDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.AcPpDataType",
         "required": [ "L1L2", "L2L3", "L3L1" ],
         "properties": {
           "L1L2": {
@@ -1740,7 +1740,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1811,7 +1811,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1882,7 +1882,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -1951,7 +1951,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -2022,7 +2022,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPeDataType",
           "required": [ "L1", "L2", "L3" ],
           "properties": {
             "L1": {
@@ -2093,7 +2093,7 @@
         "data": {
           "title": "AcPpDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.AcPpDataType",
           "required": [ "L1L2", "L2L3", "L3L1" ],
           "properties": {
             "L1L2": {
@@ -2170,7 +2170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyDevicePowerOffType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyDevicePowerOffType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2198,7 +2198,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6110",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -2349,7 +2349,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyMeasurementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2536,7 +2536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModesContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModesContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2568,7 +2568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModeStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModeStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2597,7 +2597,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "StandbyModeTransitionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.StandbyModeTransitionDataType",
         "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
         "properties": {
           "IDDestination": {
@@ -2636,7 +2636,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "title": "EnergyStateInformationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStateInformationDataType",
         "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
         "properties": {
           "IDSource": {
@@ -2679,7 +2679,7 @@
         "data": {
           "title": "StandbyModeTransitionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.StandbyModeTransitionDataType",
           "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
           "properties": {
             "IDDestination": {
@@ -2719,7 +2719,7 @@
         "data": {
           "title": "EnergyStateInformationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStateInformationDataType",
           "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
           "properties": {
             "IDSource": {
@@ -2766,7 +2766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergySavingModeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergySavingModeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3052,7 +3052,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ECM_EnergyStandbyManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ECM.EnergyStandbyManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3103,7 +3103,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentTimeToOperate", "ReturnCode" ],
           "properties": {
             "CurrentTimeToOperate": {
@@ -3131,7 +3131,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PauseTime" ],
           "properties": {
             "PauseTime": {
@@ -3143,7 +3143,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -3187,7 +3187,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ECM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ModeID" ],
           "properties": {
             "ModeID": {
@@ -3200,7 +3200,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ECM/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EffectiveModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "EffectiveModeID": {

--- a/wot-codegen/opc-output-simple/FDI5.TM.json
+++ b/wot-codegen/opc-output-simple/FDI5.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_ActionType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=11",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ActionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_ActionServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=21",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ActionServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -55,7 +55,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=29",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionNodeId" ],
           "properties": {
             "ActionNodeId": {
@@ -65,7 +65,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=30",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AbortActionError" ],
           "properties": {
             "AbortActionError": {
@@ -87,7 +87,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=23",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionName", "MethodArguments" ],
           "properties": {
             "ActionName": {
@@ -100,7 +100,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=24",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ActionNodeId", "InvokeActionError" ],
           "properties": {
             "ActionNodeId": {
@@ -125,7 +125,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=26",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ActionNodeId", "Response" ],
           "properties": {
             "ActionNodeId": {
@@ -138,7 +138,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=27",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RespondActionError" ],
           "properties": {
             "RespondActionError": {
@@ -171,7 +171,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_EditContextType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=54",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.EditContextType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     "schemaDefinitions": {
       "WindowModeType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=194",
+        "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.WindowModeType",
         "const": {
           "ModalWindow": 1,
           "NonModalWindow": 2,
@@ -207,7 +207,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -217,13 +217,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=66",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyStatus" ],
           "properties": {
             "ApplyStatus": {
               "title": "ApplyResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=44",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.ApplyResult",
               "required": [ "Status", "TransferIncidents" ],
               "properties": {
                 "Status": {
@@ -236,7 +236,7 @@
                   "items": {
                     "title": "TransferIncident",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=43",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.TransferIncident",
                     "required": [ "ContextNodeId", "StatusCode", "Diagnostics" ],
                     "properties": {
                       "ContextNodeId": {
@@ -267,7 +267,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=71",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -277,7 +277,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=72",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DiscardStatus" ],
           "properties": {
             "DiscardStatus": {
@@ -299,7 +299,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=56",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ParentId", "TargetWindowMode" ],
           "properties": {
             "ParentId": {
@@ -307,7 +307,7 @@
             },
             "TargetWindowMode": {
               "title": "WindowModeType",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=194",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.WindowModeType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -316,7 +316,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=57",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EditContextId", "GetEditContextStatus" ],
           "properties": {
             "EditContextId": {
@@ -341,7 +341,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId", "NodesToRegister" ],
           "properties": {
             "EditContextId": {
@@ -352,13 +352,13 @@
               "items": {
                 "title": "RegistrationParameters",
                 "type": "object",
-                "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=37",
+                "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegistrationParameters",
                 "required": [ "Path", "SelectionFlags" ],
                 "properties": {
                   "Path": {
                     "title": "RelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -366,7 +366,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -398,13 +398,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=60",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RegisterNodesStatus" ],
           "properties": {
             "RegisterNodesStatus": {
               "title": "RegisterNodesResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=39",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisterNodesResult",
               "required": [ "Status", "RegisteredNodes" ],
               "properties": {
                 "Status": {
@@ -417,7 +417,7 @@
                   "items": {
                     "title": "RegisteredNode",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=38",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisteredNode",
                     "required": [ "NodeStatus", "OnlineContextNodeId", "OnlineDeviceNodeId", "OfflineContextNodeId", "OfflineDeviceNodeId" ],
                     "properties": {
                       "NodeStatus": {
@@ -456,7 +456,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId", "NodesToRegister" ],
           "properties": {
             "EditContextId": {
@@ -467,13 +467,13 @@
               "items": {
                 "title": "RegistrationParameters",
                 "type": "object",
-                "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=37",
+                "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegistrationParameters",
                 "required": [ "Path", "SelectionFlags" ],
                 "properties": {
                   "Path": {
                     "title": "RelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -481,7 +481,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -513,13 +513,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RegisterNodesStatus" ],
           "properties": {
             "RegisterNodesStatus": {
               "title": "RegisterNodesResult",
               "type": "object",
-              "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=39",
+              "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisterNodesResult",
               "required": [ "Status", "RegisteredNodes" ],
               "properties": {
                 "Status": {
@@ -532,7 +532,7 @@
                   "items": {
                     "title": "RegisteredNode",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=38",
+                    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.RegisteredNode",
                     "required": [ "NodeStatus", "OnlineContextNodeId", "OnlineDeviceNodeId", "OfflineContextNodeId", "OfflineDeviceNodeId" ],
                     "properties": {
                       "NodeStatus": {
@@ -571,7 +571,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=68",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EditContextId" ],
           "properties": {
             "EditContextId": {
@@ -581,7 +581,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResetStatus" ],
           "properties": {
             "ResetStatus": {
@@ -614,7 +614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI5_DirectDeviceAccessType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=82",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI5.DirectDeviceAccessType",
     "dov:isComposite": true,
     "links": [
       {
@@ -630,7 +630,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=90",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InvalidateCache" ],
           "properties": {
             "InvalidateCache": {
@@ -640,7 +640,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=91",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EndDirectAccessError" ],
           "properties": {
             "EndDirectAccessError": {
@@ -662,7 +662,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=84",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Context" ],
           "properties": {
             "Context": {
@@ -672,7 +672,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=85",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InitDirectAccessError" ],
           "properties": {
             "InitDirectAccessError": {
@@ -694,7 +694,7 @@
         "dov:namespace": "http://fdi-cooperation.com/OPCUA/FDI5/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=87",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SendData", "ReceiveData" ],
           "properties": {
             "SendData": {
@@ -707,7 +707,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI5/;i=88",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TransferError" ],
           "properties": {
             "TransferError": {

--- a/wot-codegen/opc-output-simple/FDI7.TM.json
+++ b/wot-codegen/opc-output-simple/FDI7.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Foundation_H1",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1371",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Foundation_H1",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Foundation_HSE",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1372",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Foundation_HSE",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profibus_DP",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1373",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profibus_DP",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profibus_PA",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1374",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profibus_PA",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_Profinet_IO",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1375",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.Profinet_IO",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_HART",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1376",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.HART",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ISA100_Wireless",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1377",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ISA100_Wireless",
     "dov:isComposite": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_GenericProtocol",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1378",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.GenericProtocol",
     "dov:isComposite": true,
     "links": [
       {
@@ -243,7 +243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Foundation_H1",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1380",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Foundation_H1",
     "dov:isComposite": true,
     "links": [
       {
@@ -317,7 +317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Foundation_HSE",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1424",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Foundation_HSE",
     "dov:isComposite": true,
     "links": [
       {
@@ -382,7 +382,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Profibus_DP",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1467",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Profibus_DP",
     "dov:isComposite": true,
     "links": [
       {
@@ -430,7 +430,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_Profinet_IO",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1509",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_Profinet_IO",
     "dov:isComposite": true,
     "links": [
       {
@@ -522,7 +522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP5",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1554",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP5",
     "dov:isComposite": true,
     "links": [
       {
@@ -641,7 +641,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP6",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1601",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP6",
     "dov:isComposite": true,
     "links": [
       {
@@ -760,7 +760,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_HART_TP7",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1648",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_HART_TP7",
     "dov:isComposite": true,
     "links": [
       {
@@ -879,7 +879,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ConnectionPoint_ISA100_Wireless",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1695",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ConnectionPoint_ISA100_Wireless",
     "dov:isComposite": true,
     "links": [
       {
@@ -994,7 +994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_GenericConnectionPoint",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1742",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.GenericConnectionPoint",
     "dov:isComposite": true,
     "links": [
       {
@@ -1053,7 +1053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_CommunicationServerType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=11",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.CommunicationServerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1098,7 +1098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=93",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1152,7 +1152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFH1DeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=324",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFH1DeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1191,7 +1191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFHSEDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=452",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFHSEDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1230,7 +1230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFIBUSDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=580",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFIBUSDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1269,7 +1269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFINETDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=705",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFINETDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1308,7 +1308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationHARType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=830",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationHARType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1347,7 +1347,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationISA100_WirelessDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1788",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationISA100_WirelessDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1380,7 +1380,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationGENERICDeviceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1913",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationGENERICDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1438,7 +1438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=233",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1470,7 +1470,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFH1ServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=997",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFH1ServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1502,7 +1502,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationFFHSEServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1073",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationFFHSEServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1534,7 +1534,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFIBUSServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1149",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFIBUSServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1566,7 +1566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationPROFINETServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1222",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationPROFINETServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1598,7 +1598,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationHARTServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=1295",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationHARTServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1630,7 +1630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationISA100_WirelessServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=2057",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationISA100_WirelessServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1662,7 +1662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FDI7_ServerCommunicationGENERICServiceType",
-    "dov:typeRef": "nsu=http://fdi-cooperation.com/OPCUA/FDI7/;i=2133",
+    "dov:typeRef": "com.fdi-cooperation.OPCUA.FDI7.ServerCommunicationGENERICServiceType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/FX.AC.TM.json
+++ b/wot-codegen/opc-output-simple/FX.AC.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AcDescriptorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AcDescriptorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -61,7 +61,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AssetConnectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AssetConnectorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -186,7 +186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ClampBlockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ClampBlockType",
     "dov:isComposite": true,
     "links": [
       {
@@ -306,7 +306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ClampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ClampType",
     "links": [
       {
         "rel": "tm:extends",
@@ -400,7 +400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SlotType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SlotType",
     "dov:isComposite": true,
     "links": [
       {
@@ -477,7 +477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SocketType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SocketType",
     "dov:isComposite": true,
     "links": [
       {
@@ -572,7 +572,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AutomationComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AutomationComponentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -632,7 +632,7 @@
     "schemaDefinitions": {
       "DeviceHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
         "const": {
           "DeviceFailure": 0,
           "DeviceCheckFunction": 1,
@@ -660,7 +660,7 @@
       },
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -688,7 +688,7 @@
       },
       "FxCommandMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1024",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FxCommandMask",
         "const": {
           "VerifyAssetCmd": 0,
           "VerifyFunctionalEntityCmd": 1,
@@ -742,7 +742,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -765,7 +765,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -793,7 +793,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -837,7 +837,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConnectionEndpoints", "Remove" ],
           "properties": {
             "ConnectionEndpoints": {
@@ -853,7 +853,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1306",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -876,12 +876,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1303",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CommandMask", "AssetVerifications", "ConnectionEndpointConfigurations", "ReserveCommunicationIds", "CommunicationConfigurations" ],
           "properties": {
             "CommandMask": {
               "title": "FxCommandMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1024",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FxCommandMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -891,7 +891,7 @@
               "items": {
                 "title": "AssetVerificationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1048",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationDataType",
                 "required": [ "AssetToVerify", "VerificationMode", "ExpectedVerificationResult", "ExpectedVerificationVariables", "ExpectedAdditionalVerificationVariables" ],
                 "properties": {
                   "AssetToVerify": {
@@ -899,14 +899,14 @@
                   },
                   "VerificationMode": {
                     "title": "AssetVerificationModeEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
                   },
                   "ExpectedVerificationResult": {
                     "title": "AssetVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -916,7 +916,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -934,13 +934,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -971,7 +971,7 @@
               "items": {
                 "title": "ConnectionEndpointConfigurationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1044",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointConfigurationDataType",
                 "required": [ "FunctionalEntityNode", "ConnectionEndpoint", "ExpectedVerificationVariables", "ControlGroups", "ConfigurationData", "CommunicationLinks" ],
                 "properties": {
                   "FunctionalEntityNode": {
@@ -980,12 +980,12 @@
                   "ConnectionEndpoint": {
                     "title": "ConnectionEndpointDefinitionDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointDefinitionDataType",
                     "properties": {
                       "Parameter": {
                         "title": "ConnectionEndpointParameterDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3009",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointParameterDataType",
                         "required": [ "Name", "ConnectionEndpointTypeId", "InputVariableIds", "OutputVariableIds", "IsPersistent", "CleanupTimeout", "RelatedEndpoint", "IsPreconfigured" ],
                         "properties": {
                           "Name": {
@@ -1016,7 +1016,7 @@
                           "RelatedEndpoint": {
                             "title": "RelatedEndpointDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
                             "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
                             "properties": {
                               "Address": {
@@ -1027,7 +1027,7 @@
                                 "items": {
                                   "title": "PortableQualifiedName",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                                  "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                                   "required": [ "NamespaceUri", "Name" ],
                                   "properties": {
                                     "NamespaceUri": {
@@ -1059,13 +1059,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -1099,13 +1099,13 @@
                     "items": {
                       "title": "NodeIdValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
                           "title": "NodeIdArray",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                           "required": [ "Node", "ArrayIndex" ],
                           "properties": {
                             "Node": {
@@ -1150,7 +1150,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1304",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetVerificationResults", "ConnectionEndpointConfigurationResults", "ReserveCommunicationIdsResults", "CommunicationConfigurationResults" ],
           "properties": {
             "AssetVerificationResults": {
@@ -1158,7 +1158,7 @@
               "items": {
                 "title": "AssetVerificationResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1038",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultDataType",
                 "required": [ "VerificationStatus", "VerificationResult", "VerificationVariablesErrors", "VerificationAdditionalVariablesErrors" ],
                 "properties": {
                   "VerificationStatus": {
@@ -1166,7 +1166,7 @@
                   },
                   "VerificationResult": {
                     "title": "AssetVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1191,7 +1191,7 @@
               "items": {
                 "title": "ConnectionEndpointConfigurationResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.ConnectionEndpointConfigurationResultDataType",
                 "required": [ "ConnectionEndpointId", "FunctionalEntityNodeResult", "ConnectionEndpointResult", "VerificationResult", "VerificationStatus", "VerificationVariablesErrors", "EstablishControlResult", "ConfigurationDataResult", "ReassignControlResult", "CommunicationLinksResult", "EnableCommunicationResult" ],
                 "properties": {
                   "ConnectionEndpointId": {
@@ -1205,7 +1205,7 @@
                   },
                   "VerificationResult": {
                     "title": "FunctionalEntityVerificationResultEnum",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1274,19 +1274,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "AggregatedHealthDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.AggregatedHealthDataType",
         "required": [ "AggregatedDeviceHealth", "AggregatedOperationalHealth" ],
         "properties": {
           "AggregatedDeviceHealth": {
             "title": "DeviceHealthOptionSet",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
           },
           "AggregatedOperationalHealth": {
             "title": "OperationalHealthOptionSet",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1310,7 +1310,7 @@
       "AggregatedHealth_AggregatedDeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "DeviceHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1327,7 +1327,7 @@
       "AggregatedHealth_AggregatedOperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1360,19 +1360,19 @@
         "data": {
           "title": "AggregatedHealthDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.AggregatedHealthDataType",
           "required": [ "AggregatedDeviceHealth", "AggregatedOperationalHealth" ],
           "properties": {
             "AggregatedDeviceHealth": {
               "title": "DeviceHealthOptionSet",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "AggregatedOperationalHealth": {
               "title": "OperationalHealthOptionSet",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1392,7 +1392,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "DeviceHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.DeviceHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1410,7 +1410,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1435,7 +1435,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AuditUaFxEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AuditUaFxEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1462,7 +1462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AuditConnectionCleanupEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AuditConnectionCleanupEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1492,7 +1492,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "RelatedEndpointDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
         "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
         "properties": {
           "Address": {
@@ -1503,7 +1503,7 @@
             "items": {
               "title": "PortableQualifiedName",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
               "required": [ "NamespaceUri", "Name" ],
               "properties": {
                 "NamespaceUri": {
@@ -1563,7 +1563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IAssetExtensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IAssetExtensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1601,7 +1601,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IAssetRevisionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IAssetRevisionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1612,7 +1612,7 @@
     "schemaDefinitions": {
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -1635,7 +1635,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -1679,14 +1679,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1422",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "type": "array",
               "items": {
                 "title": "AssetVerificationModeEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1697,7 +1697,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1714,12 +1714,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1423",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1831,7 +1831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_IFunctionalEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.IFunctionalEntityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1914,7 +1914,7 @@
     "schemaDefinitions": {
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -1942,7 +1942,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -1986,7 +1986,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1420",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExpectedVerificationVariables" ],
           "properties": {
             "ExpectedVerificationVariables": {
@@ -1994,13 +1994,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -2027,12 +2027,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1421",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "FunctionalEntityVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2061,7 +2061,7 @@
         "items": {
           "title": "ApplicationIdentifierDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationIdentifierDataType",
           "required": [ "Name", "UniqueIdentifier" ],
           "properties": {
             "Name": {
@@ -2070,7 +2070,7 @@
             "UniqueIdentifier": {
               "title": "ApplicationId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationId",
               "properties": {
                 "IdNumeric": {
                   "type": "integer",
@@ -2127,7 +2127,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -2185,7 +2185,7 @@
       "OperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2204,7 +2204,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2228,7 +2228,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConnectionEndpointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2245,7 +2245,7 @@
     "schemaDefinitions": {
       "ConnectionEndpointStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
         "const": {
           "Initial": 0,
           "Ready": 1,
@@ -2394,7 +2394,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "RelatedEndpointDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
         "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
         "properties": {
           "Address": {
@@ -2405,7 +2405,7 @@
             "items": {
               "title": "PortableQualifiedName",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
               "required": [ "NamespaceUri", "Name" ],
               "properties": {
                 "NamespaceUri": {
@@ -2438,7 +2438,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "ConnectionEndpointStatusEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2530,7 +2530,7 @@
         "data": {
           "title": "RelatedEndpointDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.RelatedEndpointDataType",
           "required": [ "Address", "ConnectionEndpointPath", "ConnectionEndpointName" ],
           "properties": {
             "Address": {
@@ -2541,7 +2541,7 @@
               "items": {
                 "title": "PortableQualifiedName",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                 "required": [ "NamespaceUri", "Name" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2570,7 +2570,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "ConnectionEndpointStatusEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointStatusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2594,7 +2594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_PubSubConnectionEndpointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.PubSubConnectionEndpointType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2606,7 +2606,7 @@
     "schemaDefinitions": {
       "PubSubConnectionEndpointModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
         "const": {
           "PublisherSubscriber": 1,
           "Publisher": 2,
@@ -2651,7 +2651,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "PubSubConnectionEndpointModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2675,7 +2675,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "PubSubConnectionEndpointModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=31",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.PubSubConnectionEndpointModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2699,7 +2699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2750,7 +2750,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6093",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LockContext" ],
           "properties": {
             "LockContext": {
@@ -2760,7 +2760,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6094",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LockStatus" ],
           "properties": {
             "LockStatus": {
@@ -2782,7 +2782,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6366",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LockContext" ],
           "properties": {
             "LockContext": {
@@ -2792,7 +2792,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LockStatus" ],
           "properties": {
             "LockStatus": {
@@ -2852,7 +2852,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_AutomationComponentCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.AutomationComponentCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2878,7 +2878,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConnectionEndpointsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConnectionEndpointsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2896,7 +2896,7 @@
     "schemaDefinitions": {
       "CommHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
         "const": {
           "CommInitial": 0,
           "CommPreOperational": 1,
@@ -2936,7 +2936,7 @@
       "CommHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "CommHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2955,7 +2955,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "CommHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.CommHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2979,7 +2979,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlGroupsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlGroupsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3012,7 +3012,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FunctionalEntityCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FunctionalEntityCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3038,7 +3038,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ConfigurationDataFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ConfigurationDataFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3053,7 +3053,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6398",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariablesToClear" ],
           "properties": {
             "VariablesToClear": {
@@ -3066,7 +3066,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6399",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -3089,7 +3089,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "StoredVariables" ],
           "properties": {
             "StoredVariables": {
@@ -3097,13 +3097,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -3140,7 +3140,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VariablesToStore" ],
           "properties": {
             "VariablesToStore": {
@@ -3153,7 +3153,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=6397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -3187,7 +3187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_ControlItemFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.ControlItemFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3249,7 +3249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_InputsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.InputsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3288,7 +3288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_OutputsFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.OutputsFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3327,7 +3327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FunctionalEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FunctionalEntityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3417,7 +3417,7 @@
     "schemaDefinitions": {
       "OperationalHealthOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "const": {
           "OperationalWarning": 16,
           "OperationalError": 17,
@@ -3445,7 +3445,7 @@
       },
       "FunctionalEntityVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -3489,7 +3489,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1358",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExpectedVerificationVariables" ],
           "properties": {
             "ExpectedVerificationVariables": {
@@ -3497,13 +3497,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -3530,12 +3530,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1359",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "FunctionalEntityVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.FunctionalEntityVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3564,7 +3564,7 @@
         "items": {
           "title": "ApplicationIdentifierDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationIdentifierDataType",
           "required": [ "Name", "UniqueIdentifier" ],
           "properties": {
             "Name": {
@@ -3573,7 +3573,7 @@
             "UniqueIdentifier": {
               "title": "ApplicationId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.ApplicationId",
               "properties": {
                 "IdNumeric": {
                   "type": "integer",
@@ -3630,7 +3630,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "FxVersion",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=25",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxVersion",
         "required": [ "Major", "Minor", "Build", "SubBuild" ],
         "properties": {
           "Major": {
@@ -3688,7 +3688,7 @@
       "OperationalHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "title": "OperationalHealthOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3707,7 +3707,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "data": {
           "title": "OperationalHealthOptionSet",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.OperationalHealthOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3731,7 +3731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_FxAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3760,7 +3760,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -3793,7 +3793,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -3816,7 +3816,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -3865,12 +3865,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1356",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables", "ExpectedAdditionalVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "title": "AssetVerificationModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3880,7 +3880,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -3898,13 +3898,13 @@
               "items": {
                 "title": "NodeIdValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1028",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
                     "title": "NodeIdArray",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1034",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.Data.NodeIdArray",
                     "required": [ "Node", "ArrayIndex" ],
                     "properties": {
                       "Node": {
@@ -3931,12 +3931,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1357",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors", "VerificationAdditionalVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4038,7 +4038,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4308,7 +4308,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4332,7 +4332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_PublisherCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4343,7 +4343,7 @@
     "schemaDefinitions": {
       "FxTimeUnitsEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
         "const": {
           "Nanosecond": 0,
           "Microsecond": 1,
@@ -4430,7 +4430,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -4455,7 +4455,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4482,7 +4482,7 @@
         "items": {
           "title": "PublisherQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherQosDataType",
           "required": [ "QosCategory", "DatagramQos" ],
           "properties": {
             "QosCategory": {
@@ -4548,7 +4548,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -4573,7 +4573,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4596,7 +4596,7 @@
           "items": {
             "title": "PublisherQosDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3011",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.PublisherQosDataType",
             "required": [ "QosCategory", "DatagramQos" ],
             "properties": {
               "QosCategory": {
@@ -4630,7 +4630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_AC_SubscriberCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4641,7 +4641,7 @@
     "schemaDefinitions": {
       "FxTimeUnitsEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
         "const": {
           "Nanosecond": 0,
           "Microsecond": 1,
@@ -4728,7 +4728,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -4753,7 +4753,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4780,7 +4780,7 @@
         "items": {
           "title": "IntervalRange",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
           "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
           "properties": {
             "Min": {
@@ -4805,7 +4805,7 @@
             },
             "Unit": {
               "title": "FxTimeUnitsEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4832,7 +4832,7 @@
         "items": {
           "title": "SubscriberQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberQosDataType",
           "required": [ "QosCategory", "DatagramQos" ],
           "properties": {
             "QosCategory": {
@@ -4898,7 +4898,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -4923,7 +4923,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4946,7 +4946,7 @@
           "items": {
             "title": "IntervalRange",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.IntervalRange",
             "required": [ "Min", "Max", "Increment", "Multiplier", "Unit" ],
             "properties": {
               "Min": {
@@ -4971,7 +4971,7 @@
               },
               "Unit": {
                 "title": "FxTimeUnitsEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.FX.AC.FxTimeUnitsEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4994,7 +4994,7 @@
           "items": {
             "title": "SubscriberQosDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.AC.SubscriberQosDataType",
             "required": [ "QosCategory", "DatagramQos" ],
             "properties": {
               "QosCategory": {

--- a/wot-codegen/opc-output-simple/FX.CM.TM.json
+++ b/wot-codegen/opc-output-simple/FX.CM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_AssetVerificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1247",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.AssetVerificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -47,7 +47,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -93,12 +93,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -115,7 +115,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -123,13 +123,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -149,7 +149,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -186,18 +186,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -214,7 +214,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -222,13 +222,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -248,7 +248,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -297,7 +297,7 @@
       "ExpectedVerificationResult": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "AssetVerificationResultEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -321,18 +321,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -349,7 +349,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -357,13 +357,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -383,7 +383,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -432,7 +432,7 @@
       "VerificationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "AssetVerificationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -457,12 +457,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -479,7 +479,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -487,13 +487,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -513,7 +513,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -546,18 +546,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -574,7 +574,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -582,13 +582,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -608,7 +608,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -653,7 +653,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "AssetVerificationResultEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -673,18 +673,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -701,7 +701,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -709,13 +709,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -735,7 +735,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -780,7 +780,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "AssetVerificationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+          "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -804,7 +804,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_AutomationComponentConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1246",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.AutomationComponentConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -851,12 +851,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -873,7 +873,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -881,13 +881,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -907,7 +907,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -945,12 +945,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -967,7 +967,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -975,13 +975,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1001,7 +1001,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1038,7 +1038,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CloseConnectionErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CloseConnectionErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_EstablishConnectionErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.EstablishConnectionErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1092,7 +1092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1104,7 +1104,7 @@
     "schemaDefinitions": {
       "FxProcessEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "const": {
           "ActionEstablishConnectionsEnabled": 0,
           "ActionEstablishConnectionsDisabled": 1,
@@ -1159,7 +1159,7 @@
       "Action": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "FxProcessEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1224,7 +1224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingFailedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingFailedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1251,7 +1251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingStartedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingStartedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1278,7 +1278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetProcessingSucceededEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetProcessingSucceededEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1305,7 +1305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CommunicationFlowConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1331,7 +1331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_PubSubCommunicationFlowConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PubSubCommunicationFlowConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1349,7 +1349,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -1396,7 +1396,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "NetworkAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+        "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
         "required": [ "NetworkInterface" ],
         "properties": {
           "NetworkInterface": {
@@ -1456,7 +1456,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "CommunicationFlowQosDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowQosDataType",
         "required": [ "QosCategory", "TransmitQos", "ReceiveQos" ],
         "properties": {
           "QosCategory": {
@@ -1509,7 +1509,7 @@
       "SecurityMode": {
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1551,7 +1551,7 @@
         "data": {
           "title": "NetworkAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
           "required": [ "NetworkInterface" ],
           "properties": {
             "NetworkInterface": {
@@ -1599,7 +1599,7 @@
         "data": {
           "title": "CommunicationFlowQosDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationFlowQosDataType",
           "required": [ "QosCategory", "TransmitQos", "ReceiveQos" ],
           "properties": {
             "QosCategory": {
@@ -1644,7 +1644,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "data": {
           "title": "MessageSecurityMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+          "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1681,7 +1681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_CommunicationModelConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.CommunicationModelConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1707,7 +1707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_PubSubCommunicationModelConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PubSubCommunicationModelConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1719,7 +1719,7 @@
     "schemaDefinitions": {
       "PubSubConfigurationRefMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
         "const": {
           "ElementAdd": 0,
           "ElementMatch": 1,
@@ -1779,7 +1779,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -1791,7 +1791,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -1815,7 +1815,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -1839,7 +1839,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -1863,7 +1863,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -1964,12 +1964,12 @@
         "items": {
           "title": "PubSubConfigurationRefDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
           "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
           "properties": {
             "ConfigurationMask": {
               "title": "PubSubConfigurationRefMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2011,18 +2011,18 @@
         "items": {
           "title": "PubSubConfigurationValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
           "required": [ "ConfigurationElement", "Name", "Identifier" ],
           "properties": {
             "ConfigurationElement": {
               "title": "PubSubConfigurationRefDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
               "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
               "properties": {
                 "ConfigurationMask": {
                   "title": "PubSubConfigurationRefMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                  "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2091,7 +2091,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PubSubConfiguration2DataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23602",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfiguration2DataType",
         "required": [ "SubscribedDataSets", "DataSetClasses", "DefaultSecurityKeyServices", "SecurityGroups", "PubSubKeyPushTargets", "ConfigurationVersion", "ConfigurationProperties" ],
         "properties": {
           "SubscribedDataSets": {
@@ -2099,7 +2099,7 @@
             "items": {
               "title": "StandaloneSubscribedDataSetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+              "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
               "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -2114,7 +2114,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -2128,7 +2128,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -2139,7 +2139,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -2179,7 +2179,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -2202,7 +2202,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -2230,7 +2230,7 @@
             "items": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -2244,7 +2244,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -2255,7 +2255,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2295,7 +2295,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -2318,7 +2318,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -2341,7 +2341,7 @@
             "items": {
               "title": "EndpointDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
               "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
               "properties": {
                 "EndpointUrl": {
@@ -2350,7 +2350,7 @@
                 "Server": {
                   "title": "ApplicationDescription",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                   "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                   "properties": {
                     "ApplicationUri": {
@@ -2364,7 +2364,7 @@
                     },
                     "ApplicationType": {
                       "title": "ApplicationType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                      "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2389,7 +2389,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2402,7 +2402,7 @@
                   "items": {
                     "title": "UserTokenPolicy",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                     "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                     "properties": {
                       "PolicyId": {
@@ -2410,7 +2410,7 @@
                       },
                       "TokenType": {
                         "title": "UserTokenType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2443,7 +2443,7 @@
             "items": {
               "title": "SecurityGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+              "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
               "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
               "properties": {
                 "Name": {
@@ -2480,7 +2480,7 @@
                   "items": {
                     "title": "RolePermissionType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                    "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                     "required": [ "RoleId", "Permissions" ],
                     "properties": {
                       "RoleId": {
@@ -2488,7 +2488,7 @@
                       },
                       "Permissions": {
                         "title": "PermissionType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -2501,7 +2501,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -2522,7 +2522,7 @@
             "items": {
               "title": "PubSubKeyPushTargetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
               "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
               "properties": {
                 "ApplicationUri": {
@@ -2543,7 +2543,7 @@
                 "UserTokenType": {
                   "title": "UserTokenPolicy",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                   "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                   "properties": {
                     "PolicyId": {
@@ -2551,7 +2551,7 @@
                     },
                     "TokenType": {
                       "title": "UserTokenType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                      "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -2581,7 +2581,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -2613,7 +2613,7 @@
             "items": {
               "title": "KeyValuePair",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
               "required": [ "Key", "Value" ],
               "properties": {
                 "Key": {
@@ -2647,7 +2647,7 @@
         "items": {
           "title": "NodeIdTranslationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.NodeIdTranslationDataType",
           "required": [ "NodePlaceholder", "PortableNode" ],
           "properties": {
             "NodePlaceholder": {
@@ -2656,12 +2656,12 @@
             "PortableNode": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -2678,7 +2678,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -2686,13 +2686,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2712,7 +2712,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2755,12 +2755,12 @@
           "items": {
             "title": "PubSubConfigurationRefDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
             "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
             "properties": {
               "ConfigurationMask": {
                 "title": "PubSubConfigurationRefMask",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2798,18 +2798,18 @@
           "items": {
             "title": "PubSubConfigurationValueDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
             "required": [ "ConfigurationElement", "Name", "Identifier" ],
             "properties": {
               "ConfigurationElement": {
                 "title": "PubSubConfigurationRefDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                 "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                 "properties": {
                   "ConfigurationMask": {
                     "title": "PubSubConfigurationRefMask",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2870,7 +2870,7 @@
         "data": {
           "title": "PubSubConfiguration2DataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23602",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubConfiguration2DataType",
           "required": [ "SubscribedDataSets", "DataSetClasses", "DefaultSecurityKeyServices", "SecurityGroups", "PubSubKeyPushTargets", "ConfigurationVersion", "ConfigurationProperties" ],
           "properties": {
             "SubscribedDataSets": {
@@ -2878,7 +2878,7 @@
               "items": {
                 "title": "StandaloneSubscribedDataSetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+                "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
                 "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
                 "properties": {
                   "Name": {
@@ -2893,7 +2893,7 @@
                   "DataSetMetaData": {
                     "title": "DataSetMetaDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                     "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                     "properties": {
                       "Name": {
@@ -2907,7 +2907,7 @@
                         "items": {
                           "title": "FieldMetaData",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                          "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                           "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                           "properties": {
                             "Name": {
@@ -2918,7 +2918,7 @@
                             },
                             "FieldFlags": {
                               "title": "DataSetFieldFlags",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -2958,7 +2958,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -2981,7 +2981,7 @@
                       "ConfigurationVersion": {
                         "title": "ConfigurationVersionDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                        "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                         "required": [ "MajorVersion", "MinorVersion" ],
                         "properties": {
                           "MajorVersion": {
@@ -3009,7 +3009,7 @@
               "items": {
                 "title": "DataSetMetaDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                 "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                 "properties": {
                   "Name": {
@@ -3023,7 +3023,7 @@
                     "items": {
                       "title": "FieldMetaData",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                      "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                       "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                       "properties": {
                         "Name": {
@@ -3034,7 +3034,7 @@
                         },
                         "FieldFlags": {
                           "title": "DataSetFieldFlags",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3074,7 +3074,7 @@
                           "items": {
                             "title": "KeyValuePair",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                            "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                             "required": [ "Key", "Value" ],
                             "properties": {
                               "Key": {
@@ -3097,7 +3097,7 @@
                   "ConfigurationVersion": {
                     "title": "ConfigurationVersionDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                    "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                     "required": [ "MajorVersion", "MinorVersion" ],
                     "properties": {
                       "MajorVersion": {
@@ -3120,7 +3120,7 @@
               "items": {
                 "title": "EndpointDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                 "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                 "properties": {
                   "EndpointUrl": {
@@ -3129,7 +3129,7 @@
                   "Server": {
                     "title": "ApplicationDescription",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                     "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                     "properties": {
                       "ApplicationUri": {
@@ -3143,7 +3143,7 @@
                       },
                       "ApplicationType": {
                         "title": "ApplicationType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -3168,7 +3168,7 @@
                   },
                   "SecurityMode": {
                     "title": "MessageSecurityMode",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                    "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3181,7 +3181,7 @@
                     "items": {
                       "title": "UserTokenPolicy",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                      "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                       "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                       "properties": {
                         "PolicyId": {
@@ -3189,7 +3189,7 @@
                         },
                         "TokenType": {
                           "title": "UserTokenType",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                          "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3222,7 +3222,7 @@
               "items": {
                 "title": "SecurityGroupDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+                "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
                 "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
                 "properties": {
                   "Name": {
@@ -3259,7 +3259,7 @@
                     "items": {
                       "title": "RolePermissionType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                      "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                       "required": [ "RoleId", "Permissions" ],
                       "properties": {
                         "RoleId": {
@@ -3267,7 +3267,7 @@
                         },
                         "Permissions": {
                           "title": "PermissionType",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                          "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -3280,7 +3280,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -3301,7 +3301,7 @@
               "items": {
                 "title": "PubSubKeyPushTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
                 "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
                 "properties": {
                   "ApplicationUri": {
@@ -3322,7 +3322,7 @@
                   "UserTokenType": {
                     "title": "UserTokenPolicy",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                     "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                     "properties": {
                       "PolicyId": {
@@ -3330,7 +3330,7 @@
                       },
                       "TokenType": {
                         "title": "UserTokenType",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -3360,7 +3360,7 @@
                     "items": {
                       "title": "KeyValuePair",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                      "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                       "required": [ "Key", "Value" ],
                       "properties": {
                         "Key": {
@@ -3392,7 +3392,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -3422,7 +3422,7 @@
           "items": {
             "title": "NodeIdTranslationDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.NodeIdTranslationDataType",
             "required": [ "NodePlaceholder", "PortableNode" ],
             "properties": {
               "NodePlaceholder": {
@@ -3431,12 +3431,12 @@
               "PortableNode": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3453,7 +3453,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -3461,13 +3461,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3487,7 +3487,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3527,7 +3527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3571,7 +3571,7 @@
     "schemaDefinitions": {
       "LastActivityMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
         "const": {
           "EstablishEnabled": 0,
           "EstablishDisabled": 1,
@@ -3614,7 +3614,7 @@
       },
       "ConnectionStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
         "const": {
           "ConnectionNotMonitored": 0,
           "ConnectionNotEstablished": 1,
@@ -3657,7 +3657,7 @@
       },
       "FxErrorEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
         "const": {
           "NoError": 0,
           "UnknownStatus": 1,
@@ -3790,7 +3790,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -3814,7 +3814,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -3915,7 +3915,7 @@
         "items": {
           "title": "ConnectionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionDiagnosticsDataType",
           "required": [ "Name", "LastActivity", "ConnectionState", "ErrorEndpoint1", "Endpoint1Status", "ErrorEndpoint2", "Endpoint2Status" ],
           "properties": {
             "Name": {
@@ -3924,21 +3924,21 @@
             },
             "LastActivity": {
               "title": "LastActivityMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "ConnectionState": {
               "title": "ConnectionStateEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "ErrorEndpoint1": {
               "title": "FxErrorEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3948,7 +3948,7 @@
             },
             "ErrorEndpoint2": {
               "title": "FxErrorEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3985,7 +3985,7 @@
         "items": {
           "title": "PubSubKeyPushTargetDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
           "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
           "properties": {
             "ApplicationUri": {
@@ -4006,7 +4006,7 @@
             "UserTokenType": {
               "title": "UserTokenPolicy",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
               "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
               "properties": {
                 "PolicyId": {
@@ -4014,7 +4014,7 @@
                 },
                 "TokenType": {
                   "title": "UserTokenType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -4044,7 +4044,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -4102,7 +4102,7 @@
         "items": {
           "title": "SecurityGroupDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+          "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
           "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
           "properties": {
             "Name": {
@@ -4139,7 +4139,7 @@
               "items": {
                 "title": "RolePermissionType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                 "required": [ "RoleId", "Permissions" ],
                 "properties": {
                   "RoleId": {
@@ -4147,7 +4147,7 @@
                   },
                   "Permissions": {
                     "title": "PermissionType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                    "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4160,7 +4160,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -4193,7 +4193,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "SecurityKeyServerAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.SecurityKeyServerAddressDataType",
         "required": [ "Address", "SecurityPolicyUri", "ServerUri", "UsePushModel" ],
         "properties": {
           "Address": {
@@ -4319,7 +4319,7 @@
           "items": {
             "title": "ConnectionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3008",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionDiagnosticsDataType",
             "required": [ "Name", "LastActivity", "ConnectionState", "ErrorEndpoint1", "Endpoint1Status", "ErrorEndpoint2", "Endpoint2Status" ],
             "properties": {
               "Name": {
@@ -4328,21 +4328,21 @@
               },
               "LastActivity": {
                 "title": "LastActivityMask",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3009",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.LastActivityMask",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "ConnectionState": {
                 "title": "ConnectionStateEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionStateEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "ErrorEndpoint1": {
                 "title": "FxErrorEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4352,7 +4352,7 @@
               },
               "ErrorEndpoint2": {
                 "title": "FxErrorEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3015",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxErrorEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4378,7 +4378,7 @@
           "items": {
             "title": "PubSubKeyPushTargetDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25270",
+            "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetDataType",
             "required": [ "ApplicationUri", "PushTargetFolder", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval", "PushTargetProperties", "SecurityGroups" ],
             "properties": {
               "ApplicationUri": {
@@ -4399,7 +4399,7 @@
               "UserTokenType": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -4407,7 +4407,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -4437,7 +4437,7 @@
                 "items": {
                   "title": "KeyValuePair",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                  "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                   "required": [ "Key", "Value" ],
                   "properties": {
                     "Key": {
@@ -4474,7 +4474,7 @@
           "items": {
             "title": "SecurityGroupDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23601",
+            "dov:typeRef": "org.opcfoundation.UA.SecurityGroupDataType",
             "required": [ "Name", "SecurityGroupFolder", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount", "SecurityGroupId", "RolePermissions", "GroupProperties" ],
             "properties": {
               "Name": {
@@ -4511,7 +4511,7 @@
                 "items": {
                   "title": "RolePermissionType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                  "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                   "required": [ "RoleId", "Permissions" ],
                   "properties": {
                     "RoleId": {
@@ -4519,7 +4519,7 @@
                     },
                     "Permissions": {
                       "title": "PermissionType",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                      "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -4532,7 +4532,7 @@
                 "items": {
                   "title": "KeyValuePair",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                  "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                   "required": [ "Key", "Value" ],
                   "properties": {
                     "Key": {
@@ -4561,7 +4561,7 @@
         "data": {
           "title": "SecurityKeyServerAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.SecurityKeyServerAddressDataType",
           "required": [ "Address", "SecurityPolicyUri", "ServerUri", "UsePushModel" ],
           "properties": {
             "Address": {
@@ -4669,7 +4669,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4707,7 +4707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionEndpointConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1129",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionEndpointConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4749,18 +4749,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -4777,7 +4777,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -4785,13 +4785,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -4811,7 +4811,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -4863,12 +4863,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -4885,7 +4885,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -4893,13 +4893,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4919,7 +4919,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4957,18 +4957,18 @@
         "items": {
           "title": "PortableNodeIdentifierValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
           "required": [ "Key", "ArrayIndex", "Value" ],
           "properties": {
             "Key": {
               "title": "PortableNodeIdentifier",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
               "properties": {
                 "Node": {
                   "title": "PortableNodeId",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                  "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                   "required": [ "NamespaceUri", "Identifier" ],
                   "properties": {
                     "NamespaceUri": {
@@ -4985,7 +4985,7 @@
                 "IdentifierBrowsePath": {
                   "title": "PortableRelativePath",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -4993,13 +4993,13 @@
                       "items": {
                         "title": "PortableRelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
                             "title": "PortableNodeId",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                             "required": [ "NamespaceUri", "Identifier" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5019,7 +5019,7 @@
                           "TargetName": {
                             "title": "PortableQualifiedName",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                            "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                             "required": [ "NamespaceUri", "Name" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5069,12 +5069,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeIdentifier",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
         "properties": {
           "Node": {
             "title": "PortableNodeId",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+            "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
             "required": [ "NamespaceUri", "Identifier" ],
             "properties": {
               "NamespaceUri": {
@@ -5091,7 +5091,7 @@
           "IdentifierBrowsePath": {
             "title": "PortableRelativePath",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -5099,13 +5099,13 @@
                 "items": {
                   "title": "PortableRelativePathElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                  "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                   "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                   "properties": {
                     "ReferenceTypeId": {
                       "title": "PortableNodeId",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                       "required": [ "NamespaceUri", "Identifier" ],
                       "properties": {
                         "NamespaceUri": {
@@ -5125,7 +5125,7 @@
                     "TargetName": {
                       "title": "PortableQualifiedName",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                      "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                       "required": [ "NamespaceUri", "Name" ],
                       "properties": {
                         "NamespaceUri": {
@@ -5165,18 +5165,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -5193,7 +5193,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -5201,13 +5201,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5227,7 +5227,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5275,12 +5275,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -5297,7 +5297,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -5305,13 +5305,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5331,7 +5331,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -5365,18 +5365,18 @@
           "items": {
             "title": "PortableNodeIdentifierValuePair",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifierValuePair",
             "required": [ "Key", "ArrayIndex", "Value" ],
             "properties": {
               "Key": {
                 "title": "PortableNodeIdentifier",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
                 "properties": {
                   "Node": {
                     "title": "PortableNodeId",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                    "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                     "required": [ "NamespaceUri", "Identifier" ],
                     "properties": {
                       "NamespaceUri": {
@@ -5393,7 +5393,7 @@
                   "IdentifierBrowsePath": {
                     "title": "PortableRelativePath",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -5401,13 +5401,13 @@
                         "items": {
                           "title": "PortableRelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
                               "title": "PortableNodeId",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                               "required": [ "NamespaceUri", "Identifier" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5427,7 +5427,7 @@
                             "TargetName": {
                               "title": "PortableQualifiedName",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                              "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                               "required": [ "NamespaceUri", "Name" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5473,12 +5473,12 @@
         "data": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5495,7 +5495,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5503,13 +5503,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5529,7 +5529,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5566,7 +5566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionEndpointParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1261",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionEndpointParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5635,7 +5635,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "PortableNodeId",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
         "required": [ "NamespaceUri", "Identifier" ],
         "properties": {
           "NamespaceUri": {
@@ -5665,12 +5665,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5687,7 +5687,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5695,13 +5695,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5721,7 +5721,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5810,12 +5810,12 @@
         "items": {
           "title": "PortableNodeIdentifier",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
           "properties": {
             "Node": {
               "title": "PortableNodeId",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+              "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
               "required": [ "NamespaceUri", "Identifier" ],
               "properties": {
                 "NamespaceUri": {
@@ -5832,7 +5832,7 @@
             "IdentifierBrowsePath": {
               "title": "PortableRelativePath",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -5840,13 +5840,13 @@
                   "items": {
                     "title": "PortableRelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                    "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
                         "title": "PortableNodeId",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                         "required": [ "NamespaceUri", "Identifier" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5866,7 +5866,7 @@
                       "TargetName": {
                         "title": "PortableQualifiedName",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                        "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                         "required": [ "NamespaceUri", "Name" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5966,7 +5966,7 @@
         "data": {
           "title": "PortableNodeId",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
           "required": [ "NamespaceUri", "Identifier" ],
           "properties": {
             "NamespaceUri": {
@@ -5992,12 +5992,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -6014,7 +6014,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -6022,13 +6022,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6048,7 +6048,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6121,12 +6121,12 @@
           "items": {
             "title": "PortableNodeIdentifier",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableNodeIdentifier",
             "properties": {
               "Node": {
                 "title": "PortableNodeId",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                 "required": [ "NamespaceUri", "Identifier" ],
                 "properties": {
                   "NamespaceUri": {
@@ -6143,7 +6143,7 @@
               "IdentifierBrowsePath": {
                 "title": "PortableRelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1047",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -6151,13 +6151,13 @@
                     "items": {
                       "title": "PortableRelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1051",
+                      "dov:typeRef": "org.opcfoundation.UA.FX.CM.PortableRelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
                           "title": "PortableNodeId",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24106",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableNodeId",
                           "required": [ "NamespaceUri", "Identifier" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6177,7 +6177,7 @@
                         "TargetName": {
                           "title": "PortableQualifiedName",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24105",
+                          "dov:typeRef": "org.opcfoundation.UA.PortableQualifiedName",
                           "required": [ "NamespaceUri", "Name" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6241,7 +6241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6282,7 +6282,7 @@
     "schemaDefinitions": {
       "FxEditEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxEditEnum",
         "const": {
           "StartEditing": 0,
           "CommitUpdates": 1,
@@ -6305,7 +6305,7 @@
       },
       "FxProcessEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
         "const": {
           "ActionEstablishConnectionsEnabled": 0,
           "ActionEstablishConnectionsDisabled": 1,
@@ -6364,12 +6364,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1265",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Action", "ConnectionConfigurationSets" ],
           "properties": {
             "Action": {
               "title": "FxEditEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3001",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxEditEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6384,7 +6384,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1267",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -6407,12 +6407,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1270",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Action", "ConnectionConfigurationSets" ],
           "properties": {
             "Action": {
               "title": "FxProcessEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.FX.CM.FxProcessEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6427,7 +6427,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1271",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -6491,7 +6491,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6502,7 +6502,7 @@
     "schemaDefinitions": {
       "ConnectionConfigurationSetOperation": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=13054",
+        "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetOperation",
         "const": {
           "ElementAdd": 0,
           "ElementRemove": 1,
@@ -6529,7 +6529,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=16032",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "RequireCompleteUpdate", "Operations" ],
           "properties": {
             "FileHandle": {
@@ -6544,7 +6544,7 @@
               "type": "array",
               "items": {
                 "title": "ConnectionConfigurationSetOperation",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=13054",
+                "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetOperation",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -6554,7 +6554,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=16033",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ChangesApplied", "OperationResults", "ConfigurationObjects" ],
           "properties": {
             "ChangesApplied": {
@@ -6597,7 +6597,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionManagerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionManagerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6623,7 +6623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_ConnectionConfigurationSetStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.ConnectionConfigurationSetStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6726,7 +6726,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_CM_SubscriberConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/CM/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.FX.CM.SubscriberConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6760,7 +6760,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/CM/",
         "title": "NetworkAddressDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+        "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
         "required": [ "NetworkInterface" ],
         "properties": {
           "NetworkInterface": {
@@ -6826,7 +6826,7 @@
         "data": {
           "title": "NetworkAddressDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
           "required": [ "NetworkInterface" ],
           "properties": {
             "NetworkInterface": {

--- a/wot-codegen/opc-output-simple/FX.Data.TM.json
+++ b/wot-codegen/opc-output-simple/FX.Data.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "FX_Data_AuditUpdateMethodResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.FX.Data.AuditUpdateMethodResultEventType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/GDS.TM.json
+++ b/wot-codegen/opc-output-simple/GDS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_DirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.DirectoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26,7 +26,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -54,7 +54,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -64,7 +64,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=17",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Applications" ],
           "properties": {
             "Applications": {
@@ -72,7 +72,7 @@
               "items": {
                 "title": "ApplicationRecordDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+                "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
                 "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
                 "properties": {
                   "ApplicationId": {
@@ -83,7 +83,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -126,7 +126,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=211",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -136,13 +136,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=212",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -153,7 +153,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -195,7 +195,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=869",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartingRecordId", "MaxRecordsToReturn", "ApplicationName", "ApplicationUri", "ApplicationType", "ProductUri", "Capabilities" ],
           "properties": {
             "StartingRecordId": {
@@ -232,7 +232,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=870",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LastCounterResetTime", "NextRecordId", "Applications" ],
           "properties": {
             "LastCounterResetTime": {
@@ -249,7 +249,7 @@
               "items": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -263,7 +263,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -297,7 +297,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=24",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartingRecordId", "MaxRecordsToReturn", "ApplicationName", "ApplicationUri", "ProductUri", "ServerCapabilities" ],
           "properties": {
             "StartingRecordId": {
@@ -329,7 +329,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=25",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "LastCounterResetTime", "Servers" ],
           "properties": {
             "LastCounterResetTime": {
@@ -341,7 +341,7 @@
               "items": {
                 "title": "ServerOnNetwork",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12189",
+                "dov:typeRef": "org.opcfoundation.UA.ServerOnNetwork",
                 "required": [ "RecordId", "ServerName", "DiscoveryUrl", "ServerCapabilities" ],
                 "properties": {
                   "RecordId": {
@@ -378,13 +378,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=19",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -395,7 +395,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -427,7 +427,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=20",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -447,7 +447,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=22",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -467,13 +467,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=189",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -484,7 +484,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -537,7 +537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_ApplicationRegistrationChangedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRegistrationChangedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -564,7 +564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=63",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -579,7 +579,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=160",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Certificate" ],
           "properties": {
             "Certificate": {
@@ -590,7 +590,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateStatus", "ValidityTime" ],
           "properties": {
             "CertificateStatus": {
@@ -614,7 +614,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=86",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "RequestId" ],
           "properties": {
             "ApplicationId": {
@@ -627,7 +627,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=87",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificate", "PrivateKey", "IssuerCertificates" ],
           "properties": {
             "Certificate": {
@@ -659,7 +659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=370",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -669,7 +669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=371",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateGroupIds" ],
           "properties": {
             "CertificateGroupIds": {
@@ -692,7 +692,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=90",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId" ],
           "properties": {
             "ApplicationId": {
@@ -705,7 +705,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=108",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateTypeIds", "Certificates" ],
           "properties": {
             "CertificateTypeIds": {
@@ -735,7 +735,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=223",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId" ],
           "properties": {
             "ApplicationId": {
@@ -751,7 +751,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=224",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateRequired" ],
           "properties": {
             "UpdateRequired": {
@@ -771,7 +771,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId" ],
           "properties": {
             "ApplicationId": {
@@ -784,7 +784,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=199",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "TrustListId" ],
           "properties": {
             "TrustListId": {
@@ -804,7 +804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=15004",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "Certificate" ],
           "properties": {
             "ApplicationId": {
@@ -828,7 +828,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=77",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId", "SubjectName", "DomainNames", "PrivateKeyFormat", "PrivateKeyPassword" ],
           "properties": {
             "ApplicationId": {
@@ -859,7 +859,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=78",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -879,7 +879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=80",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationId", "CertificateGroupId", "CertificateTypeId", "CertificateRequest" ],
           "properties": {
             "ApplicationId": {
@@ -899,7 +899,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=81",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -930,7 +930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=91",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -988,7 +988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateDeliveredAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=109",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateDeliveredAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1046,7 +1046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_CertificateRevokedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.CertificateRevokedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1073,7 +1073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialManagementFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialManagementFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1105,7 +1105,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1127,7 +1127,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1027",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestId", "CancelRequest" ],
           "properties": {
             "RequestId": {
@@ -1140,7 +1140,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1028",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CredentialId", "CredentialSecret", "CertificateThumbprint", "SecurityPolicyUri", "GrantedRoles" ],
           "properties": {
             "CredentialId": {
@@ -1176,7 +1176,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId" ],
           "properties": {
             "CredentialId": {
@@ -1196,7 +1196,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri", "PublicKey", "SecurityPolicyUri", "RequestedRoles" ],
           "properties": {
             "ApplicationUri": {
@@ -1219,7 +1219,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RequestId" ],
           "properties": {
             "RequestId": {
@@ -1292,7 +1292,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1319,7 +1319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialDeliveredAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialDeliveredAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1346,7 +1346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_KeyCredentialRevokedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.KeyCredentialRevokedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1373,7 +1373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AuthorizationServicesFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=233",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AuthorizationServicesFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1399,7 +1399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AuthorizationServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=966",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AuthorizationServiceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1410,7 +1410,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -1445,7 +1445,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1005",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ServiceUri", "ServiceCertificate", "UserTokenPolicies" ],
           "properties": {
             "ServiceUri": {
@@ -1460,7 +1460,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -1468,7 +1468,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -1499,13 +1499,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/GDS/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=970",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IdentityToken", "ResourceId" ],
           "properties": {
             "IdentityToken": {
               "title": "UserIdentityToken",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=316",
+              "dov:typeRef": "org.opcfoundation.UA.UserIdentityToken",
               "required": [ "PolicyId" ],
               "properties": {
                 "PolicyId": {
@@ -1520,7 +1520,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=971",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AccessToken" ],
           "properties": {
             "AccessToken": {
@@ -1569,7 +1569,7 @@
         "items": {
           "title": "UserTokenPolicy",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
           "properties": {
             "PolicyId": {
@@ -1577,7 +1577,7 @@
             },
             "TokenType": {
               "title": "UserTokenType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1615,7 +1615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GDS_AccessTokenIssuedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=975",
+    "dov:typeRef": "org.opcfoundation.UA.GDS.AccessTokenIssuedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/GMS.TM.json
+++ b/wot-codegen/opc-output-simple/GMS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorWarningAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorWarningAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_IntermediateResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.IntermediateResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -126,7 +126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_MultiSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.MultiSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -144,7 +144,7 @@
     "schemaDefinitions": {
       "ToolAlignmentState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "const": {
           "Fixed": 0,
           "Indexed": 1,
@@ -181,7 +181,7 @@
       "Alignment": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolAlignmentState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -232,7 +232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -249,7 +249,7 @@
     "schemaDefinitions": {
       "ToolAlignmentState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "const": {
           "Fixed": 0,
           "Indexed": 1,
@@ -269,7 +269,7 @@
       },
       "ToolIsQualifiedStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolIsQualifiedStatus",
         "const": {
           "Qualified": 0,
           "Imprecise": 1,
@@ -328,7 +328,7 @@
       "Alignment": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolAlignmentState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolAlignmentState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -409,7 +409,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -444,7 +444,7 @@
       "IsQualifiedStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ToolIsQualifiedStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.ToolIsQualifiedStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -563,7 +563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CharacteristicType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CharacteristicType",
     "links": [
       {
         "rel": "tm:extends",
@@ -574,7 +574,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -733,7 +733,7 @@
       "ResultEvaluation": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "ResultEvaluationEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -862,7 +862,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CorrectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CorrectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1109,7 +1109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_LoadingMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.LoadingMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1214,7 +1214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_ToolMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.ToolMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1272,7 +1272,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1316,7 +1316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1383,7 +1383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1440,7 +1440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1478,7 +1478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1490,7 +1490,7 @@
     "schemaDefinitions": {
       "MeasurementReasonEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.MeasurementReasonEnum",
         "const": {
           "ContinuousMeasurements": 0,
           "SpecialMeasurement": 1,
@@ -1574,7 +1574,7 @@
       "MeasurementReason": {
         "dov:namespace": "http://opcfoundation.org/UA/GMS/",
         "title": "MeasurementReasonEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.GMS.MeasurementReasonEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1623,7 +1623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSPartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSPartType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1874,7 +1874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_CalibrationPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.CalibrationPrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2003,7 +2003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_GMSResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.GMSResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2035,7 +2035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_RotaryTableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.RotaryTableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2109,7 +2109,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_SensorExchangeRackType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.SensorExchangeRackType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2164,7 +2164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GMS_TipExchangeRackType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GMS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.GMS.TipExchangeRackType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/GPOS.TM.json
+++ b/wot-codegen/opc-output-simple/GPOS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "GPOS_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.GPOS.ZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -83,14 +83,14 @@
           "title": "GroundControlPointDataType",
           "description": "Defines a pair of coordinates - local and global - to allow geo-references from local coordinate to a global coordinate system",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.RSL.GroundControlPointDataType",
           "required": [ "GlobalPosition", "LocalPosition" ],
           "properties": {
             "GlobalPosition": {
               "title": "S3DGeographicCoordinateDataType",
               "description": "Represents a geographic coordinate",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
               "required": [ "Longitude", "Latitude" ],
               "properties": {
                 "Longitude": {
@@ -117,7 +117,7 @@
               "title": "ThreeDCartesianCoordinates",
               "description": "Local position in metric coordinates (in meter)",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
               "required": [ "X", "Y", "Z" ],
               "properties": {
                 "X": {
@@ -176,7 +176,7 @@
         "title": "S3DGeographicCoordinateDataType",
         "description": "Represents a geographic coordinate",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
         "required": [ "Longitude", "Latitude" ],
         "properties": {
           "Longitude": {
@@ -279,14 +279,14 @@
             "title": "GroundControlPointDataType",
             "description": "Defines a pair of coordinates - local and global - to allow geo-references from local coordinate to a global coordinate system",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.RSL.GroundControlPointDataType",
             "required": [ "GlobalPosition", "LocalPosition" ],
             "properties": {
               "GlobalPosition": {
                 "title": "S3DGeographicCoordinateDataType",
                 "description": "Represents a geographic coordinate",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
                 "required": [ "Longitude", "Latitude" ],
                 "properties": {
                   "Longitude": {
@@ -313,7 +313,7 @@
                 "title": "ThreeDCartesianCoordinates",
                 "description": "Local position in metric coordinates (in meter)",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+                "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
                 "required": [ "X", "Y", "Z" ],
                 "properties": {
                   "X": {
@@ -350,7 +350,7 @@
           "title": "S3DGeographicCoordinateDataType",
           "description": "Represents a geographic coordinate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/GPOS/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.GPOS.S3DGeographicCoordinateDataType",
           "required": [ "Longitude", "Latitude" ],
           "properties": {
             "Longitude": {

--- a/wot-codegen/opc-output-simple/Glass.Flat.TM.json
+++ b/wot-codegen/opc-output-simple/Glass.Flat.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -115,7 +115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_CommunicationErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CommunicationErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -142,7 +142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -169,7 +169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialExitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialExitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialMissingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialMissingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -223,7 +223,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MaterialReceivedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MaterialReceivedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -250,7 +250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_IntermediateStepEvent",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.IntermediateStepEvent",
     "dov:isEvent": true,
     "links": [
       {
@@ -323,7 +323,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InterruptedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InterruptedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -379,7 +379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_EmergencyButtonPressedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.EmergencyButtonPressedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -406,7 +406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_MotorTemperatureTooHighEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.MotorTemperatureTooHighEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -433,7 +433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_OpenSecurityFenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.OpenSecurityFenceType",
     "dov:isEvent": true,
     "links": [
       {
@@ -460,7 +460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_OutOfJobEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.OutOfJobEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -487,7 +487,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProcessParameterOutOfRangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProcessParameterOutOfRangeType",
     "dov:isEvent": true,
     "links": [
       {
@@ -514,7 +514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ToolMissingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ToolMissingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -541,7 +541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_JobMovedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.JobMovedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -614,7 +614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_BaseMaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.BaseMaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -861,7 +861,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_AssemblyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.AssemblyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -887,7 +887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_FoilType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FoilType",
     "dov:isComposite": true,
     "links": [
       {
@@ -966,7 +966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GasMixType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GasMixType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1114,7 +1114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1125,7 +1125,7 @@
     "schemaDefinitions": {
       "CoatingClassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoatingClassEnumeration",
         "const": {
           "HardCoating": 0,
           "SoftCoating": 1,
@@ -1149,7 +1149,7 @@
       },
       "SignificantSideEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SignificantSideEnumeration",
         "const": {
           "Indifferent": 0,
           "Top": 1,
@@ -1169,7 +1169,7 @@
       },
       "StructureAlignmentEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.StructureAlignmentEnumeration",
         "const": {
           "Indifferent": 0,
           "Longitudinal": 1,
@@ -1228,7 +1228,7 @@
       "CoatingClass": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "CoatingClassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoatingClassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1334,7 +1334,7 @@
       "SignificantSide": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "SignificantSideEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SignificantSideEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1355,7 +1355,7 @@
       "StructureAlignment": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "StructureAlignmentEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.StructureAlignmentEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1553,7 +1553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_PackagingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.PackagingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1688,7 +1688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_SealingMaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SealingMaterialType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1824,7 +1824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_SpacerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1836,7 +1836,7 @@
     "schemaDefinitions": {
       "SpacerMaterialClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerMaterialClass",
         "const": {
           "Other": 0,
           "Metalic": 1,
@@ -1943,7 +1943,7 @@
       "SpacerMaterialClass": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "SpacerMaterialClass",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.SpacerMaterialClass",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2036,7 +2036,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ConfigurationRulesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ConfigurationRulesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2047,7 +2047,7 @@
     "schemaDefinitions": {
       "CoordinateSystemEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoordinateSystemEnumeration",
         "const": {
           "Unknown": 0,
           "System1": 1,
@@ -2111,7 +2111,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -2145,7 +2145,7 @@
         "items": {
           "title": "FileFormatType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FileFormatType",
           "required": [ "Name", "FileExtension", "Version" ],
           "properties": {
             "Name": {
@@ -2171,7 +2171,7 @@
       "MachineProcessingCoordinateSystem": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "CoordinateSystemEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CoordinateSystemEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2202,7 +2202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2228,7 +2228,7 @@
         "items": {
           "title": "UserProfileType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.UserProfileType",
           "required": [ "Name", "LoginTime", "Language", "MeasurementFormat", "AccessLevel", "OpcUaUser" ],
           "properties": {
             "Name": {
@@ -2274,7 +2274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ManualFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ManualFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2328,7 +2328,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_GlassMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.GlassMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2379,7 +2379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InstructionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InstructionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2414,7 +2414,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "title": "FileFormatType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.FileFormatType",
         "required": [ "Name", "FileExtension", "Version" ],
         "properties": {
           "Name": {
@@ -2454,7 +2454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionPlanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionPlanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2480,7 +2480,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionJobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2727,7 +2727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_AssemblyJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.AssemblyJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2766,7 +2766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_CuttingJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.CuttingJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2805,7 +2805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProcessingJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProcessingJobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2844,7 +2844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2877,7 +2877,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Target", "Source", "Before" ],
           "properties": {
             "Target": {
@@ -2903,7 +2903,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6123",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier" ],
           "properties": {
             "Identifier": {
@@ -2923,7 +2923,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identifier", "Name", "InputMaterial", "OutputMaterial" ],
           "properties": {
             "Identifier": {
@@ -2948,7 +2948,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -3054,7 +3054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_InitializingSubStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.InitializingSubStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3122,7 +3122,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.ProductionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Glass.Flat.v2.TM.json
+++ b/wot-codegen/opc-output-simple/Glass.Flat.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -119,7 +119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_ConfigurationRulesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ConfigurationRulesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     "schemaDefinitions": {
       "CoordinateSystemEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.CoordinateSystemEnumeration",
         "const": {
           "Unknown": 0,
           "System1": 1,
@@ -194,7 +194,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -228,7 +228,7 @@
         "items": {
           "title": "FileFormatDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.FileFormatDataType",
           "required": [ "Name", "FileExtension", "Version" ],
           "properties": {
             "Name": {
@@ -254,7 +254,7 @@
       "MachineProcessingCoordinateSystem": {
         "dov:namespace": "http://opcfoundation.org/UA/Glass/Flat/v2/",
         "title": "CoordinateSystemEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.CoordinateSystemEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -285,7 +285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -316,7 +316,7 @@
         "items": {
           "title": "UserProfileDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.UserProfileDataType",
           "required": [ "Name", "LoginTime", "Language", "MeasurementFormat", "AccessLevel", "OpcUaUser" ],
           "properties": {
             "Name": {
@@ -355,7 +355,7 @@
         "items": {
           "title": "ProcessingCategoryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingCategoryDataType",
           "required": [ "ID", "Description", "SupportedParameter", "SupportedAssignment", "SupportedVariable", "SupportsTransformation", "SupportsSubProcessing" ],
           "properties": {
             "ID": {
@@ -369,7 +369,7 @@
               "items": {
                 "title": "ProcessingParameterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingParameterDataType",
                 "required": [ "Name", "Description", "ValueType", "TypicalValue", "Mandatory", "EClass" ],
                 "properties": {
                   "Name": {
@@ -381,7 +381,7 @@
                   "ValueType": {
                     "title": "ValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ValueDataType",
                     "required": [ "Name", "Description", "BaseUnit", "PossibleValue" ],
                     "properties": {
                       "Name": {
@@ -407,7 +407,7 @@
                   "EClass": {
                     "title": "EClassTermDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.EClassTermDataType",
                     "required": [ "ID", "Description", "EClass" ],
                     "properties": {
                       "ID": {
@@ -435,7 +435,7 @@
               "items": {
                 "title": "ProcessingParameterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ProcessingParameterDataType",
                 "required": [ "Name", "Description", "ValueType", "TypicalValue", "Mandatory", "EClass" ],
                 "properties": {
                   "Name": {
@@ -447,7 +447,7 @@
                   "ValueType": {
                     "title": "ValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3020",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ValueDataType",
                     "required": [ "Name", "Description", "BaseUnit", "PossibleValue" ],
                     "properties": {
                       "Name": {
@@ -473,7 +473,7 @@
                   "EClass": {
                     "title": "EClassTermDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=3017",
+                    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.EClassTermDataType",
                     "required": [ "ID", "Description", "EClass" ],
                     "properties": {
                       "ID": {
@@ -529,7 +529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_ManualFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.ManualFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Glass_Flat_v2_GlassMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Glass/Flat/v2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Glass.Flat.v2.GlassMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/I4AAS.TM.json
+++ b/wot-codegen/opc-output-simple/I4AAS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAdministrativeInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAdministrativeInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -80,7 +80,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAssetAdministrationShellType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetAdministrationShellType",
     "dov:isComposite": true,
     "links": [
       {
@@ -149,7 +149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -178,7 +178,7 @@
     "schemaDefinitions": {
       "AASAssetKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetKindDataType",
         "const": {
           "Type": 0,
           "Instance": 1
@@ -213,7 +213,7 @@
       "AssetKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASAssetKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAssetKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -244,7 +244,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASConceptDictionaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASConceptDictionaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -270,7 +270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASDataSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -296,7 +296,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASDataSpecificationIEC61360Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataSpecificationIEC61360Type",
     "dov:isComposite": true,
     "links": [
       {
@@ -338,7 +338,7 @@
     "schemaDefinitions": {
       "AASCategoryDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCategoryDataType",
         "const": {
           "CONSTANT": 0,
           "PARAMETER": 1,
@@ -366,7 +366,7 @@
       },
       "AASDataTypeIEC61360DataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataTypeIEC61360DataType",
         "const": {
           "BOOLEAN": 0,
           "DATE": 1,
@@ -434,7 +434,7 @@
       },
       "AASLevelTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASLevelTypeDataType",
         "const": {
           "Min": 0,
           "Max": 1,
@@ -479,7 +479,7 @@
       "Category": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASCategoryDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCategoryDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -500,7 +500,7 @@
       "DataType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASDataTypeIEC61360DataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASDataTypeIEC61360DataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -555,7 +555,7 @@
       "LevelType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASLevelTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASLevelTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -706,7 +706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIdentifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -717,7 +717,7 @@
     "schemaDefinitions": {
       "AASIdentifierTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierTypeDataType",
         "const": {
           "IRDI": 0,
           "IRI": 1,
@@ -774,7 +774,7 @@
       "IdType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASIdentifierTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIdentifierTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -805,7 +805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASQualifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASQualifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -822,7 +822,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -946,7 +946,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -977,7 +977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASReferenceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASReferenceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1001,7 +1001,7 @@
     "schemaDefinitions": {
       "AASKeyElementsDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyElementsDataType",
         "const": {
           "AccessPermissionRule": 0,
           "AnnotatedRelationshipElement": 1,
@@ -1129,7 +1129,7 @@
       },
       "AASKeyTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyTypeDataType",
         "const": {
           "IdShort": 0,
           "FragmentId": 1,
@@ -1182,12 +1182,12 @@
         "items": {
           "title": "AASKeyDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyDataType",
           "required": [ "Type", "Local", "Value", "IdType" ],
           "properties": {
             "Type": {
               "title": "AASKeyElementsDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyElementsDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1200,7 +1200,7 @@
             },
             "IdType": {
               "title": "AASKeyTypeDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASKeyTypeDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1234,7 +1234,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1257,7 +1257,7 @@
     "schemaDefinitions": {
       "AASModelingKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "const": {
           "Template": 0,
           "Instance": 1
@@ -1309,7 +1309,7 @@
       "ModelingKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASModelingKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1340,7 +1340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASBlobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASBlobType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1373,7 +1373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASCapabilityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCapabilityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1400,7 +1400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1424,7 +1424,7 @@
     "schemaDefinitions": {
       "AASEntityTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityTypeDataType",
         "const": {
           "CoManagedEntity": 0,
           "SelfManagedEntity": 1
@@ -1459,7 +1459,7 @@
       "EntityType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASEntityTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEntityTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1490,7 +1490,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASEventType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1517,7 +1517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1596,7 +1596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASMultiLanguagePropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASMultiLanguagePropertyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1661,7 +1661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASOperationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1698,7 +1698,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASPropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASPropertyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1716,7 +1716,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -1823,7 +1823,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1854,7 +1854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASRangeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASRangeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1866,7 +1866,7 @@
     "schemaDefinitions": {
       "AASValueTypeDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "const": {
           "Boolean": 0,
           "SByte": 1,
@@ -1991,7 +1991,7 @@
       "ValueType": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASValueTypeDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASValueTypeDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2022,7 +2022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASReferenceElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASReferenceElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2055,7 +2055,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASRelationshipElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASRelationshipElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2094,7 +2094,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASAnnotatedRelationshipElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASAnnotatedRelationshipElementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2127,7 +2127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelElementCollectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelElementCollectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2189,7 +2189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASOrderedSubmodelElementCollectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASOrderedSubmodelElementCollectionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2216,7 +2216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASSubmodelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASSubmodelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2245,7 +2245,7 @@
     "schemaDefinitions": {
       "AASModelingKindDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "const": {
           "Template": 0,
           "Instance": 1
@@ -2280,7 +2280,7 @@
       "ModelingKind": {
         "dov:namespace": "http://opcfoundation.org/UA/I4AAS/",
         "title": "AASModelingKindDataType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASModelingKindDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2311,7 +2311,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_IAASReferableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.IAASReferableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2367,7 +2367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_IAASIdentifiableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.IAASIdentifiableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2406,7 +2406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASCustomConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASCustomConceptDescriptionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2445,7 +2445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIrdiConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIrdiConceptDescriptionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2484,7 +2484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASIriConceptDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASIriConceptDescriptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2522,7 +2522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_AASViewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.AASViewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2560,7 +2560,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "I4AAS_ValueListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/I4AAS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.I4AAS.ValueListType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/IA.TM.json
+++ b/wot-codegen/opc-output-simple/IA.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_AcousticSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IA.AcousticSignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BaseCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BaseCalibrationTargetCategoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_DynamicCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.IA.DynamicCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -156,7 +156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_OneTimeCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.IA.OneTimeCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ReusableCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ReusableCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -210,7 +210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ReusableDeviceCalibrationTargetCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ReusableDeviceCalibrationTargetCategoryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -237,7 +237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -305,7 +305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IAggregateStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IAggregateStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -361,7 +361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_IRollingStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IA.IRollingStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -438,7 +438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_CalibrationTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.IA.CalibrationTargetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -577,7 +577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_ControlChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IA.ControlChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -588,7 +588,7 @@
     "schemaDefinitions": {
       "SignalColor": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "const": {
           "Off": 0,
           "Red": 1,
@@ -637,7 +637,7 @@
       },
       "SignalModeLight": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "const": {
           "Continuous": 0,
           "Blinking": 1,
@@ -689,7 +689,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalColor",
         "description": "Indicates in what mode (continuously on, blinking, flashing) the channel operates when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -731,7 +731,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalModeLight",
         "description": "Contains a list of audio signals used by this acoustic stacklight element.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -774,7 +774,7 @@
         "data": {
           "title": "SignalColor",
           "description": "Indicates in what mode (continuously on, blinking, flashing) the channel operates when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -808,7 +808,7 @@
         "data": {
           "title": "SignalModeLight",
           "description": "Contains a list of audio signals used by this acoustic stacklight element.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -832,7 +832,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_BasicStacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IA.BasicStacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -856,7 +856,7 @@
     "schemaDefinitions": {
       "StacklightOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "const": {
           "Segmented": 0,
           "Levelmeter": 1,
@@ -903,7 +903,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "StacklightOperationMode",
         "description": "Shows in what way (stack of individual lights, level meter, running light) the stacklight unit is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.IA.StacklightOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -934,7 +934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StacklightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StacklightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -952,7 +952,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -1008,7 +1008,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
         "description": "Contains the health status information of the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1033,7 +1033,7 @@
         "data": {
           "title": "DeviceHealthEnumeration",
           "description": "Contains the health status information of the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1057,7 +1057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1144,7 +1144,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementAcousticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementAcousticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1264,7 +1264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackElementLightType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackElementLightType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1282,7 +1282,7 @@
     "schemaDefinitions": {
       "SignalColor": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "const": {
           "Off": 0,
           "Red": 1,
@@ -1331,7 +1331,7 @@
       },
       "SignalModeLight": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "const": {
           "Continuous": 0,
           "Blinking": 1,
@@ -1403,7 +1403,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalColor",
         "description": "Indicates the colour the lamp element has when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1425,7 +1425,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "SignalModeLight",
         "description": "Shows in what way the lamp is used (continuous light, flashing, blinking) when switched on.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1447,7 +1447,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "RGBWDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.IA.RGBWDataType",
         "required": [ "Red", "Green", "Blue" ],
         "properties": {
           "Red": {
@@ -1512,7 +1512,7 @@
         "data": {
           "title": "SignalColor",
           "description": "Indicates the colour the lamp element has when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalColor",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1530,7 +1530,7 @@
         "data": {
           "title": "SignalModeLight",
           "description": "Shows in what way the lamp is used (continuous light, flashing, blinking) when switched on.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.IA.SignalModeLight",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1548,7 +1548,7 @@
         "data": {
           "title": "RGBWDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.IA.RGBWDataType",
           "required": [ "Red", "Green", "Blue" ],
           "properties": {
             "Red": {
@@ -1596,7 +1596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackLevelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackLevelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1607,7 +1607,7 @@
     "schemaDefinitions": {
       "LevelDisplayMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "const": {
           "Dimmed": 0,
           "Blinking": 1,
@@ -1654,7 +1654,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IA/",
         "title": "LevelDisplayMode",
         "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1699,7 +1699,7 @@
         "data": {
           "title": "LevelDisplayMode",
           "description": "Indicates in what way the percentual value is displayed with the stacklight.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.IA.LevelDisplayMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1739,7 +1739,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IA_StackRunningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IA/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IA.StackRunningType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/IJT.Base.TM.json
+++ b/wot-codegen/opc-output-simple/IJT.Base.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AcceptedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AcceptedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AddedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1096",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AddedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetConnectedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetConnectedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetDisabledConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetDisabledConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetDisconnectedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetDisconnectedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetEnabledConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetEnabledConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_AssetLocationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.AssetLocationConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_CertificateConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.CertificateConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ConfigurationChangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ConfigurationChangeConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_DataValidationFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DataValidationFailureConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_EntityExpiryWarningConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityExpiryWarningConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -305,7 +305,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ErrorConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ErrorConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -332,7 +332,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ExpiredEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ExpiredEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -359,7 +359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_HardwareConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.HardwareConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IncompatibleEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IncompatibleEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -413,7 +413,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_InputValidationFailureConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.InputValidationFailureConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -440,7 +440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_InvalidEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.InvalidEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -467,7 +467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemUserLoggedInConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemUserLoggedInConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -494,7 +494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemUserLoggedOutConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemUserLoggedOutConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -521,7 +521,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LicenseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LicenseConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -548,7 +548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LocationInZoneConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LocationInZoneConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -575,7 +575,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_LocationOutOfZoneConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.LocationOutOfZoneConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -602,7 +602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_MissingEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.MissingEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -629,7 +629,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_NotAvailableEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.NotAvailableEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -656,7 +656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_NotSupportedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.NotSupportedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -683,7 +683,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ReceivedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1105",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReceivedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -710,7 +710,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RejectedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1093",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RejectedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -737,7 +737,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RemovedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1102",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RemovedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -764,7 +764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SelectedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SelectedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -791,7 +791,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SelectedProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SelectedProcessConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -818,7 +818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_SoftwareConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SoftwareConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -845,7 +845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_StartedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.StartedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -872,7 +872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_StoppedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.StoppedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -899,7 +899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ThresholdViolationConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ThresholdViolationConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -926,7 +926,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ThresholdViolationResolvedConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ThresholdViolationResolvedConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -953,7 +953,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_UnacknowledgedResultsConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.UnacknowledgedResultsConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_UpdatedEntityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1099",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.UpdatedEntityConditionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1007,7 +1007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1055,7 +1055,7 @@
           "title": "EntityDataType",
           "description": "This structure provides the identification data for a given entity in the system.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
           "required": [ "EntityId", "EntityType" ],
           "properties": {
             "Name": {
@@ -1148,7 +1148,7 @@
           "title": "ReportedValueDataType",
           "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
           "required": [ "CurrentValue" ],
           "properties": {
             "PhysicalQuantity": {
@@ -1185,7 +1185,7 @@
               "title": "EUInformation",
               "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1242,7 +1242,7 @@
             "title": "EntityDataType",
             "description": "This structure provides the identification data for a given entity in the system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
             "required": [ "EntityId", "EntityType" ],
             "properties": {
               "Name": {
@@ -1339,7 +1339,7 @@
             "title": "ReportedValueDataType",
             "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
             "required": [ "CurrentValue" ],
             "properties": {
               "PhysicalQuantity": {
@@ -1376,7 +1376,7 @@
                 "title": "EUInformation",
                 "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -1418,7 +1418,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1466,7 +1466,7 @@
           "title": "EntityDataType",
           "description": "This structure provides the identification data for a given entity in the system.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
           "required": [ "EntityId", "EntityType" ],
           "properties": {
             "Name": {
@@ -1559,7 +1559,7 @@
           "title": "ReportedValueDataType",
           "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
           "required": [ "CurrentValue" ],
           "properties": {
             "PhysicalQuantity": {
@@ -1596,7 +1596,7 @@
               "title": "EUInformation",
               "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1653,7 +1653,7 @@
             "title": "EntityDataType",
             "description": "This structure provides the identification data for a given entity in the system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
             "required": [ "EntityId", "EntityType" ],
             "properties": {
               "Name": {
@@ -1750,7 +1750,7 @@
             "title": "ReportedValueDataType",
             "description": "This structure provides the given value and corresponding limits for a given physical quantity (if applicable).",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3022",
+            "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ReportedValueDataType",
             "required": [ "CurrentValue" ],
             "properties": {
               "PhysicalQuantity": {
@@ -1787,7 +1787,7 @@
                 "title": "EUInformation",
                 "description": "It is the engineering unit of the CurrentValue, PreviousValue, LowLimit, HighLimit.  It is not applicable for values which does not have PhysicalQuantity.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -1829,7 +1829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1841,7 +1841,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -1894,14 +1894,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -1967,7 +1967,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -2002,7 +2002,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2057,14 +2057,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -2130,7 +2130,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -2165,7 +2165,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_RequestedResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.RequestedResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2245,7 +2245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IJoiningAdditionalInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IJoiningAdditionalInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2317,7 +2317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IJoiningSystemAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IJoiningSystemAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2367,7 +2367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IAccessoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IAccessoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2399,7 +2399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IBatteryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IBatteryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2431,7 +2431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ICableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ICableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2463,7 +2463,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2495,7 +2495,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IFeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IFeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2527,7 +2527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IMemoryDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IMemoryDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2559,7 +2559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IPowerSupplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IPowerSupplyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2591,7 +2591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2623,7 +2623,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IServoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IServoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISoftwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2681,7 +2681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_ISubComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.ISubComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2713,7 +2713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2745,7 +2745,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_IVirtualStationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.IVirtualStationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2771,7 +2771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2981,7 +2981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningProcessManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3004,7 +3004,7 @@
         "description": "The Method AbortJoiningProcess is used to abort the input joining process if it is under execution.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6368",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "AbortMessage" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3015,7 +3015,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3039,7 +3039,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6369",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3067,7 +3067,7 @@
         "description": "The Method DecrementJoiningProcessCounter used to decrement the counter of the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6360",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "DecrementCount" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3078,7 +3078,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3104,7 +3104,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6361",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3132,7 +3132,7 @@
         "description": "The Method DeleteJoiningProcess is used to delete the input joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6127",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3143,7 +3143,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3163,7 +3163,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6140",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3191,7 +3191,7 @@
         "description": "The Method DeselectJoiningProcess is used to deselect any selected joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6356",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3202,7 +3202,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6357",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3230,7 +3230,7 @@
         "description": "The Method GetJoiningProcess is used to get the joining process based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3245,21 +3245,21 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6449",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcess", "SelectionName", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcess": {
               "title": "JoiningProcessDataType",
               "description": "This structure provides the base container for any joining process in a joining system.   Note: This specification defines the meta data of a JoiningProcess, and the actual content of the Joining Process is application specific.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessDataType",
               "required": [ "JoiningProcessMetaData", "JoiningProcessContent" ],
               "properties": {
                 "JoiningProcessMetaData": {
                   "title": "JoiningProcessMetaDataType",
                   "description": "This structure provides the meta data which describes the joining process.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                   "required": [ "JoiningProcessId" ],
                   "properties": {
                     "JoiningProcessId": {
@@ -3305,7 +3305,7 @@
                         "title": "EntityDataType",
                         "description": "This structure provides the identification data for a given entity in the system.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                         "required": [ "EntityId", "EntityType" ],
                         "properties": {
                           "Name": {
@@ -3378,7 +3378,7 @@
         "description": "The Method GetJoiningProcessList is used to get the list of joining process meta data available in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6348",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3389,7 +3389,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6349",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcessList", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcessList": {
@@ -3399,7 +3399,7 @@
                 "title": "JoiningProcessMetaDataType",
                 "description": "This structure provides the meta data which describes the joining process.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                 "required": [ "JoiningProcessId" ],
                 "properties": {
                   "JoiningProcessId": {
@@ -3445,7 +3445,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -3505,7 +3505,7 @@
         "description": "The Method GetJoiningProcessRevisionList is used to get the list available revisions of a specific joining process based on the joiningProcessOriginId.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6350",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3520,7 +3520,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6351",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JoiningProcessList", "Status", "StatusMessage" ],
           "properties": {
             "JoiningProcessList": {
@@ -3530,7 +3530,7 @@
                 "title": "JoiningProcessMetaDataType",
                 "description": "This structure provides the meta data which describes the joining process.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                 "required": [ "JoiningProcessId" ],
                 "properties": {
                   "JoiningProcessId": {
@@ -3576,7 +3576,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -3636,7 +3636,7 @@
         "description": "The Method GetSelectedJoiningProgram is used to get the selected joining program for a given asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6461",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3647,14 +3647,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6462",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SelectedJoiningProgram", "Status", "StatusMessage" ],
           "properties": {
             "SelectedJoiningProgram": {
               "title": "JoiningProcessMetaDataType",
               "description": "This structure provides the meta data which describes the joining process.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
               "required": [ "JoiningProcessId" ],
               "properties": {
                 "JoiningProcessId": {
@@ -3700,7 +3700,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -3759,7 +3759,7 @@
         "description": "The Method IncrementJoiningProcessCounter is used to increment the counter of the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6358",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "IncrementCount" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3770,7 +3770,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3796,7 +3796,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6359",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3824,7 +3824,7 @@
         "description": "The Method ResetJoiningProcess is used to reset/restart the sequential joining processes such as Job, etc.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6366",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3835,7 +3835,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3855,7 +3855,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3883,7 +3883,7 @@
         "description": "The Method SelectJoiningProcess is used to select the joining process based on the input arguments.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3894,7 +3894,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -3914,7 +3914,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -3942,7 +3942,7 @@
         "description": "The Method SendJoiningProcess is used to send a joining process to the joining system. It can be used to insert a joining program or joining batch or joining job or any other process applicable to a joining system. It shall overwrite the joining process if it already exists in the joining system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6340",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcess", "SelectionName" ],
           "properties": {
             "ProductInstanceUri": {
@@ -3953,14 +3953,14 @@
               "title": "JoiningProcessDataType",
               "description": "This structure provides the base container for any joining process in a joining system.   Note: This specification defines the meta data of a JoiningProcess, and the actual content of the Joining Process is application specific.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessDataType",
               "required": [ "JoiningProcessMetaData", "JoiningProcessContent" ],
               "properties": {
                 "JoiningProcessMetaData": {
                   "title": "JoiningProcessMetaDataType",
                   "description": "This structure provides the meta data which describes the joining process.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3024",
+                  "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessMetaDataType",
                   "required": [ "JoiningProcessId" ],
                   "properties": {
                     "JoiningProcessId": {
@@ -4006,7 +4006,7 @@
                         "title": "EntityDataType",
                         "description": "This structure provides the identification data for a given entity in the system.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                         "required": [ "EntityId", "EntityType" ],
                         "properties": {
                           "Name": {
@@ -4058,7 +4058,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6347",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4086,7 +4086,7 @@
         "description": "The Method SetJoiningProcessCounter is used to set the counter of a sequential joining processes (such as Job, etc.) to the given input value.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6362",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "CounterValue" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4097,7 +4097,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4123,7 +4123,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6363",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4151,7 +4151,7 @@
         "description": "The Method SetJoiningProcessMapping is used to set the mapping of the joining process in a joining system. It can be used to map a joining process to a selection name.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6352",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4162,7 +4162,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4182,7 +4182,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6353",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4210,7 +4210,7 @@
         "description": "The Method SetJoiningProcessSize is used to set the size of the batch joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6364",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "MaxCounterSize" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4221,7 +4221,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4247,7 +4247,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6365",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4275,7 +4275,7 @@
         "description": "The Method StartJoiningProcess is used to start the input joining process.   Note: It is not intended to be used in a hard real-time use case.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6374",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JoiningProcessIdentification", "AssociatedEntities" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4286,7 +4286,7 @@
               "title": "JoiningProcessIdentificationDataType",
               "description": "This structure contains the identification information of a Joining Process. It is used in set of methods defined in JoiningProcessManagementType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3029",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningProcessIdentificationDataType",
               "properties": {
                 "JoiningProcessId": {
                   "description": "It is the system-wide unique identifier of the joining process.",
@@ -4309,7 +4309,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -4345,7 +4345,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6375",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4373,7 +4373,7 @@
         "description": "The Method StartSelectedJoining is used to start the selected joining. The joining operation can be selected using SelectJoiningProcess or SelectJoint.   Note: It is not intended to be used in a hard real-time use case.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6408",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "DeselectAfterJoining" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4388,7 +4388,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6409",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4438,7 +4438,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemAssetMethodSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemAssetMethodSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4461,7 +4461,7 @@
         "description": "The Method DisconnectAsset is used to disconnect or connect the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6047",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Disconnect" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4476,7 +4476,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4504,7 +4504,7 @@
         "description": "The Method EnableAsset is used to Enable or Disable a given asset. It is mostly applicable for Tool.  The joining system can report a respective event when an asset is enabled or disabled.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Enable" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4519,7 +4519,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6046",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4547,7 +4547,7 @@
         "description": "The Method ExecuteOperation is an application specific interface to execute any generic operations supported by a joining system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "OperationType", "OperationText", "VendorName" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4572,7 +4572,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4600,7 +4600,7 @@
         "description": "The Method GetErrorInformation is used to get the error information based on the input identifier. The details returned from the joining system is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6088",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "ErrorId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4615,7 +4615,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorContent", "Status", "StatusMessage" ],
           "properties": {
             "ErrorContent": {
@@ -4647,7 +4647,7 @@
         "description": "The Method GetFeedbackFileList is used to get the list of feedback files from the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4658,7 +4658,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FeedbackFileList", "Status", "StatusMessage" ],
           "properties": {
             "FeedbackFileList": {
@@ -4693,7 +4693,7 @@
         "description": "The Method GetIdentifiers is used to get the list of identifiers available in the system which were managed by external systems.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierNames" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4711,7 +4711,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntityList", "Status", "StatusMessage" ],
           "properties": {
             "EntityList": {
@@ -4721,7 +4721,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -4778,7 +4778,7 @@
         "description": "The Method GetIOSignals is used to get the list of available signals from the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "SignalIdList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4796,7 +4796,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SignalList", "Status", "StatusMessage" ],
           "properties": {
             "SignalList": {
@@ -4806,7 +4806,7 @@
                 "title": "SignalDataType",
                 "description": "This structure contains the signal information which is used in SetIOSignals and GetIOSignals methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SignalDataType",
                 "required": [ "SignalId", "SignalValue", "SignalDescription", "SignalType" ],
                 "properties": {
                   "SignalId": {
@@ -4855,7 +4855,7 @@
         "description": "The Method RebootAsset is used to reboot an asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4866,7 +4866,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4894,7 +4894,7 @@
         "description": "The Method ResetIdentifiers is used to reset the specified identifiers.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6081",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierList", "ResetAll", "ResetLatest" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4920,7 +4920,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6085",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -4948,7 +4948,7 @@
         "description": "The Method SendFeedback is used to send any type of feedback to a given asset. The feedback can be a text input or other types of feedback supported by the asset.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "FeedbackType", "FeedbackText", "FeedbackFile" ],
           "properties": {
             "ProductInstanceUri": {
@@ -4973,7 +4973,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5001,7 +5001,7 @@
         "description": "The Method SendIdentifiers is used to send one or more identifiers to the joining system.  These identifiers can be used for selection of a joining process, etc.  These identifiers can often be part of the generated result.   The input argument to this method is an array of EntityDataType structure where every entity in the joining system can be associated to a specific type for filtering.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "EntityList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5015,7 +5015,7 @@
                 "title": "EntityDataType",
                 "description": "This structure provides the identification data for a given entity in the system.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                 "required": [ "EntityId", "EntityType" ],
                 "properties": {
                   "Name": {
@@ -5051,7 +5051,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6078",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5079,7 +5079,7 @@
         "description": "The Method SendTextIdentifiers is used to send one or more identifiers to a joining system.   These identifiers can be used for selection of a joining process, etc.  These identifiers can often be part of the generated result.   Note: The decision on which set of identifiers are used for the selection of a joining process and which set of identifiers should be part of the generated result is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6079",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "IdentifierList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5097,7 +5097,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6080",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5125,7 +5125,7 @@
         "description": "The Method SetCalibration is used to set the calibration information of a given asset.   It is intended to set the basic calibration information and does not cover the certification process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "CalibrationData" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5136,7 +5136,7 @@
               "title": "CalibrationDataType",
               "description": "This structure contains the Calibration information. It is used as an input argument in SetCalibration method.  Note: The input data sent in SetCalibration shall be updated in the respective parameters of the asset under Maintenance/Calibration.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.CalibrationDataType",
               "required": [ "LastCalibration" ],
               "properties": {
                 "LastCalibration": {
@@ -5173,7 +5173,7 @@
                   "title": "EUInformation",
                   "description": "It defines the engineering unit of the value.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -5198,7 +5198,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5226,7 +5226,7 @@
         "description": "The Method SetIOSignals is used to set a list of IO signals of the asset. The type of operations mapped to each signal is application specific.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "SignalList" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5240,7 +5240,7 @@
                 "title": "SignalDataType",
                 "description": "This structure contains the signal information which is used in SetIOSignals and GetIOSignals methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.SignalDataType",
                 "required": [ "SignalId", "SignalValue", "SignalDescription", "SignalType" ],
                 "properties": {
                   "SignalId": {
@@ -5268,7 +5268,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SignalStatusList", "Status", "StatusMessage" ],
           "properties": {
             "SignalStatusList": {
@@ -5305,7 +5305,7 @@
         "description": "The Method SetOfflineTimer is used to set the offline timer for the asset to determine how long the asset can perform the joining operations in an offline mode.   Note: If an asset performs the joining operation in offline mode after setting the offline timer, the corresponding results generated shall have the IsGeneratedOffline flag set to TRUE.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "OfflineTimer" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5321,7 +5321,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5349,7 +5349,7 @@
         "description": "The Method SetTime is used to set the time of the asset manually. It is recommended to be used only when an asset does not have automated time synchronization.  The joining system can report a respective event when the time is configured manually using this method.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6406",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "InputTime" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5365,7 +5365,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6407",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5415,7 +5415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5454,7 +5454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JointManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5477,7 +5477,7 @@
         "description": "The Method DeleteJoint is used to delete the joint based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5496,7 +5496,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6151",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5524,7 +5524,7 @@
         "description": "The Method DeleteJointComponent is used to delete the joint component based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6162",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponentId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5539,7 +5539,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6163",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5567,7 +5567,7 @@
         "description": "The Method DeleteJointDesign is used to delete the joint design based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6153",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesignId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5582,7 +5582,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -5610,7 +5610,7 @@
         "description": "The Method GetJoint is used to get the joint based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6310",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5625,14 +5625,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6311",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Joint", "Status", "StatusMessage" ],
           "properties": {
             "Joint": {
               "title": "JointDataType",
               "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
               "required": [ "JointId" ],
               "properties": {
                 "JointId": {
@@ -5686,7 +5686,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -5749,7 +5749,7 @@
         "description": "The Method GetJointComponent is used to get the joint component based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6314",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponentId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5764,14 +5764,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6315",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointComponent", "Status", "StatusMessage" ],
           "properties": {
             "JointComponent": {
               "title": "JointComponentDataType",
               "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
               "required": [ "JointComponentId" ],
               "properties": {
                 "JointComponentId": {
@@ -5825,7 +5825,7 @@
         "description": "The Method GetJointComponentList is used to get the list of available joint components in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5836,7 +5836,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointComponentList", "Status", "StatusMessage" ],
           "properties": {
             "JointComponentList": {
@@ -5846,7 +5846,7 @@
                 "title": "JointComponentDataType",
                 "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
                 "required": [ "JointComponentId" ],
                 "properties": {
                   "JointComponentId": {
@@ -5901,7 +5901,7 @@
         "description": "The Method GetJointDesign is used to get the joint design based on the input identifier.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6312",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesignId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -5916,14 +5916,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6313",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointDesign", "Status", "StatusMessage" ],
           "properties": {
             "JointDesign": {
               "title": "JointDesignDataType",
               "description": "This structure provides the design information of a given joint.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
               "required": [ "JointDesignId" ],
               "properties": {
                 "JointDesignId": {
@@ -5945,7 +5945,7 @@
                     "title": "DesignValueDataType",
                     "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                     "properties": {
                       "PhysicalQuantity": {
                         "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -5965,7 +5965,7 @@
                         "title": "EUInformation",
                         "description": "It is the engineering unit of the design value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6021,7 +6021,7 @@
         "description": "The Method GetJointDesignList is used to get the list of available joint designs in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6304",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6032,7 +6032,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointDesignList", "Status", "StatusMessage" ],
           "properties": {
             "JointDesignList": {
@@ -6042,7 +6042,7 @@
                 "title": "JointDesignDataType",
                 "description": "This structure provides the design information of a given joint.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
                 "required": [ "JointDesignId" ],
                 "properties": {
                   "JointDesignId": {
@@ -6064,7 +6064,7 @@
                       "title": "DesignValueDataType",
                       "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                       "properties": {
                         "PhysicalQuantity": {
                           "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -6084,7 +6084,7 @@
                           "title": "EUInformation",
                           "description": "It is the engineering unit of the design value.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -6141,7 +6141,7 @@
         "description": "The Method GetJointList is used to get the list of available joints in the system.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6235",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6152,7 +6152,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6303",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointList", "Status", "StatusMessage" ],
           "properties": {
             "JointList": {
@@ -6162,7 +6162,7 @@
                 "title": "JointDataType",
                 "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
                 "required": [ "JointId" ],
                 "properties": {
                   "JointId": {
@@ -6216,7 +6216,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -6280,7 +6280,7 @@
         "description": "The Method GetJointRevisionList is used to get the list available revisions of a specific joint based on the JointOriginId.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6308",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6295,7 +6295,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6309",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JointList", "Status", "StatusMessage" ],
           "properties": {
             "JointList": {
@@ -6305,7 +6305,7 @@
                 "title": "JointDataType",
                 "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+                "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
                 "required": [ "JointId" ],
                 "properties": {
                   "JointId": {
@@ -6359,7 +6359,7 @@
                       "title": "EntityDataType",
                       "description": "This structure provides the identification data for a given entity in the system.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                       "required": [ "EntityId", "EntityType" ],
                       "properties": {
                         "Name": {
@@ -6423,7 +6423,7 @@
         "description": "The Method SelectJoint is used to select the joint and the associated joining process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6229",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointId", "JointOriginId" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6442,7 +6442,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6230",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6470,7 +6470,7 @@
         "description": "The Method SendJoint is used to send a joint to a joining system. If the input joint already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6183",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Joint" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6481,7 +6481,7 @@
               "title": "JointDataType",
               "description": "This structure provides the joint information. Joint is the physical outcome of the joining operation which determines the properties of the point where multiple parts are assembled.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3028",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDataType",
               "required": [ "JointId" ],
               "properties": {
                 "JointId": {
@@ -6535,7 +6535,7 @@
                     "title": "EntityDataType",
                     "description": "This structure provides the identification data for a given entity in the system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.EntityDataType",
                     "required": [ "EntityId", "EntityType" ],
                     "properties": {
                       "Name": {
@@ -6577,7 +6577,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6605,7 +6605,7 @@
         "description": "The Method SendJointComponent is used to send a joint component to a joining system. If the input joint component already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointComponent" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6616,7 +6616,7 @@
               "title": "JointComponentDataType",
               "description": "This structure is the base container for any joint component such as Bolt, Rivet, Gasket, Glue string, etc.   Note: The concrete definition of joint component is not defined in this version of the specification.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointComponentDataType",
               "required": [ "JointComponentId" ],
               "properties": {
                 "JointComponentId": {
@@ -6649,7 +6649,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6228",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6677,7 +6677,7 @@
         "description": "The Method SendJointDesign is used to send a joint design to a joining system. If the input joint design already exists in the system, it shall be overwritten.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "JointDesign" ],
           "properties": {
             "ProductInstanceUri": {
@@ -6688,7 +6688,7 @@
               "title": "JointDesignDataType",
               "description": "This structure provides the design information of a given joint.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3025",
+              "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JointDesignDataType",
               "required": [ "JointDesignId" ],
               "properties": {
                 "JointDesignId": {
@@ -6710,7 +6710,7 @@
                     "title": "DesignValueDataType",
                     "description": "This structure provides the design value for a given physical quantity. It is used in JointDesignDataType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.DesignValueDataType",
                     "properties": {
                       "PhysicalQuantity": {
                         "description": "It is the physical quantity of the value. Example: Force, Angle, etc.",
@@ -6730,7 +6730,7 @@
                         "title": "EUInformation",
                         "description": "It is the engineering unit of the design value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6765,7 +6765,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status", "StatusMessage" ],
           "properties": {
             "Status": {
@@ -6815,7 +6815,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Base_JoiningSystemResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Base.JoiningSystemResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6836,7 +6836,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IJT/Base/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6459",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromSequenceNumber", "ToSequenceNumber", "FromTime", "ToTime", "RequestedMinimumDurationBetweenResults" ],
           "properties": {
             "FromSequenceNumber": {
@@ -6870,7 +6870,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6460",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedMinimumDurationBetweenResults", "Status", "StatusMessage" ],
           "properties": {
             "RevisedMinimumDurationBetweenResults": {
@@ -6902,7 +6902,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/IJT/Base/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6470",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaxResults", "RequestedMinimumDurationBetweenResults" ],
           "properties": {
             "MaxResults": {
@@ -6920,7 +6920,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Base/;i=6471",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedMinimumDurationBetweenResults", "UnacknowledgedResultCount", "Status", "StatusMessage" ],
           "properties": {
             "RevisedMinimumDurationBetweenResults": {

--- a/wot-codegen/opc-output-simple/IJT.Tightening.TM.json
+++ b/wot-codegen/opc-output-simple/IJT.Tightening.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IJT_Tightening_ITighteningToolParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IJT/Tightening/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IJT.Tightening.ITighteningToolParametersType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/IOLink.TM.json
+++ b/wot-codegen/opc-output-simple/IOLink.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -197,7 +197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -224,7 +224,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -278,7 +278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_DeviceVariantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.DeviceVariantType",
     "links": [
       {
         "rel": "tm:extends",
@@ -304,7 +304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -330,7 +330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkIODDDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkIODDDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -356,7 +356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkMasterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkMasterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -383,7 +383,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "IOLink_IOLinkPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/IOLink/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.IOLink.IOLinkPortType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/ISA95.TM.json
+++ b/wot-codegen/opc-output-simple/ISA95.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95ClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4957",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95ClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95ObjectType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4958",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95ObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_ISA95TestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4959",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.ISA95TestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_QualificationTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4977",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.QualificationTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PersonnelClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=4996",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PersonnelClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -145,7 +145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PersonType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5131",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PersonType",
     "dov:isComposite": true,
     "links": [
       {
@@ -186,7 +186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetCapabilityTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5057",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetCapabilityTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -212,7 +212,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5078",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -245,7 +245,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_PhysicalAssetType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5085",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.PhysicalAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -331,7 +331,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentCapabilityTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5015",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentCapabilityTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -357,7 +357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5034",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -390,7 +390,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_EquipmentType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5040",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -483,7 +483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialTestSpecificationType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5172",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialTestSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -509,7 +509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialClassType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5209",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -549,7 +549,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialDefinitionType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5219",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialDefinitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -589,7 +589,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialLotType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5232",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialLotType",
     "links": [
       {
         "rel": "tm:extends",
@@ -636,7 +636,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "ISA95_MaterialSublotType",
-    "dov:typeRef": "nsu=http://www.OPCFoundation.org/UA/2013/01/ISA95;i=5259",
+    "dov:typeRef": "org.opcfoundation.www.UA.2013.01.ISA95.MaterialSublotType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/LADS.TM.json
+++ b/wot-codegen/opc-output-simple/LADS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSComponentsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSOperationCountersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSOperationCountersType",
     "dov:isComposite": true,
     "links": [
       {
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -113,7 +113,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -139,7 +139,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramTemplateSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramTemplateSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -165,7 +165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramTemplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramTemplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -191,7 +191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SupportedPropertiesSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SupportedPropertiesSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -217,7 +217,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SupportedPropertyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SupportedPropertyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -243,7 +243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultFileSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultFileSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -269,7 +269,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -295,7 +295,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -321,7 +321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ResultType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ResultType",
     "links": [
       {
         "rel": "tm:extends",
@@ -347,7 +347,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_CoverStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.CoverStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -373,7 +373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSDeviceStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSDeviceStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -399,7 +399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -425,7 +425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_RunningStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.RunningStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -451,7 +451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MaintenanceSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MaintenanceSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -477,7 +477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MaintenanceTaskType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MaintenanceTaskType",
     "dov:isEvent": true,
     "links": [
       {
@@ -504,7 +504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -557,7 +557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -609,7 +609,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_BaseControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.BaseControlFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -635,7 +635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -662,7 +662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithTotalizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithTotalizerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -689,7 +689,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_DiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.DiscreteControlFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -715,7 +715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiStateDiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiStateDiscreteControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -742,7 +742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TwoStateDiscreteControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TwoStateDiscreteControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -769,7 +769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_BaseSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.BaseSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -795,7 +795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogScalarSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogScalarSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -822,7 +822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_DiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.DiscreteSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_CoverFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.CoverFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -875,7 +875,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ProgramManagerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ProgramManagerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -901,7 +901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TimerControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TimerControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -928,7 +928,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogScalarSensorFunctionWithCompensationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogScalarSensorFunctionWithCompensationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -955,7 +955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerTuningParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerTuningParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -981,7 +981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_PidControllerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.PidControllerParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1008,7 +1008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_TwoStateDiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.TwoStateDiscreteSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1035,7 +1035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiStateDiscreteSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiStateDiscreteSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1062,7 +1062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_FunctionalUnitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.FunctionalUnitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1088,7 +1088,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControlFunctionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControlFunctionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1114,7 +1114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiModeAnalogControlFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiModeAnalogControlFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1141,7 +1141,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1167,7 +1167,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_ControllerParameterSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.ControllerParameterSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1193,7 +1193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithComposedTargetValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithComposedTargetValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1220,7 +1220,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_MultiSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.MultiSensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1247,7 +1247,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogControlFunctionWithRelativeTargetValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogControlFunctionWithRelativeTargetValueType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1274,7 +1274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogArraySensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogArraySensorFunctionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1301,7 +1301,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_SetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.SetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1327,7 +1327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_VariableSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.VariableSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_AnalogSensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.AnalogSensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1379,7 +1379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LADS_LADSOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LADS/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.LADS.LADSOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/LaserSystems.TM.json
+++ b/wot-codegen/opc-output-simple/LaserSystems.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ActivityDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ActivityDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -146,7 +146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ConditionDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ConditionDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -346,7 +346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_ConsumptionDataMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.ConsumptionDataMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -446,7 +446,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemOperationCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -527,7 +527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -583,7 +583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -615,7 +615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -653,7 +653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -704,7 +704,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemMaintenancePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemMaintenancePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -780,7 +780,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemUtilityChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemUtilityChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -856,7 +856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_RecipeSettingsAndOverviewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.RecipeSettingsAndOverviewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1023,7 +1023,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "LaserSystems_LaserSystemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/LaserSystems/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.LaserSystems.LaserSystemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/MDIS.TM.json
+++ b/wot-codegen/opc-output-simple/MDIS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=194",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISBaseObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35,7 +35,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=196",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -213,7 +213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISAggregateObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1315",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISAggregateObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -329,7 +329,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISChokeObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISChokeObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -340,7 +340,7 @@
     "schemaDefinitions": {
       "ChokeMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "const": {
           "Moving": 1,
           "Stopped": 2
@@ -358,7 +358,7 @@
       },
       "SetCalculatedPositionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
         "const": {
           "Initial": 0,
           "Inprogress": 1,
@@ -386,7 +386,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -409,7 +409,7 @@
       },
       "ChokeCommandEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=701",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeCommandEnum",
         "const": {
           "Close": 1,
           "Open": 2
@@ -453,7 +453,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Position": {
@@ -469,7 +469,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -488,7 +488,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -511,13 +511,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1158",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "Steps", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Direction": {
               "title": "ChokeCommandEnum",
               "description": "The direction for the valve, true is opening a valve, false if closing the valve",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=701",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeCommandEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -535,7 +535,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -605,7 +605,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ChokeMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -659,7 +659,7 @@
       "SetCalculatedPositionStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "SetCalculatedPositionEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -772,7 +772,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ChokeMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -830,7 +830,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "SetCalculatedPositionEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1287",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.SetCalculatedPositionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -854,7 +854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISCIMVObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15114",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISCIMVObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -877,7 +877,7 @@
     "schemaDefinitions": {
       "CIMVMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
         "const": {
           "MoveClose": 1,
           "MoveOpen": 2,
@@ -900,7 +900,7 @@
       },
       "CIMVOperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
         "const": {
           "Position": 1,
           "Flow": 2,
@@ -923,7 +923,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -972,7 +972,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15167",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Initial" ],
           "properties": {
             "Initial": {
@@ -995,7 +995,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FlowRate", "SEM", "ShutdownRequest" ],
           "properties": {
             "FlowRate": {
@@ -1007,7 +1007,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1030,13 +1030,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "Delta", "SEM", "ShutdownRequest" ],
           "properties": {
             "Direction": {
               "title": "CIMVMoveEnum",
               "description": "Direction to move – Open or Close",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1050,7 +1050,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1073,13 +1073,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode", "SEM", "ShutdownRequest" ],
           "properties": {
             "Mode": {
               "title": "CIMVOperationModeEnum",
               "description": "Enumeration indicating the requested operation mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1087,7 +1087,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1110,7 +1110,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15173",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "SEM", "ShutdownRequest" ],
           "properties": {
             "Position": {
@@ -1122,7 +1122,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1214,7 +1214,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CIMVMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1266,7 +1266,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CIMVOperationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1428,7 +1428,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CIMVMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15007",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1484,7 +1484,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CIMVOperationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15102",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CIMVOperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1583,7 +1583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=889",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1646,7 +1646,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15015",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1657,7 +1657,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -1716,13 +1716,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15029",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1742,7 +1742,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1785,7 +1785,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1835,7 +1835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDigitalOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1230",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDigitalOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1850,7 +1850,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State" ],
           "properties": {
             "State": {
@@ -1882,7 +1882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1214",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1949,7 +1949,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15032",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1960,7 +1960,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -2019,13 +2019,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15546",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2045,7 +2045,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2092,7 +2092,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2146,7 +2146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISDiscreteOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1242",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISDiscreteOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2161,7 +2161,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1253",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State" ],
           "properties": {
             "State": {
@@ -2195,7 +2195,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISElectricChokeObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15076",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISElectricChokeObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2206,7 +2206,7 @@
     "schemaDefinitions": {
       "ChokeMoveEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "const": {
           "Moving": 1,
           "Stopped": 2
@@ -2224,7 +2224,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -2273,7 +2273,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15093",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Position", "OverrideInterlocks", "SEM" ],
           "properties": {
             "Position": {
@@ -2289,7 +2289,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2359,7 +2359,7 @@
       "Moving": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ChokeMoveEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2456,7 +2456,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ChokeMoveEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=602",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ChokeMoveEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2506,7 +2506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=971",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2754,7 +2754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentArbitrationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15547",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentArbitrationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2765,7 +2765,7 @@
     "schemaDefinitions": {
       "ArbitrationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "const": {
           "Average": 1,
           "DefaultA": 2,
@@ -2829,13 +2829,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15075",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArbitrationMode" ],
           "properties": {
             "ArbitrationMode": {
               "title": "ArbitrationModeEnum",
               "description": "ArbitrationMode enumeration value Variable, that defines the new arbitration mode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2855,7 +2855,7 @@
       "ArbitrationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ArbitrationModeEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2921,7 +2921,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ArbitrationModeEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ArbitrationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2975,7 +2975,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInstrumentOutObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1254",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInstrumentOutObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2990,7 +2990,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1278",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -3024,7 +3024,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISMotorObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15190",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISMotorObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3035,7 +3035,7 @@
     "schemaDefinitions": {
       "MotorOperationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
         "const": {
           "Off": 1,
           "Auto": 2,
@@ -3074,13 +3074,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15210",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "MotorOperationEnum",
               "description": "Mode to operate in (i.e. Auto or Manual)",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3099,7 +3099,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15206",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OverrideInterlocks" ],
           "properties": {
             "OverrideInterlocks": {
@@ -3120,7 +3120,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15208",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OverrideInterlocks" ],
           "properties": {
             "OverrideInterlocks": {
@@ -3190,7 +3190,7 @@
       "Operation": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "MotorOperationEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3273,7 +3273,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "MotorOperationEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15013",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.MotorOperationEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3310,7 +3310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISValveObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=794",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISValveObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3328,7 +3328,7 @@
     "schemaDefinitions": {
       "CommandEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
         "const": {
           "Close": 1,
           "Open": 2,
@@ -3351,7 +3351,7 @@
       },
       "ValvePositionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
         "const": {
           "Closed": 1,
           "Open": 2,
@@ -3379,7 +3379,7 @@
       },
       "SignatureStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
         "const": {
           "NotAvailable": 1,
           "Completed": 2,
@@ -3402,7 +3402,7 @@
       },
       "SEMEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
         "const": {
           "SEM_A": 1,
           "SEM_B": 2,
@@ -3441,13 +3441,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Direction", "OverrideInterlock", "SEM", "Signature", "ShutdownRequest" ],
           "properties": {
             "Direction": {
               "title": "CommandEnum",
               "description": "The enumeration indicates whether the command is to open the valve or to close the valve",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3459,7 +3459,7 @@
             "SEM": {
               "title": "SEMEnum",
               "description": "The selection of which SEM to send the command to",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=5",
+              "dov:typeRef": "org.opcfoundation.UA.MDIS.SEMEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3536,7 +3536,7 @@
       "LastCommand": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "CommandEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3589,7 +3589,7 @@
       "Position": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "ValvePositionEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3605,7 +3605,7 @@
       "SignatureRequestStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "SignatureStatusEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3663,7 +3663,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "CommandEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=3",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.CommandEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3706,7 +3706,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "ValvePositionEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=703",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.ValvePositionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3723,7 +3723,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "data": {
           "title": "SignatureStatusEnum",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=699",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.SignatureStatusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3747,7 +3747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISCounterObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15098",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISCounterObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3774,7 +3774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=15101",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Initial" ],
           "properties": {
             "Initial": {
@@ -3831,7 +3831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISInformationObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1471",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISInformationObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3872,7 +3872,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "title": "MDISVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1289",
+        "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISVersionDataType",
         "required": [ "MajorVersion", "MinorVersion", "Build" ],
         "properties": {
           "MajorVersion": {
@@ -3907,7 +3907,7 @@
         "data": {
           "title": "MDISVersionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1289",
+          "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISVersionDataType",
           "required": [ "MajorVersion", "MinorVersion", "Build" ],
           "properties": {
             "MajorVersion": {
@@ -3946,7 +3946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MDIS_MDISTimeSyncObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1468",
+    "dov:typeRef": "org.opcfoundation.UA.MDIS.MDISTimeSyncObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3961,7 +3961,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MDIS",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MDIS;i=1470",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetTime" ],
           "properties": {
             "TargetTime": {

--- a/wot-codegen/opc-output-simple/MTConnect.v2.TM.json
+++ b/wot-codegen/opc-output-simple/MTConnect.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2059",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -124,7 +124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2021",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -251,7 +251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2015",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -337,7 +337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTCompositionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2067",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCompositionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -423,7 +423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2044",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -449,7 +449,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTSensorConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2046",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSensorConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -537,7 +537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDescriptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2053",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDescriptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -622,7 +622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2074",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -649,7 +649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AuxiliariesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2076",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AuxiliariesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -676,7 +676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BarFeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2082",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BarFeederType",
     "dov:isComposite": true,
     "links": [
       {
@@ -703,7 +703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EnvironmentalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2102",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EnvironmentalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2112",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoaderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -757,7 +757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2134",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -784,7 +784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolingDeliveryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2140",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolingDeliveryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -811,7 +811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WasteDisposalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2142",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WasteDisposalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -838,7 +838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2078",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -865,7 +865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2110",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -892,7 +892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2132",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -919,7 +919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2086",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckType",
     "dov:isComposite": true,
     "links": [
       {
@@ -946,7 +946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2088",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -973,7 +973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2120",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1000,7 +1000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2096",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1027,7 +1027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_InterfacesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2108",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.InterfacesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1054,7 +1054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BarFeederInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2080",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BarFeederInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1081,7 +1081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2084",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1108,7 +1108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2094",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1135,7 +1135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialHandlerInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2116",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialHandlerInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1162,7 +1162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResourcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2130",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResourcesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1189,7 +1189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2118",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1216,7 +1216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StockType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2136",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StockType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1243,7 +1243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PersonnelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2122",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PersonnelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1270,7 +1270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SystemsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2138",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SystemsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1297,7 +1297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CoolantType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2090",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CoolantType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1324,7 +1324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DielectricType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2092",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DielectricType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1351,7 +1351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ElectricType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2098",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ElectricType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1378,7 +1378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EnclosureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2100",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EnclosureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1405,7 +1405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2104",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FeederType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1432,7 +1432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HydraulicType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2106",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HydraulicType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1459,7 +1459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LubricationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2114",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LubricationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1486,7 +1486,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PneumaticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2124",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PneumaticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1513,7 +1513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessPowerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2126",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessPowerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1540,7 +1540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProtectiveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2128",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProtectiveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1567,7 +1567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2629",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1593,7 +1593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConstraintType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2647",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConstraintType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1687,7 +1687,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2631",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1713,7 +1713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTMessageEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2656",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTMessageEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1759,7 +1759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=4326",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1771,7 +1771,7 @@
     "schemaDefinitions": {
       "MTSeverityDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2669",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSeverityDataType",
         "const": {
           "FAULT": 0,
           "NORMAL": 1,
@@ -1795,7 +1795,7 @@
       },
       "QualifierDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2668",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.QualifierDataType",
         "const": {
           "HIGH": 0,
           "LOW": 1
@@ -1853,7 +1853,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTSeverityDataType",
         "description": "        The condition type is derived from the UA \\uamodel{ContitionType}. When        the \\mtmodel{Warning} or \\mtmodel{Fault} state occurs, an        \\mtuatype{MTConditionEventType} \\uamodel{Event} is created with the        \\mtmodel{ActiveState} set to \\uamodel{True} and \\uamodel{Retain} set to        \\uamodel{True}. The severity is used to represent the MTConnect condition        states of Warning and Fault with the values of 500 and 1000 respectively.        A new \\uamodel{NodeId} will be created for every unique instance of the        MTConnect \\mtmodel{Condition} reported. When the \\mtmodel{Condition} goes        back to Normal, the \\mtmodel{ActiveState} is set to \\uamodel{False} and        \\uamodel{Retain} is also set to \\uamodel{False} with the \\uamodel{NodeId}        of the associated \\mtmodel{Condition}. If multiple MTConnect        \\mtmodel{Condition}s have been cleared at the same time, all currently        active \\mtuatype{MTConditionEventType} \\uamodel{Event}s will need to        deactivated. The \\mtuatype{MTConditionEventType} must set the        \\uamodel{BaseEvent} \\uamodel{SourceNode} to the related        \\mtuatype{MTConditionType} that represents the meta-data for this        Condition. The \\mtuatype{MTConditionEventType} will never be instantiated        in the \\uaterm{AddressSpace} as an \\uamodel{Object}.       ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2669",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSeverityDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1922,7 +1922,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "QualifierDataType",
         "description": "        The condition type is derived from the UA \\uamodel{ContitionType}. When        the \\mtmodel{Warning} or \\mtmodel{Fault} state occurs, an        \\mtuatype{MTConditionEventType} \\uamodel{Event} is created with the        \\mtmodel{ActiveState} set to \\uamodel{True} and \\uamodel{Retain} set to        \\uamodel{True}. The severity is used to represent the MTConnect condition        states of Warning and Fault with the values of 500 and 1000 respectively.        A new \\uamodel{NodeId} will be created for every unique instance of the        MTConnect \\mtmodel{Condition} reported. When the \\mtmodel{Condition} goes        back to Normal, the \\mtmodel{ActiveState} is set to \\uamodel{False} and        \\uamodel{Retain} is also set to \\uamodel{False} with the \\uamodel{NodeId}        of the associated \\mtmodel{Condition}. If multiple MTConnect        \\mtmodel{Condition}s have been cleared at the same time, all currently        active \\mtuatype{MTConditionEventType} \\uamodel{Event}s will need to        deactivated. The \\mtuatype{MTConditionEventType} must set the        \\uamodel{BaseEvent} \\uamodel{SourceNode} to the related        \\mtuatype{MTConditionType} that represents the meta-data for this        Condition. The \\mtuatype{MTConditionEventType} will never be instantiated        in the \\uaterm{AddressSpace} as an \\uamodel{Object}.       ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2668",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.QualifierDataType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1948,7 +1948,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2660",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTConditionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1966,7 +1966,7 @@
     "schemaDefinitions": {
       "MTCategoryType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2634",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCategoryType",
         "const": {
           "EVENT": 0,
           "CONDITION": 1,
@@ -1990,7 +1990,7 @@
       },
       "MTRepresentationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2633",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTRepresentationType",
         "const": {
           "DISCRETE": 0,
           "TIME_SERIES": 1,
@@ -2027,7 +2027,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTCategoryType",
         "description": "        The data item mixin will inject the properties and the methods into the        related classes. This facility is similar to the Ruby module mixin or the        Scala traits. data entity describing a piece of information reported about        a piece of equipment.      ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2634",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTCategoryType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2098,7 +2098,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MTConnect/v2/",
         "title": "MTRepresentationType",
         "description": "        The data item mixin will inject the properties and the methods into the        related classes. This facility is similar to the Ruby module mixin or the        Scala traits. data entity describing a piece of information reported about        a piece of equipment.      ",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2633",
+        "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTRepresentationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2165,7 +2165,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDataItemClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2425",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDataItemClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2191,7 +2191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTMessageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2427",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTMessageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2218,7 +2218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTSampleClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2345",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTSampleClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2244,7 +2244,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AccelerationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2265",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AccelerationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2271,7 +2271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AccumulatedTimeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2267",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AccumulatedTimeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2298,7 +2298,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AmperageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2273",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AmperageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2325,7 +2325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngleClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2275",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngleClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2352,7 +2352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngularAccelerationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2269",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngularAccelerationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2379,7 +2379,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AngularVelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2271",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AngularVelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2406,7 +2406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisFeedrateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2277",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisFeedrateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2433,7 +2433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ClockTimeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2279",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ClockTimeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2460,7 +2460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ConcentrationClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2281",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ConcentrationClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2487,7 +2487,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ConductivityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2283",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ConductivityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2514,7 +2514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DisplacementClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2285",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DisplacementClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2541,7 +2541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ElectricalEnergyClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2287",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ElectricalEnergyClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2568,7 +2568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EquipmentTimerClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2289",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EquipmentTimerClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2595,7 +2595,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FillLevelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2291",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FillLevelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2622,7 +2622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FlowClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2293",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FlowClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2649,7 +2649,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FrequencyClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2295",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FrequencyClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2676,7 +2676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LengthClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2297",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LengthClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2703,7 +2703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearForceClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearForceClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2730,7 +2730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2263",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2757,7 +2757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MassClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2301",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MassClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2784,7 +2784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathFeedrateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2303",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathFeedrateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2811,7 +2811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathPositionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2305",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathPositionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2838,7 +2838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PHClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PHClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2865,7 +2865,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PositionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PositionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2892,7 +2892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PowerFactorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PowerFactorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2919,7 +2919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PressureClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2313",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PressureClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2946,7 +2946,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessTimerClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2315",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessTimerClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2973,7 +2973,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResistenceClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2317",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResistenceClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3000,7 +3000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryVelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2319",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryVelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3027,7 +3027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SoundLevelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2321",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SoundLevelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3054,7 +3054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StrainClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2323",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StrainClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3081,7 +3081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TemperatureClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2325",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TemperatureClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3108,7 +3108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TensionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2327",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TensionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3135,7 +3135,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TiltClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2329",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TiltClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3162,7 +3162,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TorqueClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2331",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TorqueClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3189,7 +3189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VelocityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2335",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VelocityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3216,7 +3216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ViscosityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2339",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ViscosityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3243,7 +3243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2341",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3270,7 +3270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltAmpereClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2333",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltAmpereClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3297,7 +3297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VoltAmpereReactiveClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2337",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VoltAmpereReactiveClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3324,7 +3324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WattageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2343",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WattageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3351,7 +3351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTControlledVocabEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2144",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTControlledVocabEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3377,7 +3377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2146",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3426,7 +3426,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AvailabilityClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2149",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AvailabilityClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3475,7 +3475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisCouplingClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2152",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisCouplingClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3524,7 +3524,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2155",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3573,7 +3573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2158",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3622,7 +3622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2161",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3671,7 +3671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ChuckStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2164",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ChuckStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3720,7 +3720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CloseChuckClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2256",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CloseChuckClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3769,7 +3769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CloseDoorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2250",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CloseDoorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3818,7 +3818,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CompositionStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2173",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CompositionStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3867,7 +3867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2167",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3916,7 +3916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControllerModeOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2176",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControllerModeOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3965,7 +3965,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DirectionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2179",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DirectionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4014,7 +4014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DoorStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2182",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DoorStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4063,7 +4063,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EmergencyStopClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2185",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EmergencyStopClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4112,7 +4112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EndOfBarClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2188",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EndOfBarClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4161,7 +4161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_EquipmentModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2191",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.EquipmentModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4210,7 +4210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ExecutionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2170",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ExecutionClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4259,7 +4259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FunctionalModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2194",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FunctionalModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4308,7 +4308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_InterfaceStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2227",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.InterfaceStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4357,7 +4357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialChangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2235",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialChangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4406,7 +4406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialFeedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2231",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialFeedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4455,7 +4455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialLoadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2241",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialLoadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4504,7 +4504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialRetractClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2238",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialRetractClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4553,7 +4553,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialUnloadClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2244",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialUnloadClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4602,7 +4602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OpenChuckClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2253",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OpenChuckClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4651,7 +4651,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OpenDoorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2247",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OpenDoorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4700,7 +4700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartChangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2259",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartChangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4749,7 +4749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2215",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4798,7 +4798,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PowerStateClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2218",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PowerStateClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4847,7 +4847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramEditClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2221",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramEditClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4896,7 +4896,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryModeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2224",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryModeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4945,7 +4945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SpindleInterlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2212",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SpindleInterlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4994,7 +4994,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTNumericEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2359",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTNumericEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5020,7 +5020,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AxisFeedrateOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2347",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AxisFeedrateOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5047,7 +5047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BlockCountClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2349",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BlockCountClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5074,7 +5074,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HardnessClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2351",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HardnessClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5101,7 +5101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2353",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5128,7 +5128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartCountClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2355",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartCountClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5155,7 +5155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PathFeedrateOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=3628",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PathFeedrateOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5182,7 +5182,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotaryVelocityOverrideClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2357",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotaryVelocityOverrideClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5209,7 +5209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTStringEventClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2361",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTStringEventClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5235,7 +5235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AssetChangedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2405",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AssetChangedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5262,7 +5262,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AssetRemovedClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2407",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AssetRemovedClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5289,7 +5289,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BlockClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2363",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BlockClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5316,7 +5316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CoupledAxesClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2365",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CoupledAxesClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5343,7 +5343,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2409",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5370,7 +5370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineLabelClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2367",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineLabelClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5397,7 +5397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaterialClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2369",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaterialClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5424,7 +5424,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MessageClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2403",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MessageClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5451,7 +5451,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatorIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2371",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatorIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5478,7 +5478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PalletIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2373",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PalletIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5505,7 +5505,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2375",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5532,7 +5532,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PartNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2377",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PartNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5559,7 +5559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2379",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5586,7 +5586,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramCommentClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2385",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramCommentClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5613,7 +5613,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramEditNameClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2381",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramEditNameClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5640,7 +5640,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgramHeaderClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2383",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgramHeaderClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5667,7 +5667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SerialNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2387",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SerialNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5694,7 +5694,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolAssetIdClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2389",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolAssetIdClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5721,7 +5721,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolNumberClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2391",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolNumberClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5748,7 +5748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolOffsetClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2393",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolOffsetClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5775,7 +5775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_UserClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2395",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.UserClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5802,7 +5802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WireClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2397",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WireClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5829,7 +5829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkholdingClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2399",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkholdingClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5856,7 +5856,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkOffsetClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2401",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkOffsetClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5883,7 +5883,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActuatorClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2411",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActuatorClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5910,7 +5910,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CommunicationsClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2413",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CommunicationsClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5937,7 +5937,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DataRangeClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2415",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DataRangeClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5964,7 +5964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_HardwareClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2419",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.HardwareClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5991,7 +5991,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LogicProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2417",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LogicProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6018,7 +6018,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MotionProgramClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2421",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MotionProgramClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6045,7 +6045,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SystemClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2423",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SystemClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6072,7 +6072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MTDataItemSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2476",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MTDataItemSubClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6098,7 +6098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AbsoluteSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2478",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AbsoluteSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6125,7 +6125,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActionSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2482",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActionSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6152,7 +6152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ActualSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2480",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ActualSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6179,7 +6179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AllSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2484",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AllSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6206,7 +6206,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AlternatingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2486",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AlternatingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6233,7 +6233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2488",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6260,7 +6260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_AuxiliarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2490",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.AuxiliarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6287,7 +6287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BadSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2492",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BadSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6314,7 +6314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BrinellSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2494",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BrinellSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6341,7 +6341,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_BScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2496",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.BScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6368,7 +6368,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CommandedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2498",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CommandedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6395,7 +6395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ControlSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2502",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ControlSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6422,7 +6422,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_CScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2504",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.CScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6449,7 +6449,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DelaySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2506",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DelaySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6476,7 +6476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DirectSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2508",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DirectSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6503,7 +6503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DryRunSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2510",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DryRunSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6530,7 +6530,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_DScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2512",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.DScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6557,7 +6557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_FixtureSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2514",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.FixtureSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6584,7 +6584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_GoodSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2500",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.GoodSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6611,7 +6611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_IncrementalSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2516",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.IncrementalSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6638,7 +6638,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_JobSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2518",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.JobSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6665,7 +6665,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_KineticSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2520",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.KineticSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6692,7 +6692,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LateralSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2522",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LateralSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6719,7 +6719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LeebSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2524",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LeebSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6746,7 +6746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LengthSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2526",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LengthSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6773,7 +6773,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LinearSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2528",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LinearSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6800,7 +6800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LineSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2530",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LineSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6827,7 +6827,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_LoadedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2532",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.LoadedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6854,7 +6854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MachineAxisLockSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2534",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MachineAxisLockSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6881,7 +6881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaintenanceSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2536",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaintenanceSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6908,7 +6908,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ManualUnclampSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2538",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ManualUnclampSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6935,7 +6935,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MaximumSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2540",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MaximumSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6962,7 +6962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MinimumSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2542",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MinimumSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6989,7 +6989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MohsSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2544",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MohsSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7016,7 +7016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MoleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2546",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MoleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7043,7 +7043,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_MotionSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2548",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.MotionSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7070,7 +7070,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_NoScaleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2550",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.NoScaleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7097,7 +7097,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2552",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7124,7 +7124,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OperatorSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2554",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OperatorSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7151,7 +7151,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OptionalStopSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2556",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OptionalStopSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7178,7 +7178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_OverrideSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2558",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.OverrideSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7205,7 +7205,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PoweredSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2562",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PoweredSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7232,7 +7232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_PrimarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2560",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.PrimarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7259,7 +7259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProbeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2564",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProbeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7286,7 +7286,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProcessSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2566",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProcessSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7313,7 +7313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ProgrammedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2568",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ProgrammedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7340,7 +7340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RadialSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2570",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RadialSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7367,7 +7367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RapidSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2572",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RapidSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7394,7 +7394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RelativeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2574",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RelativeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7421,7 +7421,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RemainingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2576",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RemainingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7448,7 +7448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RequestSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2578",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RequestSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7475,7 +7475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ResponseSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2580",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ResponseSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7502,7 +7502,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RockwellSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2582",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RockwellSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7529,7 +7529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_RotarySubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2584",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.RotarySubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7556,7 +7556,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SetUpSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2586",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SetUpSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7583,7 +7583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ShoreSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2588",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ShoreSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7610,7 +7610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_StandardSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2590",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.StandardSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7637,7 +7637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_SwitchedSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2592",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.SwitchedSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7664,7 +7664,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_TargetSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2594",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.TargetSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7691,7 +7691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolChangeStopSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2596",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolChangeStopSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7718,7 +7718,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolEdgeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2598",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolEdgeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7745,7 +7745,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolGroupSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2600",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolGroupSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7772,7 +7772,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_ToolSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2602",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.ToolSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7799,7 +7799,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_UasbleSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2604",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.UasbleSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7826,7 +7826,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VerticalSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2606",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VerticalSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7853,7 +7853,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VickersSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2610",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VickersSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7880,7 +7880,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_VolumeSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2608",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.VolumeSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7907,7 +7907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WeightSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2612",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WeightSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7934,7 +7934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkingSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2614",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkingSubClassType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7961,7 +7961,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MTConnect_v2_WorkpieceSubClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MTConnect/v2/;i=2616",
+    "dov:typeRef": "org.opcfoundation.UA.MTConnect.v2.WorkpieceSubClassType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/MachineTool.TM.json
+++ b/wot-codegen/opc-output-simple/MachineTool.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_OperatorConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=47",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.OperatorConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ClampingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=48",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ClampingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ManualProcessStepConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ManualProcessStepConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MeasurementConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=53",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MeasurementConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartMissingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=54",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartMissingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProcessIrregularityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=55",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularityConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolBreakageConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=57",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolBreakageConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolChangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolChangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_UtilityConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=60",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.UtilityConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_AlertType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=39",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.AlertType",
     "dov:isEvent": true,
     "links": [
       {
@@ -288,7 +288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_InterruptionConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=19",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.InterruptionConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -334,7 +334,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=35",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -380,7 +380,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -513,7 +513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -525,7 +525,7 @@
     "schemaDefinitions": {
       "PartQuality": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "const": {
           "CapabilityUnavailable": 0,
           "Good": 1,
@@ -558,7 +558,7 @@
       },
       "ProcessIrregularity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "const": {
           "CapabilityUnavailable": 0,
           "Detected": 1,
@@ -651,7 +651,7 @@
       "PartQuality": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "PartQuality",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -667,7 +667,7 @@
       "ProcessIrregularity": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ProcessIrregularity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -686,7 +686,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "PartQuality",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -703,7 +703,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ProcessIrregularity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -727,7 +727,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=17",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -785,7 +785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_BaseToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.BaseToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -848,7 +848,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=51",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -881,7 +881,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -898,7 +898,7 @@
     "schemaDefinitions": {
       "ToolManagement": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "const": {
           "NumberBased": 0,
           "GroupBased": 1,
@@ -966,7 +966,7 @@
       "ControlIdentifierInterpretation": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ToolManagement",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1052,7 +1052,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ToolManagement",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=69",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolManagement",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1116,7 +1116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ChannelModifierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=33",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelModifierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1279,7 +1279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ElementMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ElementMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1324,7 +1324,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ChannelMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=16",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1342,7 +1342,7 @@
     "schemaDefinitions": {
       "ChannelMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
         "const": {
           "Automatic": 0,
           "MdaMdi": 1,
@@ -1390,7 +1390,7 @@
       },
       "ChannelState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
         "const": {
           "Active": 0,
           "Interrupted": 1,
@@ -1430,7 +1430,7 @@
       "ChannelMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ChannelMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1446,7 +1446,7 @@
       "ChannelState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ChannelState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1493,7 +1493,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ChannelMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=67",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1510,7 +1510,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ChannelState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=64",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ChannelState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_CombinedChannelMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=46",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.CombinedChannelMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1591,7 +1591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_WorkingUnitMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.WorkingUnitMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1617,7 +1617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EDMGeneratorMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1629,7 +1629,7 @@
     "schemaDefinitions": {
       "EDMGeneratorState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
         "const": {
           "Undefined": 0,
           "Ready": 1,
@@ -1679,7 +1679,7 @@
       "EDMGeneratorState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "EDMGeneratorState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1710,7 +1710,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "EDMGeneratorState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=71",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.EDMGeneratorState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1747,7 +1747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_LaserMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=36",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1759,7 +1759,7 @@
     "schemaDefinitions": {
       "LaserState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "const": {
           "Undefined": 0,
           "Ready": 1,
@@ -1816,7 +1816,7 @@
       "LaserState": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "LaserState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1848,7 +1848,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "LaserState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=70",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.LaserState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1872,7 +1872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_SpindleMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.SpindleMonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1990,7 +1990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_EquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.EquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2022,7 +2022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2054,7 +2054,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2071,7 +2071,7 @@
     "schemaDefinitions": {
       "MachineOperationMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "const": {
           "Manual": 0,
           "Automatic": 1,
@@ -2152,7 +2152,7 @@
       "OperationMode": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "MachineOperationMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2213,7 +2213,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "MachineOperationMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=65",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2252,7 +2252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2315,7 +2315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MessagesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MessagesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2341,7 +2341,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2385,7 +2385,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_NotificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.NotificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2423,7 +2423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ObligationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ObligationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2511,7 +2511,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2537,7 +2537,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=29",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2758,7 +2758,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2884,7 +2884,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=56",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2901,7 +2901,7 @@
     "schemaDefinitions": {
       "PartQuality": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "const": {
           "CapabilityUnavailable": 0,
           "Good": 1,
@@ -2934,7 +2934,7 @@
       },
       "ProcessIrregularity": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "const": {
           "CapabilityUnavailable": 0,
           "Detected": 1,
@@ -3015,7 +3015,7 @@
       "PartQuality": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "PartQuality",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3031,7 +3031,7 @@
       "ProcessIrregularity": {
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "title": "ProcessIrregularity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3050,7 +3050,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "PartQuality",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=63",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartQuality",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3067,7 +3067,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineTool/",
         "data": {
           "title": "ProcessIrregularity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=62",
+          "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessIrregularity",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3091,7 +3091,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=59",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3155,7 +3155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionActiveProgramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionActiveProgramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3249,7 +3249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3316,7 +3316,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3360,7 +3360,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3410,7 +3410,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PrognosisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3456,7 +3456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MaintenancePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MaintenancePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3520,7 +3520,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ManualActivityPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ManualActivityPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3584,7 +3584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartLoadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartLoadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3723,7 +3723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_PartUnloadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.PartUnloadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3862,7 +3862,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProcessChangeoverPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProcessChangeoverPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3951,7 +3951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobEndPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobEndPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4040,7 +4040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=45",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4179,7 +4179,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolLoadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolLoadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4293,7 +4293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolUnloadPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=18",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolUnloadPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4432,7 +4432,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_UtilityChangePrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.UtilityChangePrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4496,7 +4496,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_SoftwareIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.SoftwareIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4565,7 +4565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MachineOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MachineOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4746,7 +4746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_MaintenanceModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.MaintenanceModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4802,7 +4802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4977,7 +4977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionJobStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionJobStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5093,7 +5093,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionPartStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionPartStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5209,7 +5209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ProductionProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ProductionProgramStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5325,7 +5325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineTool_ToolListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineTool/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.MachineTool.ToolListType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/MachineVision.AMCM.TM.json
+++ b/wot-codegen/opc-output-simple/MachineVision.AMCM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IVisionInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IVisionInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ICableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ICableType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IComputingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IComputingDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IDisplayUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IDisplayUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILampType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILensType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILensType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILicenseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILicenseType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_ILightingControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.ILightingControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_IPhysicalInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.IPhysicalInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -242,7 +242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionItemFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionItemFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -268,7 +268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -539,7 +539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionComponentIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -810,7 +810,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionHealthInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionHealthInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -827,7 +827,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -883,7 +883,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
         "description": "indicates the status as defined by NAMUR Recommendation NE107. The DeviceHealthEnumeration DataType is formally defined in OPC 10000-100 Device Model",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -924,7 +924,7 @@
         "title": "SEMI_E10SystemStateDataType",
         "description": "denotes the SEMI E10 State of the item ",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.SEMI_E10SystemStateDataType",
         "required": [ "Id", "Priority" ],
         "properties": {
           "Id": {
@@ -979,7 +979,7 @@
         "data": {
           "title": "DeviceHealthEnumeration",
           "description": "indicates the status as defined by NAMUR Recommendation NE107. The DeviceHealthEnumeration DataType is formally defined in OPC 10000-100 Device Model",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1012,7 +1012,7 @@
           "title": "SEMI_E10SystemStateDataType",
           "description": "denotes the SEMI E10 State of the item ",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.SEMI_E10SystemStateDataType",
           "required": [ "Id", "Priority" ],
           "properties": {
             "Id": {
@@ -1062,7 +1062,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionMaintenanceInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionMaintenanceInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1288,7 +1288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAcquisitionBackgroundType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAcquisitionBackgroundType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1315,7 +1315,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageReceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageReceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1342,7 +1342,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageTransceiverType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageTransceiverType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1369,7 +1369,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionAspectImageTransmitterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionAspectImageTransmitterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1396,7 +1396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionCableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionCableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1423,7 +1423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionClimateControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionClimateControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1450,7 +1450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionComputingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionComputingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1477,7 +1477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionDisplayUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionDisplayUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1504,7 +1504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionFrameGrabberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionFrameGrabberType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1531,7 +1531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionHousingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionHousingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1558,7 +1558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionImageSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionImageSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1585,7 +1585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLampType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLampType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1612,7 +1612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLensControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLensControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1639,7 +1639,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLensType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLensType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1666,7 +1666,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLicenseType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLicenseType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1693,7 +1693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionLightingControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionLightingControllerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1720,7 +1720,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionNetworkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionNetworkDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1747,7 +1747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionOpticalFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionOpticalFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1774,7 +1774,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionOtherOpticalEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionOtherOpticalEquipmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1801,7 +1801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPatternGeneratorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPatternGeneratorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1828,7 +1828,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPhysicalInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPhysicalInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1855,7 +1855,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionPowerSupplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionPowerSupplyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1882,7 +1882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionSurroundingEnvironmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionSurroundingEnvironmentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1909,7 +1909,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionSystemAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionSystemAssetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2092,7 +2092,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionTriggerSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionTriggerSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2119,7 +2119,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AMCM_VisionWayEncoderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision/AMCM/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AMCM.VisionWayEncoderType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/MachineVision.TM.json
+++ b/wot-codegen/opc-output-simple/MachineVision.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_AcquisitionDoneEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.AcquisitionDoneEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38,7 +38,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -73,7 +73,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -173,7 +173,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -216,7 +216,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -259,7 +259,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -302,7 +302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -345,7 +345,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -371,7 +371,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -401,7 +401,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -431,7 +431,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -461,7 +461,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -513,7 +513,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionErrorConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionErrorConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -540,7 +540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionPersistentErrorConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionPersistentErrorConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -567,7 +567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionWarningConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionWarningConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -594,7 +594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_EnterStepSequenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.EnterStepSequenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -652,7 +652,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_JobStartedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobStartedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -682,7 +682,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -717,7 +717,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_LeaveStepSequenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.LeaveStepSequenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -744,7 +744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_NextStepEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.NextStepEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -802,7 +802,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -832,7 +832,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -867,7 +867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipePreparedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipePreparedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -897,7 +897,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -940,7 +940,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -983,7 +983,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1022,7 +1022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1070,7 +1070,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1113,7 +1113,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1156,7 +1156,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1199,7 +1199,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1276,7 +1276,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1302,7 +1302,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1332,7 +1332,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1362,7 +1362,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProcessingTimesDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
         "required": [ "StartTime", "EndTime" ],
         "properties": {
           "StartTime": {
@@ -1404,7 +1404,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1455,7 +1455,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1509,7 +1509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ErrorEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ErrorEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1536,7 +1536,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ErrorResolvedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ErrorResolvedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1563,7 +1563,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_StateChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.StateChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1590,7 +1590,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1637,7 +1637,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1680,7 +1680,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1723,7 +1723,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1766,7 +1766,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1809,7 +1809,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1835,7 +1835,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "MeasIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1865,7 +1865,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "PartIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1895,7 +1895,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1925,7 +1925,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -1960,7 +1960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionDiagnosticInfoEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionDiagnosticInfoEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1987,7 +1987,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionInformationEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionInformationEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2014,7 +2014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionSafetyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionSafetyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2087,7 +2087,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2131,13 +2131,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6116",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2167,7 +2167,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6117",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2189,13 +2189,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6096",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2225,13 +2225,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6097",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Configuration", "TransferRequired", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2282,13 +2282,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId", "Timeout" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2323,7 +2323,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConfigurationHandle", "Configuration", "Error" ],
           "properties": {
             "ConfigurationHandle": {
@@ -2334,7 +2334,7 @@
             "Configuration": {
               "title": "ConfigurationDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
               "required": [ "InternalId", "LastModified" ],
               "properties": {
                 "HasTransferableDataOnFile": {
@@ -2345,7 +2345,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Identification of the configuration used by the environment. This argument must not be empty.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -2375,7 +2375,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -2427,7 +2427,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6104",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "MaxResults": {
@@ -2449,7 +2449,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6105",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "ConfigurationHandle", "ConfigurationList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -2470,7 +2470,7 @@
               "items": {
                 "title": "ConfigurationDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
                 "required": [ "InternalId", "LastModified" ],
                 "properties": {
                   "HasTransferableDataOnFile": {
@@ -2481,7 +2481,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Identification of the configuration used by the environment. This argument must not be empty.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -2511,7 +2511,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -2564,7 +2564,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationHandle" ],
           "properties": {
             "ConfigurationHandle": {
@@ -2576,7 +2576,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6109",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2598,13 +2598,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2634,7 +2634,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6113",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -2658,7 +2658,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ConfigurationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
         "required": [ "InternalId", "LastModified" ],
         "properties": {
           "HasTransferableDataOnFile": {
@@ -2669,7 +2669,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Identification of the configuration used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2699,7 +2699,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2752,7 +2752,7 @@
         "data": {
           "title": "ConfigurationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
           "required": [ "InternalId", "LastModified" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -2763,7 +2763,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Identification of the configuration used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2793,7 +2793,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -2845,7 +2845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2879,7 +2879,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ConfigurationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
         "required": [ "InternalId", "LastModified" ],
         "properties": {
           "HasTransferableDataOnFile": {
@@ -2890,7 +2890,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Identification of the configuration used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2920,7 +2920,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -2974,7 +2974,7 @@
         "data": {
           "title": "ConfigurationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationDataType",
           "required": [ "InternalId", "LastModified" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -2985,7 +2985,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Identification of the configuration used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3015,7 +3015,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "System-wide unique ID for identifying a configuration. This ID is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3068,7 +3068,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ProductFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3102,14 +3102,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ProductDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductDataType",
         "required": [ "ExternalId" ],
         "properties": {
           "ExternalId": {
             "title": "ProductIdDataType",
             "description": "Identification of the product used by the environment. This argument must not be empty.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3145,14 +3145,14 @@
         "data": {
           "title": "ProductDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductDataType",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "ProductIdDataType",
               "description": "Identification of the product used by the environment. This argument must not be empty.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3187,7 +3187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3219,7 +3219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3253,14 +3253,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
         "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
         "properties": {
           "ResultId": {
             "title": "ResultIdDataType",
             "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3291,7 +3291,7 @@
             "title": "MeasIdDataType",
             "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3308,7 +3308,7 @@
             "title": "PartIdDataType",
             "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3325,7 +3325,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3355,7 +3355,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3385,7 +3385,7 @@
             "title": "ProductIdDataType",
             "description": "productId which was used to trigger the job which created the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3402,7 +3402,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3432,7 +3432,7 @@
             "title": "BinaryIdBaseDataType",
             "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3462,7 +3462,7 @@
             "title": "JobIdDataType",
             "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
             "required": [ "Id" ],
             "properties": {
               "Id": {
@@ -3480,7 +3480,7 @@
             "title": "ProcessingTimesDataType",
             "description": "Collection of different processing times that were needed to create the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
             "required": [ "StartTime", "EndTime" ],
             "properties": {
               "StartTime": {
@@ -3553,7 +3553,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3597,7 +3597,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "BinaryIdBaseDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3659,7 +3659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "JobIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3686,7 +3686,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "ResultIdDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -3736,14 +3736,14 @@
         "data": {
           "title": "ResultDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
           "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3774,7 +3774,7 @@
               "title": "MeasIdDataType",
               "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3791,7 +3791,7 @@
               "title": "PartIdDataType",
               "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3808,7 +3808,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3838,7 +3838,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3868,7 +3868,7 @@
               "title": "ProductIdDataType",
               "description": "productId which was used to trigger the job which created the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3885,7 +3885,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3915,7 +3915,7 @@
               "title": "BinaryIdBaseDataType",
               "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3945,7 +3945,7 @@
               "title": "JobIdDataType",
               "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -3963,7 +3963,7 @@
               "title": "ProcessingTimesDataType",
               "description": "Collection of different processing times that were needed to create the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
               "required": [ "StartTime", "EndTime" ],
               "properties": {
                 "StartTime": {
@@ -4028,7 +4028,7 @@
         "data": {
           "title": "BinaryIdBaseDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4068,7 +4068,7 @@
         "data": {
           "title": "BinaryIdBaseDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4122,7 +4122,7 @@
         "data": {
           "title": "JobIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4145,7 +4145,7 @@
         "data": {
           "title": "ResultIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4190,7 +4190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4219,7 +4219,7 @@
     "schemaDefinitions": {
       "TriStateBooleanDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.TriStateBooleanDataType",
         "const": {
           "FALSE_0": 0,
           "TRUE_1": 1,
@@ -4246,13 +4246,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "ProductId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4281,7 +4281,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4298,13 +4298,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Recipe", "Product", "TransferRequired", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4358,13 +4358,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6156",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "ProductId", "IsPrepared", "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4393,7 +4393,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4408,7 +4408,7 @@
             },
             "IsPrepared": {
               "title": "TriStateBooleanDataType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.TriStateBooleanDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4432,7 +4432,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6157",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "RecipeHandle", "RecipeList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -4453,7 +4453,7 @@
               "items": {
                 "title": "BinaryIdBaseDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                 "required": [ "Id" ],
                 "properties": {
                   "Id": {
@@ -4499,13 +4499,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6172",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4522,13 +4522,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4573,13 +4573,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6148",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "InternalIdIn" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4608,7 +4608,7 @@
             "InternalIdIn": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4638,13 +4638,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6149",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalIdOut", "IsCompleted", "Error" ],
           "properties": {
             "InternalIdOut": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4692,7 +4692,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6160",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeHandle" ],
           "properties": {
             "RecipeHandle": {
@@ -4704,7 +4704,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6161",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -4726,13 +4726,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6164",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4762,7 +4762,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6165",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -4784,13 +4784,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InternalId", "ProductId" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4819,7 +4819,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4836,7 +4836,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -4858,13 +4858,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4881,13 +4881,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalId", "Error" ],
           "properties": {
             "InternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4932,13 +4932,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6152",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExternalId", "InternalIdIn" ],
           "properties": {
             "ExternalId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4967,7 +4967,7 @@
             "InternalIdIn": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -4997,13 +4997,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6153",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "InternalIdOut", "Error" ],
           "properties": {
             "InternalIdOut": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5059,7 +5059,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5092,13 +5092,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6190",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5115,7 +5115,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5137,7 +5137,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6202",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsCompleted", "Error" ],
           "properties": {
             "IsCompleted": {
@@ -5162,13 +5162,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6196",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5185,7 +5185,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6197",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5207,7 +5207,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6205",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -5232,7 +5232,7 @@
         "title": "BinaryIdBaseDataType",
         "description": "Recipe ID for identifying the recipe outside the vision system. The ExternalID is only managed by the host system.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -5276,7 +5276,7 @@
         "title": "BinaryIdBaseDataType",
         "description": "System-wide unique ID for identifying a recipe. This ID is assigned by the vision system.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
         "required": [ "Id" ],
         "properties": {
           "Id": {
@@ -5357,7 +5357,7 @@
         "items": {
           "title": "ProductIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -5397,7 +5397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5424,13 +5424,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6209",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5448,7 +5448,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6210",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -5459,14 +5459,14 @@
             "Result": {
               "title": "ResultDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
               "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
               "properties": {
                 "ResultId": {
                   "title": "ResultIdDataType",
                   "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5497,7 +5497,7 @@
                   "title": "MeasIdDataType",
                   "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5514,7 +5514,7 @@
                   "title": "PartIdDataType",
                   "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5531,7 +5531,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5561,7 +5561,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5591,7 +5591,7 @@
                   "title": "ProductIdDataType",
                   "description": "productId which was used to trigger the job which created the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5608,7 +5608,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5638,7 +5638,7 @@
                   "title": "BinaryIdBaseDataType",
                   "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5668,7 +5668,7 @@
                   "title": "JobIdDataType",
                   "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -5686,7 +5686,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Collection of different processing times that were needed to create the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -5740,13 +5740,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
               "title": "ResultIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5764,7 +5764,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "HasTransferableDataOnFile", "ResultHandle", "IsPartial", "IsSimulated", "ResultState", "MeasId", "PartId", "ExternalRecipeId", "InternalRecipeId", "ProductId", "ExternalConfigurationId", "InternalConfigurationId", "JobId", "CreationTime", "ProcessingTimes", "ResultContent", "Error" ],
           "properties": {
             "HasTransferableDataOnFile": {
@@ -5789,7 +5789,7 @@
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5805,7 +5805,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5821,7 +5821,7 @@
             "ExternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5850,7 +5850,7 @@
             "InternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5879,7 +5879,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5895,7 +5895,7 @@
             "ExternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5924,7 +5924,7 @@
             "InternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5953,7 +5953,7 @@
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -5969,7 +5969,7 @@
             "ProcessingTimes": {
               "title": "ProcessingTimesDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
               "required": [ "StartTime", "EndTime" ],
               "properties": {
                 "StartTime": {
@@ -6019,7 +6019,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultState", "MeasId", "PartId", "ExternalRecipeId", "InternalRecipeId", "ExternalConfigurationId", "InternalConfigurationId", "ProductId", "JobId", "MaxResults", "StartIndex", "Timeout" ],
           "properties": {
             "ResultState": {
@@ -6030,7 +6030,7 @@
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6046,7 +6046,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6062,7 +6062,7 @@
             "ExternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6091,7 +6091,7 @@
             "InternalRecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6120,7 +6120,7 @@
             "ExternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6149,7 +6149,7 @@
             "InternalConfigurationId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6178,7 +6178,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6194,7 +6194,7 @@
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6222,7 +6222,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "IsComplete", "ResultCount", "ResultHandle", "ResultList", "Error" ],
           "properties": {
             "IsComplete": {
@@ -6243,14 +6243,14 @@
               "items": {
                 "title": "ResultDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultDataType",
                 "required": [ "ResultId", "IsPartial", "ResultState", "InternalRecipeId", "InternalConfigurationId", "JobId", "CreationTime" ],
                 "properties": {
                   "ResultId": {
                     "title": "ResultIdDataType",
                     "description": "System-wide unique identifier, which is assigned by the system. This ID can be used for fetching exactly this result using the pertinent result management methods and it is identical to the ResultId of the ResultReadyEventType.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6281,7 +6281,7 @@
                     "title": "MeasIdDataType",
                     "description": "This identifier is given by the client when starting a single job or continuous execution and transmitted to the vision system. It is used to identify the respective result data generated for this job. Although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6298,7 +6298,7 @@
                     "title": "PartIdDataType",
                     "description": "A PartId is given by the client when starting the job; although the system-wide unique JobId would be sufficient to identify the job which the result belongs to, this makes for easier filtering on the part of the client without keeping track of JobIds.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6315,7 +6315,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "External Id of the recipe in use which produced the result. The ExternalID is only managed by the environment.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6345,7 +6345,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Internal Id of the recipe in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6375,7 +6375,7 @@
                     "title": "ProductIdDataType",
                     "description": "productId which was used to trigger the job which created the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6392,7 +6392,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "External Id of the configuration in use which produced the result. The ExternalID is only managed by the environment.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6422,7 +6422,7 @@
                     "title": "BinaryIdBaseDataType",
                     "description": "Internal Id of the configuration in use which produced the result. This ID is system-wide unique and is assigned by the vision system.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6452,7 +6452,7 @@
                     "title": "JobIdDataType",
                     "description": "The ID of the job, created by the transition from state Ready to state SingleExecution or to state ContinuousExecution which produced the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Id": {
@@ -6470,7 +6470,7 @@
                     "title": "ProcessingTimesDataType",
                     "description": "Collection of different processing times that were needed to create the result.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProcessingTimesDataType",
                     "required": [ "StartTime", "EndTime" ],
                     "properties": {
                       "StartTime": {
@@ -6525,7 +6525,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -6537,7 +6537,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -6570,7 +6570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_SafetyStateManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.SafetyStateManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6602,7 +6602,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6222",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SafetyTriggered", "SafetyInformation" ],
           "properties": {
             "SafetyTriggered": {
@@ -6615,7 +6615,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6223",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -6708,7 +6708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionAutomaticModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionAutomaticModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6867,7 +6867,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -6882,7 +6882,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6286",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -6904,7 +6904,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6289",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Activate", "Cause", "CauseDescription" ],
           "properties": {
             "Activate": {
@@ -6922,7 +6922,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6290",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -6944,13 +6944,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MeasId", "PartId", "RecipeId", "ProductId", "Parameters" ],
           "properties": {
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6966,7 +6966,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -6982,7 +6982,7 @@
             "RecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7011,7 +7011,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7034,13 +7034,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobId", "Error" ],
           "properties": {
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7068,13 +7068,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6281",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MeasId", "PartId", "RecipeId", "ProductId", "Parameters" ],
           "properties": {
             "MeasId": {
               "title": "MeasIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.MeasIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7090,7 +7090,7 @@
             "PartId": {
               "title": "PartIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.PartIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7106,7 +7106,7 @@
             "RecipeId": {
               "title": "BinaryIdBaseDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7135,7 +7135,7 @@
             "ProductId": {
               "title": "ProductIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ProductIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7158,13 +7158,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6282",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobId", "Error" ],
           "properties": {
             "JobId": {
               "title": "JobIdDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.JobIdDataType",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
@@ -7192,7 +7192,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6287",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7207,7 +7207,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6288",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7240,7 +7240,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7417,7 +7417,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -7437,7 +7437,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6254",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7452,7 +7452,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6255",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7474,7 +7474,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6256",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7489,7 +7489,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6257",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7511,7 +7511,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6258",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7544,7 +7544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionStepModelStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionStepModelStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7619,7 +7619,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Cause", "CauseDescription" ],
           "properties": {
             "Cause": {
@@ -7634,7 +7634,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6320",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -7667,7 +7667,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ConfigurationTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7681,20 +7681,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6617",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ConfigurationTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The Id of the configuration to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -7726,7 +7726,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6618",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -7753,20 +7753,20 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6121",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ConfigurationTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ConfigurationTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The Id of the configuration to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -7798,7 +7798,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6122",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -7834,7 +7834,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_RecipeTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7848,20 +7848,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "generateOptions" ],
           "properties": {
             "generateOptions": {
               "title": "RecipeTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The InternalId of the recipe to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -7893,7 +7893,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6185",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "fileNodeId", "fileHandle", "completionStateMachine" ],
           "properties": {
             "fileNodeId": {
@@ -7920,20 +7920,20 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6583",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "RecipeTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.RecipeTransferOptions",
               "required": [ "InternalId" ],
               "properties": {
                 "InternalId": {
                   "title": "BinaryIdBaseDataType",
                   "description": "The InternalId of the recipe to be transferred to or from the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.BinaryIdBaseDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -7965,7 +7965,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6584",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -8001,7 +8001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8015,20 +8015,20 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "ResultTransferOptions",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3022",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultTransferOptions",
               "required": [ "Id" ],
               "properties": {
                 "Id": {
                   "title": "ResultIdDataType",
                   "description": "The Id of the result to be transferred to the client.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3021",
+                  "dov:typeRef": "org.opcfoundation.UA.MachineVision.ResultIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Id": {
@@ -8043,7 +8043,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=6170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -8082,7 +8082,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MachineVision_VisionSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MachineVision.VisionSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8124,7 +8124,7 @@
     "schemaDefinitions": {
       "SystemStateDataType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
         "const": {
           "PRD_1": 1,
           "SBY_2": 2,
@@ -8204,13 +8204,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/MachineVision",
         "title": "SystemStateDescriptionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDescriptionDataType",
         "required": [ "State" ],
         "properties": {
           "State": {
             "title": "SystemStateDataType",
             "description": "Denotes one of the basic SEMI E10 states",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+            "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -8256,13 +8256,13 @@
         "data": {
           "title": "SystemStateDescriptionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDescriptionDataType",
           "required": [ "State" ],
           "properties": {
             "State": {
               "title": "SystemStateDataType",
               "description": "Denotes one of the basic SEMI E10 states",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/MachineVision;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.MachineVision.SystemStateDataType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647

--- a/wot-codegen/opc-output-simple/Machinery.Energy.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery.Energy.TM.json
@@ -9,7 +9,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IBaseFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IBaseFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -291,7 +291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IMassFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IMassFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -573,7 +573,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_IVolumeFlowType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.IVolumeFlowType",
     "links": [
       {
         "rel": "tm:extends",
@@ -854,7 +854,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Energy_INonElectricalEnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Energy/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Energy.INonElectricalEnergyType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Machinery.Jobs.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery.Jobs.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Jobs_JobManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobManagementType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Machinery.ProcessValues.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery.ProcessValues.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ZeroPointAdjustmentEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ZeroPointAdjustmentEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -65,7 +65,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_ProcessValues_ProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/ProcessValues/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.ProcessValues.ProcessValueType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Machinery.Result.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery.Result.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -73,14 +73,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -146,7 +146,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -181,7 +181,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -236,14 +236,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -309,7 +309,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -344,7 +344,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -397,7 +397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -421,7 +421,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -450,7 +450,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -546,7 +546,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultIds" ],
           "properties": {
             "ResultIds": {
@@ -560,7 +560,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ErrorPerResultId", "Error" ],
           "properties": {
             "ErrorPerResultId": {
@@ -592,7 +592,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Timeout" ],
           "properties": {
             "Timeout": {
@@ -605,7 +605,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -618,14 +618,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -691,7 +691,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -726,7 +726,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -781,7 +781,7 @@
         "description": "The server shall return to each client requesting result data a system-wide unique handle identifying the result set / client combination. This handle should be used by the client to indicate to the server that the result data is no longer needed, allowing the server to optimize its resource handling.  If the instance of ResultManagementType does not support the ReleaseResultHandle Method, the resultHandle should always be set to 0.  If the error is set to a value other than 0, the resultHandle may be set to 0.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -798,7 +798,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -811,14 +811,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -884,7 +884,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -919,7 +919,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -973,14 +973,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Filter", "OrderedBy", "MaxResults", "Timeout" ],
           "properties": {
             "Filter": {
               "title": "ContentFilter",
               "description": "Filter used to filter for specific results based on the meta data of the results. Valid BrowsePaths used in the filter can be built from the fields of the ResultReadyEventType, the ResultType VariableType or the ResultDataType or corresponding subtypes.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -988,12 +988,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -1015,7 +1015,7 @@
               "items": {
                 "title": "RelativePath",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                 "required": [ "Elements" ],
                 "properties": {
                   "Elements": {
@@ -1023,7 +1023,7 @@
                     "items": {
                       "title": "RelativePathElement",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                       "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                       "properties": {
                         "ReferenceTypeId": {
@@ -1060,7 +1060,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "ResultIdList", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -1096,7 +1096,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultHandle" ],
           "properties": {
             "ResultHandle": {
@@ -1109,7 +1109,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Error" ],
           "properties": {
             "Error": {
@@ -1160,7 +1160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Result_ResultTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultTransferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1174,14 +1174,14 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6035",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
               "title": "BaseResultTransferOptionsDataType",
               "description": "Abstract type containing information which file should be provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.BaseResultTransferOptionsDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -1194,7 +1194,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=6036",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {

--- a/wot-codegen/opc-output-simple/Machinery.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineTagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineTagNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -64,7 +64,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineryEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineryEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineryItemVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineryItemVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -273,7 +273,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_IMachineVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.IMachineVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -319,7 +319,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -571,7 +571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -653,7 +653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryComponentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryComponentIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -722,7 +722,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -835,7 +835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryEquipmentFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryEquipmentFolderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -897,7 +897,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryLifetimeCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryLifetimeCounterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -990,7 +990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MonitoringType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1060,7 +1060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_NotificationsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.NotificationsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1116,7 +1116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineComponentsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineComponentsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1178,7 +1178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_MachineryOperationModeStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery.MachineryOperationModeStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Machinery_Example.TM.json
+++ b/wot-codegen/opc-output-simple/Machinery_Example.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Example_ExampleComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery_Example/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery_Example.ExampleComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,7 +40,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Machinery_Example_ExampleMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery_Example/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Machinery_Example.ExampleMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/MetalForming.TM.json
+++ b/wot-codegen/opc-output-simple/MetalForming.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_AllowableTiltingExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.AllowableTiltingExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_BreakthroughTonnageExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.BreakthroughTonnageExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CorrectionValueOutOfRangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CorrectionValueOutOfRangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_EccentricLoadExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.EccentricLoadExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -138,7 +138,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_OverloadTriggeredConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.OverloadTriggeredConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -164,7 +164,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_PositionOutOfRangeConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.PositionOutOfRangeConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_ProcessForceExceededConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.ProcessForceExceededConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CyclicEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -330,7 +330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingToolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -362,7 +362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingMultiToolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingMultiToolType",
     "dov:isComposite": true,
     "links": [
       {
@@ -395,7 +395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_ProcessWorkingUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.ProcessWorkingUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -440,7 +440,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingProcessWorkingUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingProcessWorkingUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_FormingPositionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.FormingPositionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -529,7 +529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "MetalForming_CyclicProcessValueType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueType",
     "links": [
       {
         "rel": "tm:extends",
@@ -563,7 +563,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/MetalForming/",
         "title": "CyclicProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueDataType",
         "required": [ "AnalogSignal", "Setpoint", "CycleCount", "IsActive" ],
         "properties": {
           "AnalogSignal": {
@@ -602,7 +602,7 @@
         "data": {
           "title": "CyclicProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/MetalForming/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.MetalForming.CyclicProcessValueDataType",
           "required": [ "AnalogSignal", "Setpoint", "CycleCount", "IsActive" ],
           "properties": {
             "AnalogSignal": {

--- a/wot-codegen/opc-output-simple/Mining.DevelopmentSupport.Dozer.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.DevelopmentSupport.Dozer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_DevelopmentSupport_Dozer_DozerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/DevelopmentSupport/Dozer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.DevelopmentSupport.Dozer.DozerType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.DevelopmentSupport.RoofSupportSystem.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.DevelopmentSupport.RoofSupportSystem.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_DevelopmentSupport_RoofSupportSystem_RoofSupportSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/DevelopmentSupport/RoofSupportSystem/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.DevelopmentSupport.RoofSupportSystem.RoofSupportSystemType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.ExternalStandards.IREDES.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.ExternalStandards.IREDES.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_DisplayToOperatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DisplayToOperatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "DispFlag": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
         "const": {
           "MachStart": 0,
           "FileLoad": 1
@@ -95,7 +95,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "DispFlag",
         "description": "States under which circumstances the line (message) has to be displayed to the operator.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -152,7 +152,7 @@
         "data": {
           "title": "DispFlag",
           "description": "States under which circumstances the line (message) has to be displayed to the operator.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.DispFlag",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -190,7 +190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_EquipmentInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.EquipmentInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -408,7 +408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_GenHeadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.GenHeadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -518,7 +518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_GenTrailerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.GenTrailerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -611,7 +611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IREDESType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IREDESType",
     "links": [
       {
         "rel": "tm:extends",
@@ -702,7 +702,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLHDTruckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLHDTruckType",
     "dov:isComposite": true,
     "links": [
       {
@@ -759,7 +759,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTMMonType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTMMonType",
     "links": [
       {
         "rel": "tm:extends",
@@ -850,7 +850,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTPlanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTPlanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -942,7 +942,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRLTPPerfType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRLTPPerfType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1033,7 +1033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IROptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IROptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1126,7 +1126,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRplanGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRplanGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1325,7 +1325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRpPerfGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRpPerfGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1473,7 +1473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRreplyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRreplyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1568,7 +1568,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRStatusGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRStatusGenType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1749,7 +1749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRWorkOrderGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRWorkOrderGenType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1785,7 +1785,7 @@
         "title": "JobAssignmentTimeDataType",
         "description": "Time the execution of the job is expected to take.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.JobAssignmentTimeDataType",
         "properties": {
           "ExpectedFinishTime": {
             "description": "Time Machine is expected to finish the job.",
@@ -2034,7 +2034,7 @@
           "title": "JobAssignmentTimeDataType",
           "description": "Time the execution of the job is expected to take.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.JobAssignmentTimeDataType",
           "properties": {
             "ExpectedFinishTime": {
               "description": "Time Machine is expected to finish the job.",
@@ -2197,7 +2197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_IRWorkOrderReplyGenType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.IRWorkOrderReplyGenType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2208,7 +2208,7 @@
     "schemaDefinitions": {
       "Answer": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
         "const": {
           "Accepted": 0,
           "Delayed": 1,
@@ -2259,7 +2259,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "Answer",
         "description": "See Answer enumeration.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2379,7 +2379,7 @@
         "data": {
           "title": "Answer",
           "description": "See Answer enumeration.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.Answer",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2465,7 +2465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPaccPtsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPaccPtsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2765,7 +2765,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPLoadRepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPLoadRepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2970,7 +2970,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPMissionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMissionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2981,7 +2981,7 @@
     "schemaDefinitions": {
       "LTPPMaction": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
         "const": {
           "Load": 0,
           "Dump": 1,
@@ -3014,7 +3014,7 @@
       },
       "LTPPMptFromType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
         "const": {
           "LoadPt": 0,
           "DumpPt": 1,
@@ -3047,7 +3047,7 @@
       },
       "LTPPMptToType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
         "const": {
           "LoadPt": 0,
           "DumpPt": 1,
@@ -3125,7 +3125,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMaction",
         "description": "Action to be carried out at destination point specified in LTPPMptTo.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3297,7 +3297,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMptFromType",
         "description": "Type of the point where the mission started.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3355,7 +3355,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES",
         "title": "LTPPMptToType",
         "description": "Type of the point where the mission ended.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3476,7 +3476,7 @@
         "data": {
           "title": "LTPPMaction",
           "description": "Action to be carried out at destination point specified in LTPPMptTo.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMaction",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3582,7 +3582,7 @@
         "data": {
           "title": "LTPPMptFromType",
           "description": "Type of the point where the mission started.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptFromType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3628,7 +3628,7 @@
         "data": {
           "title": "LTPPMptToType",
           "description": "Type of the point where the mission ended.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPMptToType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3713,7 +3713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPTimeRepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPTimeRepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3807,7 +3807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_LTPPwaitProcType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.LTPPwaitProcType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4072,7 +4072,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_OpPerfLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.OpPerfLogType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4336,7 +4336,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_ProjectInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ProjectInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4461,7 +4461,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_ExternalStandards_IREDES_SiteHeadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/ExternalStandards/IREDES;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.ExternalStandards.IREDES.SiteHeadType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Mining.Extraction.ShearerLoader.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.Extraction.ShearerLoader.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Extraction_ShearerLoader_ShearerLoaderDrumType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Extraction/ShearerLoader/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Extraction.ShearerLoader.ShearerLoaderDrumType",
     "dov:isComposite": true,
     "links": [
       {
@@ -41,7 +41,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Extraction_ShearerLoader_ShearerLoaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Extraction/ShearerLoader/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Extraction.ShearerLoader.ShearerLoaderType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.General.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -130,7 +130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_General_MiningEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.General.MiningEquipmentType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Mining.Loading.General.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.Loading.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Loading_General_LoadingMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Loading/General/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Loading.General.LoadingMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.Loading.HydraulicExcavator.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.Loading.HydraulicExcavator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_Loading_HydraulicExcavator_HydraulicExcavatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/Loading/HydraulicExcavator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.Loading.HydraulicExcavator.HydraulicExcavatorType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.MineralProcessing.RockCrusher.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.MineralProcessing.RockCrusher.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_MineralProcessing_RockCrusher_RockCrusherControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/MineralProcessing/RockCrusher/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.MineralProcessing.RockCrusher.RockCrusherControlType",
     "dov:isComposite": true,
     "links": [
       {
@@ -47,7 +47,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_MineralProcessing_RockCrusher_RockCrusherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/MineralProcessing/RockCrusher/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.MineralProcessing.RockCrusher.RockCrusherType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.PELOServices.FaceAlignmentSystem.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.PELOServices.FaceAlignmentSystem.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_PELOServices_FaceAlignmentSystem_FaceAlignmentSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/PELOServices/FaceAlignmentSystem/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.PELOServices.FaceAlignmentSystem.FaceAlignmentSystemType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.TransportDumping.ArmouredFaceConveyor.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.TransportDumping.ArmouredFaceConveyor.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_ArmouredFaceConveyor_AFCType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/ArmouredFaceConveyor/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.ArmouredFaceConveyor.AFCType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.TransportDumping.General.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.TransportDumping.General.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_General_HaulageMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/General/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.General.HaulageMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Mining.TransportDumping.RearDumpTruck.TM.json
+++ b/wot-codegen/opc-output-simple/Mining.TransportDumping.RearDumpTruck.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Mining_TransportDumping_RearDumpTruck_RearDumpTruckType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Mining/TransportDumping/RearDumpTruck/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Mining.TransportDumping.RearDumpTruck.RearDumpTruckType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/OPENSCS-SER.TM.json
+++ b/wot-codegen/opc-output-simple/OPENSCS-SER.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSAggregationManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15094",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -99,7 +99,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AggregationElement", "ParentSNFormat", "PackedElementSNFormat", "AggregationContext" ],
           "properties": {
             "AggregationElement": {
@@ -108,14 +108,14 @@
                 "title": "OPENSCSAggregationDataType",
                 "description": "Iidentifies a parent element and a collection of packed elements. This is used in the aggregation packing and unpacking methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationDataType",
                 "required": [ "ParentElement", "ParentElementCollection" ],
                 "properties": {
                   "ParentElement": {
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -128,7 +128,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -148,7 +148,7 @@
                     "title": "OPENSCSLabelCollectionDataType",
                     "description": "Identifies the Serial Number Collection that was added to, or removed from, the parent element.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
                     "required": [ "LabelCollection" ],
                     "properties": {
                       "LabelCollection": {
@@ -158,7 +158,7 @@
                           "title": "OPENSCSLabelDataType",
                           "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                           "required": [ "ID", "LabelProperties" ],
                           "properties": {
                             "ID": {
@@ -171,7 +171,7 @@
                               "items": {
                                 "title": "OPENSCSKeyValueDataType",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -194,7 +194,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -224,7 +224,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -242,13 +242,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -267,7 +267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=6011",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AggregationElement", "ParentSNFormat", "PackedElementSNFormat", "AggregationContext" ],
           "properties": {
             "AggregationElement": {
@@ -276,14 +276,14 @@
                 "title": "OPENSCSAggregationDataType",
                 "description": "Iidentifies a parent element and a collection of packed elements. This is used in the aggregation packing and unpacking methods.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSAggregationDataType",
                 "required": [ "ParentElement", "ParentElementCollection" ],
                 "properties": {
                   "ParentElement": {
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -296,7 +296,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -316,7 +316,7 @@
                     "title": "OPENSCSLabelCollectionDataType",
                     "description": "Identifies the Serial Number Collection that was added to, or removed from, the parent element.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
                     "required": [ "LabelCollection" ],
                     "properties": {
                       "LabelCollection": {
@@ -326,7 +326,7 @@
                           "title": "OPENSCSLabelDataType",
                           "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                           "required": [ "ID", "LabelProperties" ],
                           "properties": {
                             "ID": {
@@ -339,7 +339,7 @@
                               "items": {
                                 "title": "OPENSCSKeyValueDataType",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -362,7 +362,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -392,7 +392,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -410,12 +410,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=6013",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -459,7 +459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSEventManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15062",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSEventManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -477,7 +477,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -545,7 +545,7 @@
       },
       "OPENSCSSerialNumberStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
         "const": {
           "Unassigned0": 0,
           "Unallocated1": 1,
@@ -629,14 +629,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15089",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -646,7 +646,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -659,7 +659,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -682,7 +682,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -708,7 +708,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -726,13 +726,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15090",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -751,14 +751,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -768,7 +768,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -781,7 +781,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -804,7 +804,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -830,7 +830,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -848,13 +848,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15084",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -873,14 +873,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15080",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -890,7 +890,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -903,7 +903,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -926,7 +926,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -952,7 +952,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -970,13 +970,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15081",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -995,14 +995,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1012,7 +1012,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1025,7 +1025,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1048,7 +1048,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1074,7 +1074,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1092,13 +1092,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15087",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1117,14 +1117,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15077",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1134,7 +1134,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1147,7 +1147,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1170,7 +1170,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1196,7 +1196,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1214,13 +1214,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15078",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1239,14 +1239,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1256,7 +1256,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1269,7 +1269,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1292,7 +1292,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1318,7 +1318,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1336,13 +1336,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1361,14 +1361,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15074",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1378,7 +1378,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1391,7 +1391,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1414,7 +1414,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1440,7 +1440,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1458,13 +1458,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15075",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1483,14 +1483,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15068",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1500,7 +1500,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1513,7 +1513,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1536,7 +1536,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1562,7 +1562,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1580,13 +1580,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15069",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1605,14 +1605,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15071",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LabelCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "LabelCollection": {
               "title": "OPENSCSLabelCollectionDataType",
               "description": "Identifies the Label Collection with Serial Numbers and optional label properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15006",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelCollectionDataType",
               "required": [ "LabelCollection" ],
               "properties": {
                 "LabelCollection": {
@@ -1622,7 +1622,7 @@
                     "title": "OPENSCSLabelDataType",
                     "description": "Defines a single serial number and label, which may be associated with an SID, and collection of properties in the form of OPENSCSKeyValueDataType. ",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelDataType",
                     "required": [ "ID", "LabelProperties" ],
                     "properties": {
                       "ID": {
@@ -1635,7 +1635,7 @@
                         "items": {
                           "title": "OPENSCSKeyValueDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -1658,7 +1658,7 @@
                   "items": {
                     "title": "OPENSCSKeyValueDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -1684,7 +1684,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1702,13 +1702,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15072",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1727,14 +1727,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15092",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "SNFormat", "OPENSCSEventContext" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Identifies the Serial Number Collection.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -1748,7 +1748,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -1776,7 +1776,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1794,13 +1794,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15093",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1882,7 +1882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSPoolManagerObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15032",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSPoolManagerObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1894,7 +1894,7 @@
     "schemaDefinitions": {
       "OPENSCSReturnEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
         "const": {
           "Undefined0": 0,
           "NoError1": 1,
@@ -1962,7 +1962,7 @@
       },
       "OPENSCSSerialNumberStateEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+        "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
         "const": {
           "Unassigned0": 0,
           "Unallocated1": 1,
@@ -2041,7 +2041,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2064,7 +2064,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2086,13 +2086,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15055",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2101,7 +2101,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2115,7 +2115,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2151,7 +2151,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2174,7 +2174,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2196,13 +2196,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2211,7 +2211,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2225,7 +2225,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2261,7 +2261,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15060",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollectionID", "Count", "SNFormat", "PoolSelectionCriteria", "RequestToken" ],
           "properties": {
             "SNCollectionID": {
@@ -2284,7 +2284,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2306,13 +2306,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15061",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus", "SNCollection", "ReturnedRequestToken" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution. ",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2321,7 +2321,7 @@
               "title": "OPENSCSCollectionDataType",
               "description": "Contains requested Serial Number collection with Serial Numbers of the specified state. ",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2335,7 +2335,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2371,14 +2371,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15048",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Contains a Serial Number Collection from which Serial Numbers were originally provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2392,7 +2392,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2416,7 +2416,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2438,13 +2438,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2463,14 +2463,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "description": "Contains a Serial Number Collection from which Serial Numbers were originally provided.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2484,7 +2484,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2508,7 +2508,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2530,13 +2530,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
               "description": "Returns the status of the method execution.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2555,13 +2555,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15111",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2575,7 +2575,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2598,7 +2598,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2619,12 +2619,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15112",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2643,13 +2643,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15039",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2663,7 +2663,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2686,7 +2686,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2707,12 +2707,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15040",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2731,13 +2731,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/OPENSCS-SER/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15045",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SNCollection", "PoolSelectionCriteria", "SNFormat" ],
           "properties": {
             "SNCollection": {
               "title": "OPENSCSCollectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15005",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSCollectionDataType",
               "required": [ "ID", "Description", "State", "AssociatedPoolID", "SerialNumbers" ],
               "properties": {
                 "ID": {
@@ -2751,7 +2751,7 @@
                 "State": {
                   "title": "OPENSCSSerialNumberStateEnum",
                   "description": "State of the Serial Numbers in the Collection. ",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15143",
+                  "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSerialNumberStateEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2774,7 +2774,7 @@
               "items": {
                 "title": "OPENSCSKeyValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -2795,12 +2795,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15046",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
               "title": "OPENSCSReturnEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15001",
+              "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSReturnEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2865,7 +2865,7 @@
         "items": {
           "title": "OPENSCSKeyValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15010",
+          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSKeyValueDataType",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -2915,7 +2915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OPENSCS_SER_OPENSCSSIDClassObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15102",
+    "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSIDClassObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3007,7 +3007,7 @@
         "items": {
           "title": "OPENSCSSIDClassPropertyDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15009",
+          "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSSIDClassPropertyDataType",
           "required": [ "PropertyID", "PropertyDescription", "PropertyValue", "LabelProperty" ],
           "properties": {
             "PropertyID": {
@@ -3028,7 +3028,7 @@
               "items": {
                 "title": "OPENSCSLabelPropertyDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/OPENSCS-SER/;i=15007",
+                "dov:typeRef": "org.opcfoundation.UA.OPENSCS-SER.OPENSCSLabelPropertyDataType",
                 "required": [ "PropertyID", "PropertyDescription", "PropertyValue" ],
                 "properties": {
                   "PropertyID": {

--- a/wot-codegen/opc-output-simple/Onboarding.TM.json
+++ b/wot-codegen/opc-output-simple/Onboarding.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrarAdminType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1175",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrarAdminType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35,7 +35,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -48,7 +48,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1178",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -71,7 +71,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -84,7 +84,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -118,7 +118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1259",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrarType",
     "links": [
       {
         "rel": "tm:extends",
@@ -135,7 +135,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -163,7 +163,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1506",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Managers" ],
           "properties": {
             "Managers": {
@@ -171,7 +171,7 @@
               "items": {
                 "title": "ManagerDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1495",
+                "dov:typeRef": "org.opcfoundation.UA.Onboarding.ManagerDescription",
                 "required": [ "Name", "IsRequired", "PurposeUri", "ProtocolUri", "EndpointUrls" ],
                 "properties": {
                   "Name": {
@@ -209,7 +209,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1261",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Identities", "Issuers", "Tickets" ],
           "properties": {
             "Identities": {
@@ -236,7 +236,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1262",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SelectedIdentity", "MatchingTicket", "ApplicationId", "SoftwareUpdateManager" ],
           "properties": {
             "SelectedIdentity": {
@@ -246,7 +246,7 @@
             "MatchingTicket": {
               "title": "BaseTicketType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1165",
+              "dov:typeRef": "org.opcfoundation.UA.Onboarding.BaseTicketType",
               "required": [ "ManufacturerName", "ModelName", "ModelVersion", "HardwareRevision", "SoftwareRevision", "SerialNumber", "ManufactureDate", "Authorities" ],
               "properties": {
                 "ManufacturerName": {
@@ -276,7 +276,7 @@
                   "items": {
                     "title": "CertificateAuthorityType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1164",
+                    "dov:typeRef": "org.opcfoundation.UA.Onboarding.CertificateAuthorityType",
                     "required": [ "AuthorityCertificate", "IssuerCertificates" ],
                     "properties": {
                       "AuthorityCertificate": {
@@ -301,7 +301,7 @@
             "SoftwareUpdateManager": {
               "title": "ManagerDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1495",
+              "dov:typeRef": "org.opcfoundation.UA.Onboarding.ManagerDescription",
               "required": [ "Name", "IsRequired", "PurposeUri", "ProtocolUri", "EndpointUrls" ],
               "properties": {
                 "Name": {
@@ -338,13 +338,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1264",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application" ],
           "properties": {
             "Application": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -358,7 +358,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -391,13 +391,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1508",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Application", "ProtocolUri" ],
           "properties": {
             "Application": {
               "title": "ApplicationRecordDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/GDS/;i=1",
+              "dov:typeRef": "org.opcfoundation.UA.GDS.ApplicationRecordDataType",
               "required": [ "ApplicationId", "ApplicationUri", "ApplicationType", "ApplicationNames", "ProductUri", "DiscoveryUrls", "ServerCapabilities" ],
               "properties": {
                 "ApplicationId": {
@@ -408,7 +408,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -443,7 +443,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1509",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplicationId" ],
           "properties": {
             "ApplicationId": {
@@ -463,7 +463,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Onboarding/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1504",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductInstanceUri", "Status", "SoftwareRevision" ],
           "properties": {
             "ProductInstanceUri": {
@@ -500,7 +500,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceRegistrationAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1517",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceRegistrationAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -546,7 +546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceIdentityAcceptedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1533",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceIdentityAcceptedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -617,7 +617,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Onboarding_DeviceSoftwareUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Onboarding/;i=1552",
+    "dov:typeRef": "org.opcfoundation.UA.Onboarding.DeviceSoftwareUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/OpcUaCore.TM.json
+++ b/wot-codegen/opc-output-simple/OpcUaCore.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=58",
+    "dov:typeRef": "org.opcfoundation.UA.BaseObjectType",
     "links": [
     ],
     "schemaDefinitions": {
@@ -29,7 +29,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=61",
+    "dov:typeRef": "org.opcfoundation.UA.FolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -55,7 +55,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=75",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -81,7 +81,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeEncodingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=76",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeEncodingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -107,7 +107,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ModellingRuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=77",
+    "dov:typeRef": "org.opcfoundation.UA.ModellingRuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -133,7 +133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2004",
+    "dov:typeRef": "org.opcfoundation.UA.ServerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -174,7 +174,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -229,7 +229,7 @@
       "GetMonitoredItems": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11490",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -241,7 +241,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11491",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ServerHandles", "ClientHandles" ],
           "properties": {
             "ServerHandles": {
@@ -273,12 +273,12 @@
       "RequestServerStateChange": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12884",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "State", "EstimatedReturnTime", "SecondsTillShutdown", "Reason", "Restart" ],
           "properties": {
             "State": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -311,7 +311,7 @@
       "ResendData": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12872",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -332,7 +332,7 @@
       "SetSubscriptionDurable": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "LifetimeInHours" ],
           "properties": {
             "SubscriptionId": {
@@ -349,7 +349,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RevisedLifetimeInHours" ],
           "properties": {
             "RevisedLifetimeInHours": {
@@ -395,7 +395,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -447,7 +447,7 @@
       "ServerStatus": {
         "title": "ServerStatusDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=862",
+        "dov:typeRef": "org.opcfoundation.UA.ServerStatusDataType",
         "required": [ "StartTime", "CurrentTime", "State", "BuildInfo", "SecondsTillShutdown", "ShutdownReason" ],
         "properties": {
           "StartTime": {
@@ -460,7 +460,7 @@
           },
           "State": {
             "title": "ServerState",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+            "dov:typeRef": "org.opcfoundation.UA.ServerState",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -468,7 +468,7 @@
           "BuildInfo": {
             "title": "BuildInfo",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+            "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
             "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
             "properties": {
               "ProductUri": {
@@ -514,7 +514,7 @@
       "ServerStatus_BuildInfo": {
         "title": "BuildInfo",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+        "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
         "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
         "properties": {
           "ProductUri": {
@@ -675,7 +675,7 @@
       },
       "ServerStatus_State": {
         "title": "ServerState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -721,7 +721,7 @@
         "data": {
           "title": "ServerStatusDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=862",
+          "dov:typeRef": "org.opcfoundation.UA.ServerStatusDataType",
           "required": [ "StartTime", "CurrentTime", "State", "BuildInfo", "SecondsTillShutdown", "ShutdownReason" ],
           "properties": {
             "StartTime": {
@@ -734,7 +734,7 @@
             },
             "State": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -742,7 +742,7 @@
             "BuildInfo": {
               "title": "BuildInfo",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+              "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
               "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
               "properties": {
                 "ProductUri": {
@@ -789,7 +789,7 @@
         "data": {
           "title": "BuildInfo",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=338",
+          "dov:typeRef": "org.opcfoundation.UA.BuildInfo",
           "required": [ "ProductUri", "ManufacturerName", "ProductName", "SoftwareVersion", "BuildNumber", "BuildDate" ],
           "properties": {
             "ProductUri": {
@@ -961,7 +961,7 @@
       "ServerStatus_State": {
         "data": {
           "title": "ServerState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+          "dov:typeRef": "org.opcfoundation.UA.ServerState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -986,7 +986,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2013",
+    "dov:typeRef": "org.opcfoundation.UA.ServerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1289,7 +1289,7 @@
         "items": {
           "title": "SignedSoftwareCertificate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=344",
+          "dov:typeRef": "org.opcfoundation.UA.SignedSoftwareCertificate",
           "required": [ "CertificateData", "Signature" ],
           "properties": {
             "CertificateData": {
@@ -1351,7 +1351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2020",
+    "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1408,7 +1408,7 @@
         "items": {
           "title": "SamplingIntervalDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=856",
+          "dov:typeRef": "org.opcfoundation.UA.SamplingIntervalDiagnosticsDataType",
           "required": [ "SamplingInterval", "MonitoredItemCount", "MaxMonitoredItemCount", "DisabledMonitoredItemCount" ],
           "properties": {
             "SamplingInterval": {
@@ -1444,7 +1444,7 @@
       "ServerDiagnosticsSummary": {
         "title": "ServerDiagnosticsSummaryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=859",
+        "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsSummaryDataType",
         "required": [ "ServerViewCount", "CurrentSessionCount", "CumulatedSessionCount", "SecurityRejectedSessionCount", "RejectedSessionCount", "SessionTimeoutCount", "SessionAbortCount", "CurrentSubscriptionCount", "CumulatedSubscriptionCount", "PublishingIntervalCount", "SecurityRejectedRequestsCount", "RejectedRequestsCount" ],
         "properties": {
           "ServerViewCount": {
@@ -1691,7 +1691,7 @@
         "items": {
           "title": "SubscriptionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+          "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
           "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
           "properties": {
             "SessionId": {
@@ -1863,7 +1863,7 @@
           "items": {
             "title": "SamplingIntervalDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=856",
+            "dov:typeRef": "org.opcfoundation.UA.SamplingIntervalDiagnosticsDataType",
             "required": [ "SamplingInterval", "MonitoredItemCount", "MaxMonitoredItemCount", "DisabledMonitoredItemCount" ],
             "properties": {
               "SamplingInterval": {
@@ -1900,7 +1900,7 @@
         "data": {
           "title": "ServerDiagnosticsSummaryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=859",
+          "dov:typeRef": "org.opcfoundation.UA.ServerDiagnosticsSummaryDataType",
           "required": [ "ServerViewCount", "CurrentSessionCount", "CumulatedSessionCount", "SecurityRejectedSessionCount", "RejectedSessionCount", "SessionTimeoutCount", "SessionAbortCount", "CurrentSubscriptionCount", "CumulatedSubscriptionCount", "PublishingIntervalCount", "SecurityRejectedRequestsCount", "RejectedRequestsCount" ],
           "properties": {
             "ServerViewCount": {
@@ -2160,7 +2160,7 @@
           "items": {
             "title": "SubscriptionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+            "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
             "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
             "properties": {
               "SessionId": {
@@ -2335,7 +2335,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SessionsDiagnosticsSummaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2026",
+    "dov:typeRef": "org.opcfoundation.UA.SessionsDiagnosticsSummaryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2352,7 +2352,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -2376,7 +2376,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -2419,7 +2419,7 @@
         "items": {
           "title": "SessionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+          "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
           "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
           "properties": {
             "SessionId": {
@@ -2431,7 +2431,7 @@
             "ClientDescription": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -2445,7 +2445,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -2511,7 +2511,7 @@
             "TotalRequestCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2534,7 +2534,7 @@
             "ReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2552,7 +2552,7 @@
             "HistoryReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2570,7 +2570,7 @@
             "WriteCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2588,7 +2588,7 @@
             "HistoryUpdateCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2606,7 +2606,7 @@
             "CallCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2624,7 +2624,7 @@
             "CreateMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2642,7 +2642,7 @@
             "ModifyMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2660,7 +2660,7 @@
             "SetMonitoringModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2678,7 +2678,7 @@
             "SetTriggeringCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2696,7 +2696,7 @@
             "DeleteMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2714,7 +2714,7 @@
             "CreateSubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2732,7 +2732,7 @@
             "ModifySubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2750,7 +2750,7 @@
             "SetPublishingModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2768,7 +2768,7 @@
             "PublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2786,7 +2786,7 @@
             "RepublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2804,7 +2804,7 @@
             "TransferSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2822,7 +2822,7 @@
             "DeleteSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2840,7 +2840,7 @@
             "AddNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2858,7 +2858,7 @@
             "AddReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2876,7 +2876,7 @@
             "DeleteNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2894,7 +2894,7 @@
             "DeleteReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2912,7 +2912,7 @@
             "BrowseCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2930,7 +2930,7 @@
             "BrowseNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2948,7 +2948,7 @@
             "TranslateBrowsePathsToNodeIdsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2966,7 +2966,7 @@
             "QueryFirstCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -2984,7 +2984,7 @@
             "QueryNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3002,7 +3002,7 @@
             "RegisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3020,7 +3020,7 @@
             "UnregisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -3051,7 +3051,7 @@
         "items": {
           "title": "SessionSecurityDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+          "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
           "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
           "properties": {
             "SessionId": {
@@ -3077,7 +3077,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3108,7 +3108,7 @@
           "items": {
             "title": "SessionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+            "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
             "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
             "properties": {
               "SessionId": {
@@ -3120,7 +3120,7 @@
               "ClientDescription": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -3134,7 +3134,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -3200,7 +3200,7 @@
               "TotalRequestCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3223,7 +3223,7 @@
               "ReadCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3241,7 +3241,7 @@
               "HistoryReadCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3259,7 +3259,7 @@
               "WriteCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3277,7 +3277,7 @@
               "HistoryUpdateCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3295,7 +3295,7 @@
               "CallCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3313,7 +3313,7 @@
               "CreateMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3331,7 +3331,7 @@
               "ModifyMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3349,7 +3349,7 @@
               "SetMonitoringModeCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3367,7 +3367,7 @@
               "SetTriggeringCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3385,7 +3385,7 @@
               "DeleteMonitoredItemsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3403,7 +3403,7 @@
               "CreateSubscriptionCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3421,7 +3421,7 @@
               "ModifySubscriptionCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3439,7 +3439,7 @@
               "SetPublishingModeCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3457,7 +3457,7 @@
               "PublishCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3475,7 +3475,7 @@
               "RepublishCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3493,7 +3493,7 @@
               "TransferSubscriptionsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3511,7 +3511,7 @@
               "DeleteSubscriptionsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3529,7 +3529,7 @@
               "AddNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3547,7 +3547,7 @@
               "AddReferencesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3565,7 +3565,7 @@
               "DeleteNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3583,7 +3583,7 @@
               "DeleteReferencesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3601,7 +3601,7 @@
               "BrowseCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3619,7 +3619,7 @@
               "BrowseNextCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3637,7 +3637,7 @@
               "TranslateBrowsePathsToNodeIdsCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3655,7 +3655,7 @@
               "QueryFirstCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3673,7 +3673,7 @@
               "QueryNextCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3691,7 +3691,7 @@
               "RegisterNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3709,7 +3709,7 @@
               "UnregisterNodesCount": {
                 "title": "ServiceCounterDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+                "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
                 "required": [ "TotalCount", "ErrorCount" ],
                 "properties": {
                   "TotalCount": {
@@ -3741,7 +3741,7 @@
           "items": {
             "title": "SessionSecurityDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+            "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
             "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
             "properties": {
               "SessionId": {
@@ -3767,7 +3767,7 @@
               },
               "SecurityMode": {
                 "title": "MessageSecurityMode",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -3801,7 +3801,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SessionDiagnosticsObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2029",
+    "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3812,7 +3812,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -3836,7 +3836,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -3891,7 +3891,7 @@
       "SessionDiagnostics": {
         "title": "SessionDiagnosticsDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+        "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
         "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
         "properties": {
           "SessionId": {
@@ -3903,7 +3903,7 @@
           "ClientDescription": {
             "title": "ApplicationDescription",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+            "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
             "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
             "properties": {
               "ApplicationUri": {
@@ -3917,7 +3917,7 @@
               },
               "ApplicationType": {
                 "title": "ApplicationType",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -3983,7 +3983,7 @@
           "TotalRequestCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4006,7 +4006,7 @@
           "ReadCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4024,7 +4024,7 @@
           "HistoryReadCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4042,7 +4042,7 @@
           "WriteCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4060,7 +4060,7 @@
           "HistoryUpdateCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4078,7 +4078,7 @@
           "CallCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4096,7 +4096,7 @@
           "CreateMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4114,7 +4114,7 @@
           "ModifyMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4132,7 +4132,7 @@
           "SetMonitoringModeCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4150,7 +4150,7 @@
           "SetTriggeringCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4168,7 +4168,7 @@
           "DeleteMonitoredItemsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4186,7 +4186,7 @@
           "CreateSubscriptionCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4204,7 +4204,7 @@
           "ModifySubscriptionCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4222,7 +4222,7 @@
           "SetPublishingModeCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4240,7 +4240,7 @@
           "PublishCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4258,7 +4258,7 @@
           "RepublishCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4276,7 +4276,7 @@
           "TransferSubscriptionsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4294,7 +4294,7 @@
           "DeleteSubscriptionsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4312,7 +4312,7 @@
           "AddNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4330,7 +4330,7 @@
           "AddReferencesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4348,7 +4348,7 @@
           "DeleteNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4366,7 +4366,7 @@
           "DeleteReferencesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4384,7 +4384,7 @@
           "BrowseCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4402,7 +4402,7 @@
           "BrowseNextCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4420,7 +4420,7 @@
           "TranslateBrowsePathsToNodeIdsCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4438,7 +4438,7 @@
           "QueryFirstCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4456,7 +4456,7 @@
           "QueryNextCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4474,7 +4474,7 @@
           "RegisterNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4492,7 +4492,7 @@
           "UnregisterNodesCount": {
             "title": "ServiceCounterDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+            "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
             "required": [ "TotalCount", "ErrorCount" ],
             "properties": {
               "TotalCount": {
@@ -4534,7 +4534,7 @@
       "SessionDiagnostics_AddNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4561,7 +4561,7 @@
       "SessionDiagnostics_AddReferencesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4588,7 +4588,7 @@
       "SessionDiagnostics_BrowseCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4615,7 +4615,7 @@
       "SessionDiagnostics_BrowseNextCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4642,7 +4642,7 @@
       "SessionDiagnostics_CallCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4682,7 +4682,7 @@
       "SessionDiagnostics_ClientDescription": {
         "title": "ApplicationDescription",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
         "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
         "properties": {
           "ApplicationUri": {
@@ -4696,7 +4696,7 @@
           },
           "ApplicationType": {
             "title": "ApplicationType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+            "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -4740,7 +4740,7 @@
       "SessionDiagnostics_CreateMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4767,7 +4767,7 @@
       "SessionDiagnostics_CreateSubscriptionCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4836,7 +4836,7 @@
       "SessionDiagnostics_DeleteMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4863,7 +4863,7 @@
       "SessionDiagnostics_DeleteNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4890,7 +4890,7 @@
       "SessionDiagnostics_DeleteReferencesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4917,7 +4917,7 @@
       "SessionDiagnostics_DeleteSubscriptionsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4956,7 +4956,7 @@
       "SessionDiagnostics_HistoryReadCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -4983,7 +4983,7 @@
       "SessionDiagnostics_HistoryUpdateCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5039,7 +5039,7 @@
       "SessionDiagnostics_ModifyMonitoredItemsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5066,7 +5066,7 @@
       "SessionDiagnostics_ModifySubscriptionCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5093,7 +5093,7 @@
       "SessionDiagnostics_PublishCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5120,7 +5120,7 @@
       "SessionDiagnostics_QueryFirstCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5147,7 +5147,7 @@
       "SessionDiagnostics_QueryNextCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5174,7 +5174,7 @@
       "SessionDiagnostics_ReadCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5201,7 +5201,7 @@
       "SessionDiagnostics_RegisterNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5228,7 +5228,7 @@
       "SessionDiagnostics_RepublishCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5291,7 +5291,7 @@
       "SessionDiagnostics_SetMonitoringModeCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5318,7 +5318,7 @@
       "SessionDiagnostics_SetPublishingModeCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5345,7 +5345,7 @@
       "SessionDiagnostics_SetTriggeringCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5372,7 +5372,7 @@
       "SessionDiagnostics_TotalRequestCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5399,7 +5399,7 @@
       "SessionDiagnostics_TransferSubscriptionsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5426,7 +5426,7 @@
       "SessionDiagnostics_TranslateBrowsePathsToNodeIdsCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5467,7 +5467,7 @@
       "SessionDiagnostics_UnregisterNodesCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5494,7 +5494,7 @@
       "SessionDiagnostics_WriteCount": {
         "title": "ServiceCounterDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+        "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
         "required": [ "TotalCount", "ErrorCount" ],
         "properties": {
           "TotalCount": {
@@ -5521,7 +5521,7 @@
       "SessionSecurityDiagnostics": {
         "title": "SessionSecurityDiagnosticsDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+        "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
         "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
         "properties": {
           "SessionId": {
@@ -5547,7 +5547,7 @@
           },
           "SecurityMode": {
             "title": "MessageSecurityMode",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+            "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5636,7 +5636,7 @@
       },
       "SessionSecurityDiagnostics_SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5691,7 +5691,7 @@
         "items": {
           "title": "SubscriptionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+          "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
           "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
           "properties": {
             "SessionId": {
@@ -5861,7 +5861,7 @@
         "data": {
           "title": "SessionDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=865",
+          "dov:typeRef": "org.opcfoundation.UA.SessionDiagnosticsDataType",
           "required": [ "SessionId", "SessionName", "ClientDescription", "ServerUri", "EndpointUrl", "LocaleIds", "ActualSessionTimeout", "MaxResponseMessageSize", "ClientConnectionTime", "ClientLastContactTime", "CurrentSubscriptionsCount", "CurrentMonitoredItemsCount", "CurrentPublishRequestsInQueue", "TotalRequestCount", "UnauthorizedRequestCount", "ReadCount", "HistoryReadCount", "WriteCount", "HistoryUpdateCount", "CallCount", "CreateMonitoredItemsCount", "ModifyMonitoredItemsCount", "SetMonitoringModeCount", "SetTriggeringCount", "DeleteMonitoredItemsCount", "CreateSubscriptionCount", "ModifySubscriptionCount", "SetPublishingModeCount", "PublishCount", "RepublishCount", "TransferSubscriptionsCount", "DeleteSubscriptionsCount", "AddNodesCount", "AddReferencesCount", "DeleteNodesCount", "DeleteReferencesCount", "BrowseCount", "BrowseNextCount", "TranslateBrowsePathsToNodeIdsCount", "QueryFirstCount", "QueryNextCount", "RegisterNodesCount", "UnregisterNodesCount" ],
           "properties": {
             "SessionId": {
@@ -5873,7 +5873,7 @@
             "ClientDescription": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -5887,7 +5887,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -5953,7 +5953,7 @@
             "TotalRequestCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -5976,7 +5976,7 @@
             "ReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -5994,7 +5994,7 @@
             "HistoryReadCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6012,7 +6012,7 @@
             "WriteCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6030,7 +6030,7 @@
             "HistoryUpdateCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6048,7 +6048,7 @@
             "CallCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6066,7 +6066,7 @@
             "CreateMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6084,7 +6084,7 @@
             "ModifyMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6102,7 +6102,7 @@
             "SetMonitoringModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6120,7 +6120,7 @@
             "SetTriggeringCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6138,7 +6138,7 @@
             "DeleteMonitoredItemsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6156,7 +6156,7 @@
             "CreateSubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6174,7 +6174,7 @@
             "ModifySubscriptionCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6192,7 +6192,7 @@
             "SetPublishingModeCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6210,7 +6210,7 @@
             "PublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6228,7 +6228,7 @@
             "RepublishCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6246,7 +6246,7 @@
             "TransferSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6264,7 +6264,7 @@
             "DeleteSubscriptionsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6282,7 +6282,7 @@
             "AddNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6300,7 +6300,7 @@
             "AddReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6318,7 +6318,7 @@
             "DeleteNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6336,7 +6336,7 @@
             "DeleteReferencesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6354,7 +6354,7 @@
             "BrowseCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6372,7 +6372,7 @@
             "BrowseNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6390,7 +6390,7 @@
             "TranslateBrowsePathsToNodeIdsCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6408,7 +6408,7 @@
             "QueryFirstCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6426,7 +6426,7 @@
             "QueryNextCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6444,7 +6444,7 @@
             "RegisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6462,7 +6462,7 @@
             "UnregisterNodesCount": {
               "title": "ServiceCounterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+              "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
               "required": [ "TotalCount", "ErrorCount" ],
               "properties": {
                 "TotalCount": {
@@ -6506,7 +6506,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6534,7 +6534,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6562,7 +6562,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6590,7 +6590,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6618,7 +6618,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6660,7 +6660,7 @@
         "data": {
           "title": "ApplicationDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+          "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
           "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
           "properties": {
             "ApplicationUri": {
@@ -6674,7 +6674,7 @@
             },
             "ApplicationType": {
               "title": "ApplicationType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6720,7 +6720,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6748,7 +6748,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6821,7 +6821,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6849,7 +6849,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6877,7 +6877,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6905,7 +6905,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6946,7 +6946,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -6974,7 +6974,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7033,7 +7033,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7061,7 +7061,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7089,7 +7089,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7117,7 +7117,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7145,7 +7145,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7173,7 +7173,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7201,7 +7201,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7229,7 +7229,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7296,7 +7296,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7324,7 +7324,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7352,7 +7352,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7380,7 +7380,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7408,7 +7408,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7436,7 +7436,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7479,7 +7479,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7507,7 +7507,7 @@
         "data": {
           "title": "ServiceCounterDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=871",
+          "dov:typeRef": "org.opcfoundation.UA.ServiceCounterDataType",
           "required": [ "TotalCount", "ErrorCount" ],
           "properties": {
             "TotalCount": {
@@ -7535,7 +7535,7 @@
         "data": {
           "title": "SessionSecurityDiagnosticsDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=868",
+          "dov:typeRef": "org.opcfoundation.UA.SessionSecurityDiagnosticsDataType",
           "required": [ "SessionId", "ClientUserIdOfSession", "ClientUserIdHistory", "AuthenticationMechanism", "Encoding", "TransportProtocol", "SecurityMode", "SecurityPolicyUri", "ClientCertificate" ],
           "properties": {
             "SessionId": {
@@ -7561,7 +7561,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7656,7 +7656,7 @@
       "SessionSecurityDiagnostics_SecurityMode": {
         "data": {
           "title": "MessageSecurityMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+          "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7715,7 +7715,7 @@
           "items": {
             "title": "SubscriptionDiagnosticsDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=874",
+            "dov:typeRef": "org.opcfoundation.UA.SubscriptionDiagnosticsDataType",
             "required": [ "SessionId", "SubscriptionId", "Priority", "PublishingInterval", "MaxKeepAliveCount", "MaxLifetimeCount", "MaxNotificationsPerPublish", "PublishingEnabled", "ModifyCount", "EnableCount", "DisableCount", "RepublishRequestCount", "RepublishMessageRequestCount", "RepublishMessageCount", "TransferRequestCount", "TransferredToAltClientCount", "TransferredToSameClientCount", "PublishRequestCount", "DataChangeNotificationsCount", "EventNotificationsCount", "NotificationsCount", "LatePublishRequestCount", "CurrentKeepAliveCount", "CurrentLifetimeCount", "UnacknowledgedMessageCount", "DiscardedMessageCount", "MonitoredItemCount", "DisabledMonitoredItemCount", "MonitoringQueueOverflowCount", "NextSequenceNumber", "EventQueueOverflowCount" ],
             "properties": {
               "SessionId": {
@@ -7890,7 +7890,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_VendorServerInfoType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2033",
+    "dov:typeRef": "org.opcfoundation.UA.VendorServerInfoType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7916,7 +7916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2034",
+    "dov:typeRef": "org.opcfoundation.UA.ServerRedundancyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7927,7 +7927,7 @@
     "schemaDefinitions": {
       "RedundancySupport": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=851",
+        "dov:typeRef": "org.opcfoundation.UA.RedundancySupport",
         "const": {
           "None": 0,
           "Cold": 1,
@@ -7959,7 +7959,7 @@
       },
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -8010,7 +8010,7 @@
     "properties": {
       "RedundancySupport": {
         "title": "RedundancySupport",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=851",
+        "dov:typeRef": "org.opcfoundation.UA.RedundancySupport",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8028,7 +8028,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -8041,7 +8041,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8070,7 +8070,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransparentRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2036",
+    "dov:typeRef": "org.opcfoundation.UA.TransparentRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8082,7 +8082,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -8147,7 +8147,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -8160,7 +8160,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8189,7 +8189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2039",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8237,7 +8237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentNetworkRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11945",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentNetworkRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8263,7 +8263,7 @@
         "items": {
           "title": "NetworkGroupDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11944",
+          "dov:typeRef": "org.opcfoundation.UA.NetworkGroupDataType",
           "required": [ "ServerUri", "NetworkPaths" ],
           "properties": {
             "ServerUri": {
@@ -8274,7 +8274,7 @@
               "items": {
                 "title": "EndpointUrlListDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11943",
+                "dov:typeRef": "org.opcfoundation.UA.EndpointUrlListDataType",
                 "required": [ "EndpointUrlList" ],
                 "properties": {
                   "EndpointUrlList": {
@@ -8310,7 +8310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonTransparentBackupRedundancyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32411",
+    "dov:typeRef": "org.opcfoundation.UA.NonTransparentBackupRedundancyType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8322,7 +8322,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -8362,7 +8362,7 @@
       },
       "RedundantServerMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32417",
+        "dov:typeRef": "org.opcfoundation.UA.RedundantServerMode",
         "const": {
           "PrimaryWithBackup": 0,
           "PrimaryOnly": 1,
@@ -8406,7 +8406,7 @@
     "properties": {
       "Mode": {
         "title": "RedundantServerMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32417",
+        "dov:typeRef": "org.opcfoundation.UA.RedundantServerMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8424,7 +8424,7 @@
         "items": {
           "title": "RedundantServerDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=853",
+          "dov:typeRef": "org.opcfoundation.UA.RedundantServerDataType",
           "required": [ "ServerId", "ServiceLevel", "ServerState" ],
           "properties": {
             "ServerId": {
@@ -8437,7 +8437,7 @@
             },
             "ServerState": {
               "title": "ServerState",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+              "dov:typeRef": "org.opcfoundation.UA.ServerState",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8466,7 +8466,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OperationLimitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11564",
+    "dov:typeRef": "org.opcfoundation.UA.OperationLimitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8655,7 +8655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11575",
+    "dov:typeRef": "org.opcfoundation.UA.FileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8676,7 +8676,7 @@
       "Close": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11584",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -8697,7 +8697,7 @@
       "GetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11591",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -8709,7 +8709,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11592",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Position" ],
           "properties": {
             "Position": {
@@ -8730,7 +8730,7 @@
       "Open": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11581",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
@@ -8742,7 +8742,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11582",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -8763,7 +8763,7 @@
       "Read": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11586",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Length" ],
           "properties": {
             "FileHandle": {
@@ -8780,7 +8780,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11587",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Data" ],
           "properties": {
             "Data": {
@@ -8800,7 +8800,7 @@
       "SetPosition": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11594",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Position" ],
           "properties": {
             "FileHandle": {
@@ -8826,7 +8826,7 @@
       "Write": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11589",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "Data" ],
           "properties": {
             "FileHandle": {
@@ -8947,7 +8947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AddressSpaceFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11595",
+    "dov:typeRef": "org.opcfoundation.UA.AddressSpaceFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8982,7 +8982,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NamespaceMetadataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11616",
+    "dov:typeRef": "org.opcfoundation.UA.NamespaceMetadataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8999,7 +8999,7 @@
     "schemaDefinitions": {
       "IdType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=256",
+        "dov:typeRef": "org.opcfoundation.UA.IdType",
         "const": {
           "Numeric": 0,
           "String": 1,
@@ -9023,7 +9023,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -9099,7 +9099,7 @@
       },
       "AccessRestrictionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=95",
+        "dov:typeRef": "org.opcfoundation.UA.AccessRestrictionType",
         "const": {
           "SigningRequired": 0,
           "EncryptionRequired": 1,
@@ -9147,7 +9147,7 @@
       },
       "DefaultAccessRestrictions": {
         "title": "AccessRestrictionType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=95",
+        "dov:typeRef": "org.opcfoundation.UA.AccessRestrictionType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9165,7 +9165,7 @@
         "items": {
           "title": "RolePermissionType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+          "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
           "required": [ "RoleId", "Permissions" ],
           "properties": {
             "RoleId": {
@@ -9173,7 +9173,7 @@
             },
             "Permissions": {
               "title": "PermissionType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+              "dov:typeRef": "org.opcfoundation.UA.PermissionType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9194,7 +9194,7 @@
         "items": {
           "title": "RolePermissionType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+          "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
           "required": [ "RoleId", "Permissions" ],
           "properties": {
             "RoleId": {
@@ -9202,7 +9202,7 @@
             },
             "Permissions": {
               "title": "PermissionType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+              "dov:typeRef": "org.opcfoundation.UA.PermissionType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9278,7 +9278,7 @@
         "type": "array",
         "items": {
           "title": "IdType",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=256",
+          "dov:typeRef": "org.opcfoundation.UA.IdType",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -9330,7 +9330,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NamespacesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11645",
+    "dov:typeRef": "org.opcfoundation.UA.NamespacesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9362,7 +9362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2041",
+    "dov:typeRef": "org.opcfoundation.UA.BaseEventType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9458,7 +9458,7 @@
       "LocalTime": {
         "title": "TimeZoneDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -9562,7 +9562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2052",
+    "dov:typeRef": "org.opcfoundation.UA.AuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9663,7 +9663,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditSecurityEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2058",
+    "dov:typeRef": "org.opcfoundation.UA.AuditSecurityEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9708,7 +9708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditChannelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2059",
+    "dov:typeRef": "org.opcfoundation.UA.AuditChannelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9753,7 +9753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditOpenSecureChannelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2060",
+    "dov:typeRef": "org.opcfoundation.UA.AuditOpenSecureChannelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9765,7 +9765,7 @@
     "schemaDefinitions": {
       "SecurityTokenRequestType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=315",
+        "dov:typeRef": "org.opcfoundation.UA.SecurityTokenRequestType",
         "const": {
           "Issue": 0,
           "Renew": 1
@@ -9781,7 +9781,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -9863,7 +9863,7 @@
       },
       "RequestType": {
         "title": "SecurityTokenRequestType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=315",
+        "dov:typeRef": "org.opcfoundation.UA.SecurityTokenRequestType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9878,7 +9878,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -9915,7 +9915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2069",
+    "dov:typeRef": "org.opcfoundation.UA.AuditSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -9960,7 +9960,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCreateSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2071",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCreateSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10040,7 +10040,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUrlMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2748",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUrlMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10085,7 +10085,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditActivateSessionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2075",
+    "dov:typeRef": "org.opcfoundation.UA.AuditActivateSessionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10111,7 +10111,7 @@
         "items": {
           "title": "SignedSoftwareCertificate",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=344",
+          "dov:typeRef": "org.opcfoundation.UA.SignedSoftwareCertificate",
           "required": [ "CertificateData", "Signature" ],
           "properties": {
             "CertificateData": {
@@ -10161,7 +10161,7 @@
       "UserIdentityToken": {
         "title": "UserIdentityToken",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=316",
+        "dov:typeRef": "org.opcfoundation.UA.UserIdentityToken",
         "required": [ "PolicyId" ],
         "properties": {
           "PolicyId": {
@@ -10190,7 +10190,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCancelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2078",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCancelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10237,7 +10237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2080",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10283,7 +10283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateDataMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2082",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateDataMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10339,7 +10339,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateExpiredEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2085",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateExpiredEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10366,7 +10366,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateInvalidEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2086",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateInvalidEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10393,7 +10393,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateUntrustedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2087",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateUntrustedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10420,7 +10420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateRevokedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2088",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateRevokedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10447,7 +10447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditCertificateMismatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2089",
+    "dov:typeRef": "org.opcfoundation.UA.AuditCertificateMismatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10474,7 +10474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditNodeManagementEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2090",
+    "dov:typeRef": "org.opcfoundation.UA.AuditNodeManagementEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10501,7 +10501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditAddNodesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2091",
+    "dov:typeRef": "org.opcfoundation.UA.AuditAddNodesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10513,7 +10513,7 @@
     "schemaDefinitions": {
       "NodeClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+        "dov:typeRef": "org.opcfoundation.UA.NodeClass",
         "const": {
           "Unspecified": 0,
           "Object": 1,
@@ -10580,7 +10580,7 @@
         "items": {
           "title": "AddNodesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=376",
+          "dov:typeRef": "org.opcfoundation.UA.AddNodesItem",
           "required": [ "ParentNodeId", "ReferenceTypeId", "RequestedNewNodeId", "BrowseName", "NodeClass", "NodeAttributes", "TypeDefinition" ],
           "properties": {
             "ParentNodeId": {
@@ -10597,7 +10597,7 @@
             },
             "NodeClass": {
               "title": "NodeClass",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+              "dov:typeRef": "org.opcfoundation.UA.NodeClass",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10632,7 +10632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditDeleteNodesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2093",
+    "dov:typeRef": "org.opcfoundation.UA.AuditDeleteNodesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10658,7 +10658,7 @@
         "items": {
           "title": "DeleteNodesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=382",
+          "dov:typeRef": "org.opcfoundation.UA.DeleteNodesItem",
           "required": [ "NodeId", "DeleteTargetReferences" ],
           "properties": {
             "NodeId": {
@@ -10691,7 +10691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditAddReferencesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2095",
+    "dov:typeRef": "org.opcfoundation.UA.AuditAddReferencesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10703,7 +10703,7 @@
     "schemaDefinitions": {
       "NodeClass": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+        "dov:typeRef": "org.opcfoundation.UA.NodeClass",
         "const": {
           "Unspecified": 0,
           "Object": 1,
@@ -10770,7 +10770,7 @@
         "items": {
           "title": "AddReferencesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=379",
+          "dov:typeRef": "org.opcfoundation.UA.AddReferencesItem",
           "required": [ "SourceNodeId", "ReferenceTypeId", "IsForward", "TargetServerUri", "TargetNodeId", "TargetNodeClass" ],
           "properties": {
             "SourceNodeId": {
@@ -10790,7 +10790,7 @@
             },
             "TargetNodeClass": {
               "title": "NodeClass",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=257",
+              "dov:typeRef": "org.opcfoundation.UA.NodeClass",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10819,7 +10819,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditDeleteReferencesEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2097",
+    "dov:typeRef": "org.opcfoundation.UA.AuditDeleteReferencesEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10845,7 +10845,7 @@
         "items": {
           "title": "DeleteReferencesItem",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=385",
+          "dov:typeRef": "org.opcfoundation.UA.DeleteReferencesItem",
           "required": [ "SourceNodeId", "ReferenceTypeId", "IsForward", "TargetNodeId", "DeleteBidirectional" ],
           "properties": {
             "SourceNodeId": {
@@ -10887,7 +10887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2099",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10914,7 +10914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditWriteUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2100",
+    "dov:typeRef": "org.opcfoundation.UA.AuditWriteUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -10996,7 +10996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2104",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11041,7 +11041,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateMethodEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2127",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateMethodEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11127,7 +11127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2130",
+    "dov:typeRef": "org.opcfoundation.UA.SystemEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11154,7 +11154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DeviceFailureEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2131",
+    "dov:typeRef": "org.opcfoundation.UA.DeviceFailureEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11181,7 +11181,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemStatusChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11446",
+    "dov:typeRef": "org.opcfoundation.UA.SystemStatusChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11193,7 +11193,7 @@
     "schemaDefinitions": {
       "ServerState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "const": {
           "Running": 0,
           "Failed": 1,
@@ -11244,7 +11244,7 @@
     "properties": {
       "SystemState": {
         "title": "ServerState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=852",
+        "dov:typeRef": "org.opcfoundation.UA.ServerState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -11270,7 +11270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseModelChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2132",
+    "dov:typeRef": "org.opcfoundation.UA.BaseModelChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11297,7 +11297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_GeneralModelChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2133",
+    "dov:typeRef": "org.opcfoundation.UA.GeneralModelChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11323,7 +11323,7 @@
         "items": {
           "title": "ModelChangeStructureDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=877",
+          "dov:typeRef": "org.opcfoundation.UA.ModelChangeStructureDataType",
           "required": [ "Affected", "AffectedType", "Verb" ],
           "properties": {
             "Affected": {
@@ -11361,7 +11361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SemanticChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2738",
+    "dov:typeRef": "org.opcfoundation.UA.SemanticChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11387,7 +11387,7 @@
         "items": {
           "title": "SemanticChangeStructureDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=897",
+          "dov:typeRef": "org.opcfoundation.UA.SemanticChangeStructureDataType",
           "required": [ "Affected", "AffectedType" ],
           "properties": {
             "Affected": {
@@ -11420,7 +11420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EventQueueOverflowEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3035",
+    "dov:typeRef": "org.opcfoundation.UA.EventQueueOverflowEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11447,7 +11447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgressEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11436",
+    "dov:typeRef": "org.opcfoundation.UA.ProgressEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11506,7 +11506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditClientEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23606",
+    "dov:typeRef": "org.opcfoundation.UA.AuditClientEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11551,7 +11551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditClientUpdateMethodResultEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23926",
+    "dov:typeRef": "org.opcfoundation.UA.AuditClientUpdateMethodResultEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -11648,7 +11648,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AggregateFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2340",
+    "dov:typeRef": "org.opcfoundation.UA.AggregateFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11674,7 +11674,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataTypeRefinementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19820",
+    "dov:typeRef": "org.opcfoundation.UA.DataTypeRefinementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11701,7 +11701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubtypeRestrictionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19822",
+    "dov:typeRef": "org.opcfoundation.UA.SubtypeRestrictionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11728,7 +11728,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2299",
+    "dov:typeRef": "org.opcfoundation.UA.StateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11813,7 +11813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FiniteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2771",
+    "dov:typeRef": "org.opcfoundation.UA.FiniteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -11955,7 +11955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2307",
+    "dov:typeRef": "org.opcfoundation.UA.StateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12001,7 +12001,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InitialStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2309",
+    "dov:typeRef": "org.opcfoundation.UA.InitialStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12027,7 +12027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2310",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12073,7 +12073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ChoiceStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15109",
+    "dov:typeRef": "org.opcfoundation.UA.ChoiceStateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12100,7 +12100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2311",
+    "dov:typeRef": "org.opcfoundation.UA.TransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12208,7 +12208,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditUpdateStateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2315",
+    "dov:typeRef": "org.opcfoundation.UA.AuditUpdateStateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -12266,7 +12266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileDirectoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13353",
+    "dov:typeRef": "org.opcfoundation.UA.FileDirectoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12280,7 +12280,7 @@
       "CreateDirectory": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13388",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DirectoryName" ],
           "properties": {
             "DirectoryName": {
@@ -12290,7 +12290,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DirectoryNodeId" ],
           "properties": {
             "DirectoryNodeId": {
@@ -12309,7 +12309,7 @@
       "CreateFile": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13391",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileName", "RequestFileOpen" ],
           "properties": {
             "FileName": {
@@ -12322,7 +12322,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13392",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -12346,7 +12346,7 @@
       "DeleteFileSystemObject": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13394",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToDelete" ],
           "properties": {
             "ObjectToDelete": {
@@ -12365,7 +12365,7 @@
       "MoveOrCopy": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13396",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ObjectToMoveOrCopy", "TargetDirectory", "CreateCopy", "NewName" ],
           "properties": {
             "ObjectToMoveOrCopy": {
@@ -12384,7 +12384,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13397",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewNodeId" ],
           "properties": {
             "NewNodeId": {
@@ -12415,7 +12415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TemporaryFileTransferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15744",
+    "dov:typeRef": "org.opcfoundation.UA.TemporaryFileTransferType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12443,7 +12443,7 @@
       "CloseAndCommit": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15752",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -12455,7 +12455,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15753",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CompletionStateMachine" ],
           "properties": {
             "CompletionStateMachine": {
@@ -12474,7 +12474,7 @@
       "GenerateFileForRead": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15747",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -12484,7 +12484,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15748",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle", "CompletionStateMachine" ],
           "properties": {
             "FileNodeId": {
@@ -12511,7 +12511,7 @@
       "GenerateFileForWrite": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16359",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GenerateOptions" ],
           "properties": {
             "GenerateOptions": {
@@ -12521,7 +12521,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15750",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileNodeId", "FileHandle" ],
           "properties": {
             "FileNodeId": {
@@ -12569,7 +12569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_FileTransferStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15803",
+    "dov:typeRef": "org.opcfoundation.UA.FileTransferStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12688,7 +12688,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15607",
+    "dov:typeRef": "org.opcfoundation.UA.RoleSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12708,7 +12708,7 @@
       "AddRole": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15998",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RoleName", "NamespaceUri" ],
           "properties": {
             "RoleName": {
@@ -12721,7 +12721,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15999",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RoleNodeId" ],
           "properties": {
             "RoleNodeId": {
@@ -12740,7 +12740,7 @@
       "RemoveRole": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16001",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RoleNodeId" ],
           "properties": {
             "RoleNodeId": {
@@ -12771,7 +12771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15620",
+    "dov:typeRef": "org.opcfoundation.UA.RoleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12782,7 +12782,7 @@
     "schemaDefinitions": {
       "IdentityCriteriaType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+        "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
         "const": {
           "UserName": 1,
           "Thumbprint": 2,
@@ -12835,7 +12835,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -12874,7 +12874,7 @@
       "AddApplication": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -12893,13 +12893,13 @@
       "AddEndpoint": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16181",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Endpoint" ],
           "properties": {
             "Endpoint": {
               "title": "EndpointType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointType",
               "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
               "properties": {
                 "EndpointUrl": {
@@ -12907,7 +12907,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -12933,18 +12933,18 @@
       "AddIdentity": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15625",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Rule" ],
           "properties": {
             "Rule": {
               "title": "IdentityMappingRuleType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
               "required": [ "CriteriaType", "Criteria" ],
               "properties": {
                 "CriteriaType": {
                   "title": "IdentityCriteriaType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+                  "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -12967,7 +12967,7 @@
       "RemoveApplication": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16179",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri" ],
           "properties": {
             "ApplicationUri": {
@@ -12986,13 +12986,13 @@
       "RemoveEndpoint": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16183",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Endpoint" ],
           "properties": {
             "Endpoint": {
               "title": "EndpointType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+              "dov:typeRef": "org.opcfoundation.UA.EndpointType",
               "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
               "properties": {
                 "EndpointUrl": {
@@ -13000,7 +13000,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -13026,18 +13026,18 @@
       "RemoveIdentity": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15627",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Rule" ],
           "properties": {
             "Rule": {
               "title": "IdentityMappingRuleType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
               "required": [ "CriteriaType", "Criteria" ],
               "properties": {
                 "CriteriaType": {
                   "title": "IdentityCriteriaType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+                  "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -13105,7 +13105,7 @@
         "items": {
           "title": "EndpointType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15528",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointType",
           "required": [ "EndpointUrl", "SecurityMode", "SecurityPolicyUri", "TransportProfileUri" ],
           "properties": {
             "EndpointUrl": {
@@ -13113,7 +13113,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -13156,12 +13156,12 @@
         "items": {
           "title": "IdentityMappingRuleType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15634",
+          "dov:typeRef": "org.opcfoundation.UA.IdentityMappingRuleType",
           "required": [ "CriteriaType", "Criteria" ],
           "properties": {
             "CriteriaType": {
               "title": "IdentityCriteriaType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15632",
+              "dov:typeRef": "org.opcfoundation.UA.IdentityCriteriaType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -13193,7 +13193,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RoleMappingRuleChangedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17641",
+    "dov:typeRef": "org.opcfoundation.UA.RoleMappingRuleChangedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -13220,7 +13220,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17589",
+    "dov:typeRef": "org.opcfoundation.UA.DictionaryEntryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13252,7 +13252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DictionaryFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17591",
+    "dov:typeRef": "org.opcfoundation.UA.DictionaryFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13290,7 +13290,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IrdiDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17598",
+    "dov:typeRef": "org.opcfoundation.UA.IrdiDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13317,7 +13317,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UriDictionaryEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17600",
+    "dov:typeRef": "org.opcfoundation.UA.UriDictionaryEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13344,7 +13344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17602",
+    "dov:typeRef": "org.opcfoundation.UA.BaseInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13370,7 +13370,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IOrderedObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23513",
+    "dov:typeRef": "org.opcfoundation.UA.IOrderedObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13414,7 +13414,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OrderedListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23518",
+    "dov:typeRef": "org.opcfoundation.UA.OrderedListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13459,7 +13459,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SyntaxReferenceEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32439",
+    "dov:typeRef": "org.opcfoundation.UA.SyntaxReferenceEntryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13504,7 +13504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32442",
+    "dov:typeRef": "org.opcfoundation.UA.UnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13570,7 +13570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32447",
+    "dov:typeRef": "org.opcfoundation.UA.ServerUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13593,7 +13593,7 @@
     "schemaDefinitions": {
       "ConversionLimitEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32436",
+        "dov:typeRef": "org.opcfoundation.UA.ConversionLimitEnum",
         "const": {
           "NoConversion": 0,
           "Limited": 1,
@@ -13624,7 +13624,7 @@
     "properties": {
       "ConversionLimit": {
         "title": "ConversionLimitEnum",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32436",
+        "dov:typeRef": "org.opcfoundation.UA.ConversionLimitEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13650,7 +13650,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlternativeUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32467",
+    "dov:typeRef": "org.opcfoundation.UA.AlternativeUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13673,7 +13673,7 @@
       "LinearConversion": {
         "title": "LinearConversionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32435",
+        "dov:typeRef": "org.opcfoundation.UA.LinearConversionDataType",
         "required": [ "InitialAddend", "Multiplicand", "Divisor", "FinalAddend" ],
         "properties": {
           "InitialAddend": {
@@ -13741,7 +13741,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_QuantityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32475",
+    "dov:typeRef": "org.opcfoundation.UA.QuantityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13773,7 +13773,7 @@
         "items": {
           "title": "AnnotationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32434",
+          "dov:typeRef": "org.opcfoundation.UA.AnnotationDataType",
           "required": [ "Annotation", "Discipline", "Uri" ],
           "properties": {
             "Annotation": {
@@ -13810,7 +13810,7 @@
       "Dimension": {
         "title": "QuantityDimension",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32438",
+        "dov:typeRef": "org.opcfoundation.UA.QuantityDimension",
         "required": [ "MassExponent", "LengthExponent", "TimeExponent", "ElectricCurrentExponent", "AmountOfSubstanceExponent", "LuminousIntensityExponent", "AbsoluteTemperatureExponent", "DimensionlessExponent" ],
         "properties": {
           "MassExponent": {
@@ -13887,7 +13887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2782",
+    "dov:typeRef": "org.opcfoundation.UA.ConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -13914,7 +13914,7 @@
       "AddComment": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -13939,7 +13939,7 @@
       "ConditionRefresh": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId" ],
           "properties": {
             "SubscriptionId": {
@@ -13961,7 +13961,7 @@
       "ConditionRefresh2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12913",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscriptionId", "MonitoredItemId" ],
           "properties": {
             "SubscriptionId": {
@@ -14220,7 +14220,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DialogConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2830",
+    "dov:typeRef": "org.opcfoundation.UA.DialogConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14247,7 +14247,7 @@
       "Respond": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9070",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SelectedResponse" ],
           "properties": {
             "SelectedResponse": {
@@ -14268,7 +14268,7 @@
       "Respond2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24313",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SelectedResponse", "Comment" ],
           "properties": {
             "SelectedResponse": {
@@ -14427,7 +14427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2881",
+    "dov:typeRef": "org.opcfoundation.UA.AcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14454,7 +14454,7 @@
       "Acknowledge": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -14479,7 +14479,7 @@
       "Confirm": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9114",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "EventId", "Comment" ],
           "properties": {
             "EventId": {
@@ -14585,7 +14585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2915",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -14624,7 +14624,7 @@
       "GetGroupMemberships": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25154",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Groups" ],
           "properties": {
             "Groups": {
@@ -14655,7 +14655,7 @@
       "PlaceInService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24323",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14683,7 +14683,7 @@
       "RemoveFromService2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24321",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14711,7 +14711,7 @@
       "Reset2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24325",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14748,7 +14748,7 @@
       "Suppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24317",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -14776,7 +14776,7 @@
       "Unsuppress2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24319",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15101,7 +15101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16405",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15127,7 +15127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmSuppressionGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32064",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmSuppressionGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -15154,7 +15154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ShelvedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2929",
+    "dov:typeRef": "org.opcfoundation.UA.ShelvedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15238,7 +15238,7 @@
       "OneShotShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24761",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15257,7 +15257,7 @@
       "TimedShelve": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2991",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime" ],
           "properties": {
             "ShelvingTime": {
@@ -15277,7 +15277,7 @@
       "TimedShelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24757",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ShelvingTime", "Comment" ],
           "properties": {
             "ShelvingTime": {
@@ -15309,7 +15309,7 @@
       "Unshelve2": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Comment" ],
           "properties": {
             "Comment": {
@@ -15352,7 +15352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2955",
+    "dov:typeRef": "org.opcfoundation.UA.LimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15594,7 +15594,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9318",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15668,7 +15668,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9341",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15736,7 +15736,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLimitAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9906",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLimitAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15890,7 +15890,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveLevelAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10060",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveLevelAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15917,7 +15917,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveLevelAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9482",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveLevelAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -15944,7 +15944,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10368",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16000,7 +16000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NonExclusiveRateOfChangeAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10214",
+    "dov:typeRef": "org.opcfoundation.UA.NonExclusiveRateOfChangeAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16024,7 +16024,7 @@
       "EngineeringUnits": {
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -16064,7 +16064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveDeviationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9764",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveDeviationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16120,7 +16120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExclusiveRateOfChangeAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=9623",
+    "dov:typeRef": "org.opcfoundation.UA.ExclusiveRateOfChangeAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16144,7 +16144,7 @@
       "EngineeringUnits": {
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -16184,7 +16184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscreteAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10523",
+    "dov:typeRef": "org.opcfoundation.UA.DiscreteAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16211,7 +16211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_OffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10637",
+    "dov:typeRef": "org.opcfoundation.UA.OffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16256,7 +16256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11753",
+    "dov:typeRef": "org.opcfoundation.UA.SystemOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16283,7 +16283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TripAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=10751",
+    "dov:typeRef": "org.opcfoundation.UA.TripAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16310,7 +16310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_InstrumentDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18347",
+    "dov:typeRef": "org.opcfoundation.UA.InstrumentDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16337,7 +16337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemDiagnosticAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18496",
+    "dov:typeRef": "org.opcfoundation.UA.SystemDiagnosticAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16364,7 +16364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateExpirationAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13225",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateExpirationAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16445,7 +16445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DiscrepancyAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17080",
+    "dov:typeRef": "org.opcfoundation.UA.DiscrepancyAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16515,7 +16515,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11163",
+    "dov:typeRef": "org.opcfoundation.UA.BaseConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16541,7 +16541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProcessConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11164",
+    "dov:typeRef": "org.opcfoundation.UA.ProcessConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16567,7 +16567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_MaintenanceConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11165",
+    "dov:typeRef": "org.opcfoundation.UA.MaintenanceConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16593,7 +16593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SystemConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11166",
+    "dov:typeRef": "org.opcfoundation.UA.SystemConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16619,7 +16619,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SafetyConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17218",
+    "dov:typeRef": "org.opcfoundation.UA.SafetyConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16645,7 +16645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HighlyManagedAlarmConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17219",
+    "dov:typeRef": "org.opcfoundation.UA.HighlyManagedAlarmConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16671,7 +16671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrainingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17220",
+    "dov:typeRef": "org.opcfoundation.UA.TrainingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16697,7 +16697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StatisticalConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18665",
+    "dov:typeRef": "org.opcfoundation.UA.StatisticalConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16723,7 +16723,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TestingConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17221",
+    "dov:typeRef": "org.opcfoundation.UA.TestingConditionClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16749,7 +16749,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2790",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16776,7 +16776,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionEnableEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2803",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionEnableEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16803,7 +16803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionCommentEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2829",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionCommentEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16860,7 +16860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionRespondEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8927",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionRespondEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16907,7 +16907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionAcknowledgeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8944",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionAcknowledgeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -16964,7 +16964,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionConfirmEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8961",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionConfirmEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17021,7 +17021,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionShelvingEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11093",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionShelvingEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17067,7 +17067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionSuppressionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17225",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionSuppressionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17094,7 +17094,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionSilenceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17242",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionSilenceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17121,7 +17121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionResetEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15013",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionResetEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17148,7 +17148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditConditionOutOfServiceEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17259",
+    "dov:typeRef": "org.opcfoundation.UA.AuditConditionOutOfServiceEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17175,7 +17175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshStartEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2787",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshStartEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17202,7 +17202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2788",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17229,7 +17229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RefreshRequiredEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2789",
+    "dov:typeRef": "org.opcfoundation.UA.RefreshRequiredEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -17256,7 +17256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AlarmMetricsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17279",
+    "dov:typeRef": "org.opcfoundation.UA.AlarmMetricsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17514,7 +17514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2391",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -17766,7 +17766,7 @@
       "ProgramDiagnostic": {
         "title": "ProgramDiagnostic2DataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24033",
+        "dov:typeRef": "org.opcfoundation.UA.ProgramDiagnostic2DataType",
         "required": [ "CreateSessionId", "CreateClientName", "InvocationCreationTime", "LastTransitionTime", "LastMethodCall", "LastMethodSessionId", "LastMethodInputArguments", "LastMethodOutputArguments", "LastMethodInputValues", "LastMethodOutputValues", "LastMethodCallTime", "LastMethodReturnStatus" ],
         "properties": {
           "CreateSessionId": {
@@ -17794,7 +17794,7 @@
             "items": {
               "title": "Argument",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+              "dov:typeRef": "org.opcfoundation.UA.Argument",
               "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
               "properties": {
                 "Name": {
@@ -17827,7 +17827,7 @@
             "items": {
               "title": "Argument",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+              "dov:typeRef": "org.opcfoundation.UA.Argument",
               "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
               "properties": {
                 "Name": {
@@ -17954,7 +17954,7 @@
         "items": {
           "title": "Argument",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+          "dov:typeRef": "org.opcfoundation.UA.Argument",
           "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
           "properties": {
             "Name": {
@@ -18012,7 +18012,7 @@
         "items": {
           "title": "Argument",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+          "dov:typeRef": "org.opcfoundation.UA.Argument",
           "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
           "properties": {
             "Name": {
@@ -18132,7 +18132,7 @@
         "data": {
           "title": "ProgramDiagnostic2DataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24033",
+          "dov:typeRef": "org.opcfoundation.UA.ProgramDiagnostic2DataType",
           "required": [ "CreateSessionId", "CreateClientName", "InvocationCreationTime", "LastTransitionTime", "LastMethodCall", "LastMethodSessionId", "LastMethodInputArguments", "LastMethodOutputArguments", "LastMethodInputValues", "LastMethodOutputValues", "LastMethodCallTime", "LastMethodReturnStatus" ],
           "properties": {
             "CreateSessionId": {
@@ -18160,7 +18160,7 @@
               "items": {
                 "title": "Argument",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+                "dov:typeRef": "org.opcfoundation.UA.Argument",
                 "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
                 "properties": {
                   "Name": {
@@ -18193,7 +18193,7 @@
               "items": {
                 "title": "Argument",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+                "dov:typeRef": "org.opcfoundation.UA.Argument",
                 "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
                 "properties": {
                   "Name": {
@@ -18326,7 +18326,7 @@
           "items": {
             "title": "Argument",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+            "dov:typeRef": "org.opcfoundation.UA.Argument",
             "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
             "properties": {
               "Name": {
@@ -18386,7 +18386,7 @@
           "items": {
             "title": "Argument",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=296",
+            "dov:typeRef": "org.opcfoundation.UA.Argument",
             "required": [ "Name", "DataType", "ValueRank", "ArrayDimensions", "Description" ],
             "properties": {
               "Name": {
@@ -18477,7 +18477,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2378",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18541,7 +18541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditProgramTransitionEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11856",
+    "dov:typeRef": "org.opcfoundation.UA.AuditProgramTransitionEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18588,7 +18588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProgramTransitionAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3806",
+    "dov:typeRef": "org.opcfoundation.UA.ProgramTransitionAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -18650,7 +18650,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalDataConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2318",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalDataConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18673,7 +18673,7 @@
     "schemaDefinitions": {
       "ExceptionDeviationFormat": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "const": {
           "AbsoluteValue": 0,
           "PercentOfValue": 1,
@@ -18736,7 +18736,7 @@
       },
       "ExceptionDeviationFormat": {
         "title": "ExceptionDeviationFormat",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=890",
+        "dov:typeRef": "org.opcfoundation.UA.ExceptionDeviationFormat",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -18857,7 +18857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalEventConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32621",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalEventConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18888,7 +18888,7 @@
         "items": {
           "title": "SimpleAttributeOperand",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+          "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
           "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
           "properties": {
             "TypeDefinitionId": {
@@ -18956,7 +18956,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoricalExternalEventSourceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32625",
+    "dov:typeRef": "org.opcfoundation.UA.HistoricalExternalEventSourceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -18968,7 +18968,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -18992,7 +18992,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -19016,7 +19016,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -19119,7 +19119,7 @@
       "HistoricalEventFilter": {
         "title": "EventFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=725",
+        "dov:typeRef": "org.opcfoundation.UA.EventFilter",
         "required": [ "SelectClauses", "WhereClause" ],
         "properties": {
           "SelectClauses": {
@@ -19127,7 +19127,7 @@
             "items": {
               "title": "SimpleAttributeOperand",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+              "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
               "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
               "properties": {
                 "TypeDefinitionId": {
@@ -19153,7 +19153,7 @@
           "WhereClause": {
             "title": "ContentFilter",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+            "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -19161,12 +19161,12 @@
                 "items": {
                   "title": "ContentFilterElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                  "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                   "required": [ "FilterOperator", "FilterOperands" ],
                   "properties": {
                     "FilterOperator": {
                       "title": "FilterOperator",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                      "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -19195,7 +19195,7 @@
       "IdentityTokenPolicy": {
         "title": "UserTokenPolicy",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
         "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
         "properties": {
           "PolicyId": {
@@ -19203,7 +19203,7 @@
           },
           "TokenType": {
             "title": "UserTokenType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+            "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -19229,7 +19229,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19288,7 +19288,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HistoryServerCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2330",
+    "dov:typeRef": "org.opcfoundation.UA.HistoryServerCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19496,7 +19496,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryEventUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=2999",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryEventUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19508,7 +19508,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -19536,7 +19536,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -19628,7 +19628,7 @@
       "Filter": {
         "title": "EventFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=725",
+        "dov:typeRef": "org.opcfoundation.UA.EventFilter",
         "required": [ "SelectClauses", "WhereClause" ],
         "properties": {
           "SelectClauses": {
@@ -19636,7 +19636,7 @@
             "items": {
               "title": "SimpleAttributeOperand",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+              "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
               "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
               "properties": {
                 "TypeDefinitionId": {
@@ -19662,7 +19662,7 @@
           "WhereClause": {
             "title": "ContentFilter",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+            "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
             "required": [ "Elements" ],
             "properties": {
               "Elements": {
@@ -19670,12 +19670,12 @@
                 "items": {
                   "title": "ContentFilterElement",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                  "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                   "required": [ "FilterOperator", "FilterOperands" ],
                   "properties": {
                     "FilterOperator": {
                       "title": "FilterOperator",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                      "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -19731,7 +19731,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19768,7 +19768,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryValueUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3006",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryValueUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19780,7 +19780,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -19847,7 +19847,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -19884,7 +19884,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryAnnotationUpdateEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19095",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryAnnotationUpdateEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -19896,7 +19896,7 @@
     "schemaDefinitions": {
       "PerformUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -19938,7 +19938,7 @@
         "items": {
           "title": "Annotation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=891",
+          "dov:typeRef": "org.opcfoundation.UA.Annotation",
           "required": [ "Message", "UserName", "AnnotationTime" ],
           "properties": {
             "Message": {
@@ -19967,7 +19967,7 @@
         "items": {
           "title": "Annotation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=891",
+          "dov:typeRef": "org.opcfoundation.UA.Annotation",
           "required": [ "Message", "UserName", "AnnotationTime" ],
           "properties": {
             "Message": {
@@ -19993,7 +19993,7 @@
       },
       "PerformInsertReplace": {
         "title": "PerformUpdateType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11293",
+        "dov:typeRef": "org.opcfoundation.UA.PerformUpdateType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20019,7 +20019,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3012",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20064,7 +20064,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryRawModifyDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3014",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryRawModifyDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20147,7 +20147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryAtTimeDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3019",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryAtTimeDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20210,7 +20210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryEventDeleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=3022",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryEventDeleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20270,7 +20270,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryConfigurationChangeEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32758",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryConfigurationChangeEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20297,7 +20297,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuditHistoryBulkInsertEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32803",
+    "dov:typeRef": "org.opcfoundation.UA.AuditHistoryBulkInsertEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20366,7 +20366,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12522",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20377,7 +20377,7 @@
     "schemaDefinitions": {
       "TrustListValidationOptions": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "const": {
           "SuppressCertificateExpired": 0,
           "SuppressHostNameInvalid": 1,
@@ -20430,7 +20430,7 @@
       "AddCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12549",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Certificate", "IsTrustedCertificate" ],
           "properties": {
             "Certificate": {
@@ -20453,7 +20453,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12705",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -20465,7 +20465,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12547",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyChangesRequired" ],
           "properties": {
             "ApplyChangesRequired": {
@@ -20484,7 +20484,7 @@
       "OpenWithMasks": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12544",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Masks" ],
           "properties": {
             "Masks": {
@@ -20496,7 +20496,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12545",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {
@@ -20517,7 +20517,7 @@
       "RemoveCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12551",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Thumbprint", "IsTrustedCertificate" ],
           "properties": {
             "Thumbprint": {
@@ -20552,7 +20552,7 @@
       },
       "DefaultValidationOptions": {
         "title": "TrustListValidationOptions",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23564",
+        "dov:typeRef": "org.opcfoundation.UA.TrustListValidationOptions",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -20602,7 +20602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListOutOfDateAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19297",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListOutOfDateAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20671,7 +20671,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12555",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20710,7 +20710,7 @@
       "GetRejectedList": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23527",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificates" ],
           "properties": {
             "Certificates": {
@@ -20770,7 +20770,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateGroupFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=13813",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateGroupFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20814,7 +20814,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12556",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20840,7 +20840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12557",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20866,7 +20866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_HttpsCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12558",
+    "dov:typeRef": "org.opcfoundation.UA.HttpsCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20893,7 +20893,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UserCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19323",
+    "dov:typeRef": "org.opcfoundation.UA.UserCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20919,7 +20919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19324",
+    "dov:typeRef": "org.opcfoundation.UA.TlsCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20945,7 +20945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsServerCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19325",
+    "dov:typeRef": "org.opcfoundation.UA.TlsServerCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20972,7 +20972,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TlsClientCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19326",
+    "dov:typeRef": "org.opcfoundation.UA.TlsClientCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20999,7 +20999,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RsaMinApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12559",
+    "dov:typeRef": "org.opcfoundation.UA.RsaMinApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21026,7 +21026,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_RsaSha256ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12560",
+    "dov:typeRef": "org.opcfoundation.UA.RsaSha256ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21053,7 +21053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23537",
+    "dov:typeRef": "org.opcfoundation.UA.EccApplicationCertificateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21079,7 +21079,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccNistP256ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23538",
+    "dov:typeRef": "org.opcfoundation.UA.EccNistP256ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21106,7 +21106,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccNistP384ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23539",
+    "dov:typeRef": "org.opcfoundation.UA.EccNistP384ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21133,7 +21133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccBrainpoolP256r1ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23540",
+    "dov:typeRef": "org.opcfoundation.UA.EccBrainpoolP256r1ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21160,7 +21160,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccBrainpoolP384r1ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23541",
+    "dov:typeRef": "org.opcfoundation.UA.EccBrainpoolP384r1ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21187,7 +21187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccCurve25519ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23542",
+    "dov:typeRef": "org.opcfoundation.UA.EccCurve25519ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21214,7 +21214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_EccCurve448ApplicationCertificateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23543",
+    "dov:typeRef": "org.opcfoundation.UA.EccCurve448ApplicationCertificateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21241,7 +21241,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConfigurationFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15437",
+    "dov:typeRef": "org.opcfoundation.UA.ConfigurationFileType",
     "dov:isComposite": true,
     "links": [
       {
@@ -21253,7 +21253,7 @@
     "schemaDefinitions": {
       "ConfigurationUpdateType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15539",
+        "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateType",
         "const": {
           "Insert": 1,
           "Replace": 2,
@@ -21291,7 +21291,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15506",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "VersionToUpdate", "Targets", "RevertAfterTime", "RestartDelayTime" ],
           "properties": {
             "FileHandle": {
@@ -21309,7 +21309,7 @@
               "items": {
                 "title": "ConfigurationUpdateTargetType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15538",
+                "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateTargetType",
                 "required": [ "Path", "UpdateType" ],
                 "properties": {
                   "Path": {
@@ -21317,7 +21317,7 @@
                   },
                   "UpdateType": {
                     "title": "ConfigurationUpdateType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15539",
+                    "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdateType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -21337,7 +21337,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15507",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "UpdateResults", "NewVersion", "UpdateId" ],
           "properties": {
             "UpdateResults": {
@@ -21368,7 +21368,7 @@
       "ConfirmUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15511",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UpdateId" ],
           "properties": {
             "UpdateId": {
@@ -21448,7 +21448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConfigurationUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15541",
+    "dov:typeRef": "org.opcfoundation.UA.ConfigurationUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21508,7 +21508,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListUpdateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32260",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListUpdateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21535,7 +21535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TrustListUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12561",
+    "dov:typeRef": "org.opcfoundation.UA.TrustListUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -21580,7 +21580,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TransactionDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32286",
+    "dov:typeRef": "org.opcfoundation.UA.TransactionDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21645,7 +21645,7 @@
         "items": {
           "title": "TransactionErrorType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32285",
+          "dov:typeRef": "org.opcfoundation.UA.TransactionErrorType",
           "required": [ "TargetId", "Error", "Message" ],
           "properties": {
             "TargetId": {
@@ -21704,7 +21704,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16662",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21730,7 +21730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15550",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21741,7 +21741,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -21872,7 +21872,7 @@
         "items": {
           "title": "UserTokenPolicy",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
           "properties": {
             "PolicyId": {
@@ -21880,7 +21880,7 @@
             },
             "TokenType": {
               "title": "UserTokenType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -21918,7 +21918,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ServerConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12581",
+    "dov:typeRef": "org.opcfoundation.UA.ServerConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21947,7 +21947,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -21999,7 +21999,7 @@
       "CreateSelfSignedCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19338",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "SubjectName", "DnsNames", "IpAddresses", "LifetimeInDays", "KeySizeInBits" ],
           "properties": {
             "CertificateGroupId": {
@@ -22037,7 +22037,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19339",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificate" ],
           "properties": {
             "Certificate": {
@@ -22057,7 +22057,7 @@
       "CreateSigningRequest": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12732",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "SubjectName", "RegeneratePrivateKey", "Nonce" ],
           "properties": {
             "CertificateGroupId": {
@@ -22080,7 +22080,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12733",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateRequest" ],
           "properties": {
             "CertificateRequest": {
@@ -22100,7 +22100,7 @@
       "DeleteCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19341",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId" ],
           "properties": {
             "CertificateGroupId": {
@@ -22122,7 +22122,7 @@
       "GetCertificates": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId" ],
           "properties": {
             "CertificateGroupId": {
@@ -22132,7 +22132,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32298",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CertificateTypeIds", "Certificates" ],
           "properties": {
             "CertificateTypeIds": {
@@ -22161,7 +22161,7 @@
       "GetRejectedList": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12776",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Certificates" ],
           "properties": {
             "Certificates": {
@@ -22193,7 +22193,7 @@
       "UpdateCertificate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12617",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CertificateGroupId", "CertificateTypeId", "Certificate", "IssuerCertificates", "PrivateKeyFormat", "PrivateKey" ],
           "properties": {
             "CertificateGroupId": {
@@ -22224,7 +22224,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12618",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ApplyChangesRequired" ],
           "properties": {
             "ApplyChangesRequired": {
@@ -22258,7 +22258,7 @@
       },
       "ApplicationType": {
         "title": "ApplicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22391,7 +22391,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ApplicationConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25731",
+    "dov:typeRef": "org.opcfoundation.UA.ApplicationConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22414,7 +22414,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -22449,7 +22449,7 @@
     "properties": {
       "ApplicationType": {
         "title": "ApplicationType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22519,7 +22519,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateUpdateRequestedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=32306",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateUpdateRequestedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22546,7 +22546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_CertificateUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=12620",
+    "dov:typeRef": "org.opcfoundation.UA.CertificateUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22602,7 +22602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17496",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22622,7 +22622,7 @@
       "CreateCredential": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17523",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "ResourceUri", "ProfileUri", "EndpointUrls" ],
           "properties": {
             "Name": {
@@ -22644,7 +22644,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17524",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CredentialNodeId" ],
           "properties": {
             "CredentialNodeId": {
@@ -22675,7 +22675,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18001",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22705,7 +22705,7 @@
       "GetEncryptingKey": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17535",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId", "RequestedSecurityPolicyUri" ],
           "properties": {
             "CredentialId": {
@@ -22718,7 +22718,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17536",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PublicKey", "RevisedSecurityPolicyUri" ],
           "properties": {
             "PublicKey": {
@@ -22741,7 +22741,7 @@
       "UpdateCredential": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18007",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CredentialId", "CredentialSecret", "CertificateThumbprint", "SecurityPolicyUri" ],
           "properties": {
             "CredentialId": {
@@ -22840,7 +22840,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18011",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22885,7 +22885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialUpdatedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18029",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialUpdatedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22912,7 +22912,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_KeyCredentialDeletedAuditEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18047",
+    "dov:typeRef": "org.opcfoundation.UA.KeyCredentialDeletedAuditEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -22957,7 +22957,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuthorizationServicesConfigurationFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23556",
+    "dov:typeRef": "org.opcfoundation.UA.AuthorizationServicesConfigurationFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22989,7 +22989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AuthorizationServiceConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17852",
+    "dov:typeRef": "org.opcfoundation.UA.AuthorizationServiceConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23056,7 +23056,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AggregateConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=11187",
+    "dov:typeRef": "org.opcfoundation.UA.AggregateConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23137,7 +23137,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyServiceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15906",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyServiceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -23164,7 +23164,7 @@
       "GetSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15911",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId" ],
           "properties": {
             "SecurityGroupId": {
@@ -23174,7 +23174,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15912",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupNodeId": {
@@ -23193,7 +23193,7 @@
       "GetSecurityKeys": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15908",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId", "StartingTokenId", "RequestedKeyCount" ],
           "properties": {
             "SecurityGroupId": {
@@ -23213,7 +23213,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15909",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityPolicyUri", "FirstTokenId", "Keys", "TimeToNextKey", "KeyLifetime" ],
           "properties": {
             "SecurityPolicyUri": {
@@ -23264,7 +23264,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SecurityGroupFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15452",
+    "dov:typeRef": "org.opcfoundation.UA.SecurityGroupFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23291,7 +23291,7 @@
       "AddSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15462",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupName", "KeyLifetime", "SecurityPolicyUri", "MaxFutureKeyCount", "MaxPastKeyCount" ],
           "properties": {
             "SecurityGroupName": {
@@ -23318,7 +23318,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15463",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupId", "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupId": {
@@ -23340,7 +23340,7 @@
       "AddSecurityGroupFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25313",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -23350,7 +23350,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25314",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SecurityGroupFolderNodeId" ],
           "properties": {
             "SecurityGroupFolderNodeId": {
@@ -23369,7 +23369,7 @@
       "RemoveSecurityGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15465",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupNodeId" ],
           "properties": {
             "SecurityGroupNodeId": {
@@ -23388,7 +23388,7 @@
       "RemoveSecurityGroupFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25316",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupFolderNodeId" ],
           "properties": {
             "SecurityGroupFolderNodeId": {
@@ -23433,7 +23433,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SecurityGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15471",
+    "dov:typeRef": "org.opcfoundation.UA.SecurityGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23544,7 +23544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyPushTargetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25337",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23555,7 +23555,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -23589,7 +23589,7 @@
       "ConnectSecurityGroups": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25642",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupIds" ],
           "properties": {
             "SecurityGroupIds": {
@@ -23602,7 +23602,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25643",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConnectResults" ],
           "properties": {
             "ConnectResults": {
@@ -23624,7 +23624,7 @@
       "DisconnectSecurityGroups": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25645",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupIds" ],
           "properties": {
             "SecurityGroupIds": {
@@ -23637,7 +23637,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25646",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DisconnectResults" ],
           "properties": {
             "DisconnectResults": {
@@ -23752,7 +23752,7 @@
       "UserTokenType": {
         "title": "UserTokenPolicy",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
         "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
         "properties": {
           "PolicyId": {
@@ -23760,7 +23760,7 @@
           },
           "TokenType": {
             "title": "UserTokenType",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+            "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -23797,7 +23797,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubKeyPushTargetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25346",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubKeyPushTargetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -23814,7 +23814,7 @@
     "schemaDefinitions": {
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -23841,7 +23841,7 @@
       "AddPushTarget": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25367",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationUri", "EndpointUrl", "SecurityPolicyUri", "UserTokenType", "RequestedKeyCount", "RetryInterval" ],
           "properties": {
             "ApplicationUri": {
@@ -23856,7 +23856,7 @@
             "UserTokenType": {
               "title": "UserTokenPolicy",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+              "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
               "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
               "properties": {
                 "PolicyId": {
@@ -23864,7 +23864,7 @@
                 },
                 "TokenType": {
                   "title": "UserTokenType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                  "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -23893,7 +23893,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25368",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PushTargetId" ],
           "properties": {
             "PushTargetId": {
@@ -23912,7 +23912,7 @@
       "AddPushTargetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25372",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -23922,7 +23922,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25373",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "PushTargetFolderNodeId" ],
           "properties": {
             "PushTargetFolderNodeId": {
@@ -23941,7 +23941,7 @@
       "RemovePushTarget": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25370",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PushTargetId" ],
           "properties": {
             "PushTargetId": {
@@ -23960,7 +23960,7 @@
       "RemovePushTargetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25375",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PushTargetFolderNodeId" ],
           "properties": {
             "PushTargetFolderNodeId": {
@@ -23991,7 +23991,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishSubscribeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14416",
+    "dov:typeRef": "org.opcfoundation.UA.PublishSubscribeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24044,7 +24044,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -24068,7 +24068,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -24092,7 +24092,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -24116,7 +24116,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -24148,7 +24148,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -24170,13 +24170,13 @@
       "AddConnection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16599",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "PubSubConnectionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15617",
+              "dov:typeRef": "org.opcfoundation.UA.PubSubConnectionDataType",
               "required": [ "Name", "Enabled", "PublisherId", "TransportProfileUri", "Address", "ConnectionProperties", "TransportSettings", "WriterGroups", "ReaderGroups" ],
               "properties": {
                 "Name": {
@@ -24195,7 +24195,7 @@
                 "Address": {
                   "title": "NetworkAddressDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15502",
+                  "dov:typeRef": "org.opcfoundation.UA.NetworkAddressDataType",
                   "required": [ "NetworkInterface" ],
                   "properties": {
                     "NetworkInterface": {
@@ -24208,7 +24208,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -24229,7 +24229,7 @@
                   "items": {
                     "title": "WriterGroupDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15480",
+                    "dov:typeRef": "org.opcfoundation.UA.WriterGroupDataType",
                     "required": [ "WriterGroupId", "PublishingInterval", "KeepAliveTime", "Priority", "LocaleIds", "HeaderLayoutUri", "TransportSettings", "MessageSettings", "DataSetWriters" ],
                     "properties": {
                       "WriterGroupId": {
@@ -24270,7 +24270,7 @@
                         "items": {
                           "title": "DataSetWriterDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
                           "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
                           "properties": {
                             "Name": {
@@ -24286,7 +24286,7 @@
                             },
                             "DataSetFieldContentMask": {
                               "title": "DataSetFieldContentMask",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24304,7 +24304,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -24334,7 +24334,7 @@
                   "items": {
                     "title": "ReaderGroupDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15520",
+                    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupDataType",
                     "required": [ "TransportSettings", "MessageSettings", "DataSetReaders" ],
                     "properties": {
                       "TransportSettings": {
@@ -24348,7 +24348,7 @@
                         "items": {
                           "title": "DataSetReaderDataType",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+                          "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
                           "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
                           "properties": {
                             "Name": {
@@ -24374,7 +24374,7 @@
                             "DataSetMetaData": {
                               "title": "DataSetMetaDataType",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                               "properties": {
                                 "Name": {
@@ -24388,7 +24388,7 @@
                                   "items": {
                                     "title": "FieldMetaData",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                                     "properties": {
                                       "Name": {
@@ -24399,7 +24399,7 @@
                                       },
                                       "FieldFlags": {
                                         "title": "DataSetFieldFlags",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                                         "type": "integer",
                                         "minimum": -2147483648,
                                         "maximum": 2147483647
@@ -24439,7 +24439,7 @@
                                         "items": {
                                           "title": "KeyValuePair",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                           "required": [ "Key", "Value" ],
                                           "properties": {
                                             "Key": {
@@ -24462,7 +24462,7 @@
                                 "ConfigurationVersion": {
                                   "title": "ConfigurationVersionDataType",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                                   "required": [ "MajorVersion", "MinorVersion" ],
                                   "properties": {
                                     "MajorVersion": {
@@ -24481,7 +24481,7 @@
                             },
                             "DataSetFieldContentMask": {
                               "title": "DataSetFieldContentMask",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                              "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24500,7 +24500,7 @@
                             },
                             "SecurityMode": {
                               "title": "MessageSecurityMode",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -24513,7 +24513,7 @@
                               "items": {
                                 "title": "EndpointDescription",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                                "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                                 "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                                 "properties": {
                                   "EndpointUrl": {
@@ -24522,7 +24522,7 @@
                                   "Server": {
                                     "title": "ApplicationDescription",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                                    "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                                     "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                                     "properties": {
                                       "ApplicationUri": {
@@ -24536,7 +24536,7 @@
                                       },
                                       "ApplicationType": {
                                         "title": "ApplicationType",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                                        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                                         "type": "integer",
                                         "minimum": -2147483648,
                                         "maximum": 2147483647
@@ -24561,7 +24561,7 @@
                                   },
                                   "SecurityMode": {
                                     "title": "MessageSecurityMode",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                                    "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -24574,7 +24574,7 @@
                                     "items": {
                                       "title": "UserTokenPolicy",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                                      "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                                       "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                                       "properties": {
                                         "PolicyId": {
@@ -24582,7 +24582,7 @@
                                         },
                                         "TokenType": {
                                           "title": "UserTokenType",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                                          "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                                           "type": "integer",
                                           "minimum": -2147483648,
                                           "maximum": 2147483647
@@ -24615,7 +24615,7 @@
                               "items": {
                                 "title": "KeyValuePair",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                 "required": [ "Key", "Value" ],
                                 "properties": {
                                   "Key": {
@@ -24649,7 +24649,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16600",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConnectionId" ],
           "properties": {
             "ConnectionId": {
@@ -24668,7 +24668,7 @@
       "RemoveConnection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14433",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConnectionId" ],
           "properties": {
             "ConnectionId": {
@@ -24687,7 +24687,7 @@
       "SetSecurityKeys": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SecurityGroupId", "SecurityPolicyUri", "CurrentTokenId", "CurrentKey", "FutureKeys", "TimeToNextKey", "KeyLifetime" ],
           "properties": {
             "SecurityGroupId": {
@@ -24737,7 +24737,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -24789,7 +24789,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -24798,7 +24798,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -24812,7 +24812,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -24837,7 +24837,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -24850,7 +24850,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -24858,7 +24858,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -24921,7 +24921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25482",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24932,7 +24932,7 @@
     "schemaDefinitions": {
       "PubSubConfigurationRefMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
         "const": {
           "ElementAdd": 0,
           "ElementMatch": 1,
@@ -24995,7 +24995,7 @@
       "CloseAndUpdate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25509",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle", "RequireCompleteUpdate", "ConfigurationReferences" ],
           "properties": {
             "FileHandle": {
@@ -25011,12 +25011,12 @@
               "items": {
                 "title": "PubSubConfigurationRefDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                 "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                 "properties": {
                   "ConfigurationMask": {
                     "title": "PubSubConfigurationRefMask",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -25043,7 +25043,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25510",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ChangesApplied", "ReferencesResults", "ConfigurationValues", "ConfigurationObjects" ],
           "properties": {
             "ChangesApplied": {
@@ -25060,18 +25060,18 @@
               "items": {
                 "title": "PubSubConfigurationValueDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25520",
+                "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationValueDataType",
                 "required": [ "ConfigurationElement", "Name", "Identifier" ],
                 "properties": {
                   "ConfigurationElement": {
                     "title": "PubSubConfigurationRefDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25519",
+                    "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefDataType",
                     "required": [ "ConfigurationMask", "ElementIndex", "ConnectionIndex", "GroupIndex" ],
                     "properties": {
                       "ConfigurationMask": {
                         "title": "PubSubConfigurationRefMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25517",
+                        "dov:typeRef": "org.opcfoundation.UA.PubSubConfigurationRefMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -25122,7 +25122,7 @@
       "ReserveIds": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25506",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TransportProfileUri", "NumReqWriterGroupIds", "NumReqDataSetWriterIds" ],
           "properties": {
             "TransportProfileUri": {
@@ -25142,7 +25142,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25507",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DefaultPublisherId", "WriterGroupIds", "DataSetWriterIds" ],
           "properties": {
             "DefaultPublisherId": {
@@ -25189,7 +25189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14509",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25206,7 +25206,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -25230,7 +25230,7 @@
       "ConfigurationVersion": {
         "title": "ConfigurationVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+        "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
         "required": [ "MajorVersion", "MinorVersion" ],
         "properties": {
           "MajorVersion": {
@@ -25279,7 +25279,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -25293,7 +25293,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -25304,7 +25304,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -25344,7 +25344,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -25367,7 +25367,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -25405,7 +25405,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ExtensionFieldsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15489",
+    "dov:typeRef": "org.opcfoundation.UA.ExtensionFieldsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25426,7 +25426,7 @@
       "AddExtensionField": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15492",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FieldName", "FieldValue" ],
           "properties": {
             "FieldName": {
@@ -25439,7 +25439,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15493",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FieldId" ],
           "properties": {
             "FieldId": {
@@ -25458,7 +25458,7 @@
       "RemoveExtensionField": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15495",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FieldId" ],
           "properties": {
             "FieldId": {
@@ -25502,7 +25502,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedDataItemsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14534",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedDataItemsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25524,13 +25524,13 @@
       "AddVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14556",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "FieldNameAliases", "PromotedFields", "VariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25562,7 +25562,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -25607,13 +25607,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14557",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion", "AddResults" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25647,13 +25647,13 @@
       "RemoveVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14559",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "VariablesToRemove" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25680,13 +25680,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14560",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion", "RemoveResults" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25724,7 +25724,7 @@
         "items": {
           "title": "PublishedVariableDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+          "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
           "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
           "properties": {
             "PublishedVariable": {
@@ -25786,7 +25786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PublishedEventsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14572",
+    "dov:typeRef": "org.opcfoundation.UA.PublishedEventsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -25798,7 +25798,7 @@
     "schemaDefinitions": {
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -25888,13 +25888,13 @@
       "ModifyFieldSelection": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "FieldNameAliases", "PromotedFields", "SelectedFields" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25926,7 +25926,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -25953,13 +25953,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15517",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NewConfigurationVersion" ],
           "properties": {
             "NewConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -25989,7 +25989,7 @@
       "Filter": {
         "title": "ContentFilter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+        "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
         "required": [ "Elements" ],
         "properties": {
           "Elements": {
@@ -25997,12 +25997,12 @@
             "items": {
               "title": "ContentFilterElement",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
               "required": [ "FilterOperator", "FilterOperands" ],
               "properties": {
                 "FilterOperator": {
                   "title": "FilterOperator",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                  "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -26042,7 +26042,7 @@
         "items": {
           "title": "SimpleAttributeOperand",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+          "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
           "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
           "properties": {
             "TypeDefinitionId": {
@@ -26086,7 +26086,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14477",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26103,7 +26103,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -26115,7 +26115,7 @@
       },
       "FilterOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
         "const": {
           "Equals": 0,
           "IsNull": 1,
@@ -26198,7 +26198,7 @@
       "AddDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16995",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -26208,7 +26208,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16996",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -26227,7 +26227,7 @@
       "AddPublishedDataItems": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14494",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "FieldNameAliases", "FieldFlags", "VariablesToAdd" ],
           "properties": {
             "Name": {
@@ -26243,7 +26243,7 @@
               "type": "array",
               "items": {
                 "title": "DataSetFieldFlags",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -26254,7 +26254,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -26299,7 +26299,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14495",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId", "ConfigurationVersion", "AddResults" ],
           "properties": {
             "DataSetNodeId": {
@@ -26308,7 +26308,7 @@
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -26342,7 +26342,7 @@
       "AddPublishedDataItemsTemplate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16958",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "DataSetMetaData", "VariablesToAdd" ],
           "properties": {
             "Name": {
@@ -26351,7 +26351,7 @@
             "DataSetMetaData": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -26365,7 +26365,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -26376,7 +26376,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -26416,7 +26416,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -26439,7 +26439,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -26461,7 +26461,7 @@
               "items": {
                 "title": "PublishedVariableDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14273",
+                "dov:typeRef": "org.opcfoundation.UA.PublishedVariableDataType",
                 "required": [ "PublishedVariable", "AttributeId", "SamplingIntervalHint", "DeadbandType", "DeadbandValue", "IndexRange", "SubstituteValue", "MetaDataProperties" ],
                 "properties": {
                   "PublishedVariable": {
@@ -26506,7 +26506,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16959",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId", "AddResults" ],
           "properties": {
             "DataSetNodeId": {
@@ -26531,7 +26531,7 @@
       "AddPublishedEvents": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14497",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "EventNotifier", "FieldNameAliases", "FieldFlags", "SelectedFields", "Filter" ],
           "properties": {
             "Name": {
@@ -26550,7 +26550,7 @@
               "type": "array",
               "items": {
                 "title": "DataSetFieldFlags",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -26561,7 +26561,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -26587,7 +26587,7 @@
             "Filter": {
               "title": "ContentFilter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -26595,12 +26595,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -26620,13 +26620,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14498",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ConfigurationVersion", "DataSetNodeId" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -26657,7 +26657,7 @@
       "AddPublishedEventsTemplate": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16961",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "DataSetMetaData", "EventNotifier", "SelectedFields", "Filter" ],
           "properties": {
             "Name": {
@@ -26666,7 +26666,7 @@
             "DataSetMetaData": {
               "title": "DataSetMetaDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
               "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
               "properties": {
                 "Name": {
@@ -26680,7 +26680,7 @@
                   "items": {
                     "title": "FieldMetaData",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                    "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                     "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                     "properties": {
                       "Name": {
@@ -26691,7 +26691,7 @@
                       },
                       "FieldFlags": {
                         "title": "DataSetFieldFlags",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -26731,7 +26731,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -26754,7 +26754,7 @@
                 "ConfigurationVersion": {
                   "title": "ConfigurationVersionDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                  "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                   "required": [ "MajorVersion", "MinorVersion" ],
                   "properties": {
                     "MajorVersion": {
@@ -26779,7 +26779,7 @@
               "items": {
                 "title": "SimpleAttributeOperand",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=601",
+                "dov:typeRef": "org.opcfoundation.UA.SimpleAttributeOperand",
                 "required": [ "TypeDefinitionId", "BrowsePath", "AttributeId", "IndexRange" ],
                 "properties": {
                   "TypeDefinitionId": {
@@ -26805,7 +26805,7 @@
             "Filter": {
               "title": "ContentFilter",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=586",
+              "dov:typeRef": "org.opcfoundation.UA.ContentFilter",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -26813,12 +26813,12 @@
                   "items": {
                     "title": "ContentFilterElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=583",
+                    "dov:typeRef": "org.opcfoundation.UA.ContentFilterElement",
                     "required": [ "FilterOperator", "FilterOperands" ],
                     "properties": {
                       "FilterOperator": {
                         "title": "FilterOperator",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=576",
+                        "dov:typeRef": "org.opcfoundation.UA.FilterOperator",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -26838,7 +26838,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=16971",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetNodeId" ],
           "properties": {
             "DataSetNodeId": {
@@ -26857,7 +26857,7 @@
       "RemoveDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17007",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -26876,7 +26876,7 @@
       "RemovePublishedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14500",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetNodeId" ],
           "properties": {
             "DataSetNodeId": {
@@ -26907,7 +26907,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14209",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26942,7 +26942,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -26974,7 +26974,7 @@
       },
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -26986,7 +26986,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -27010,7 +27010,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -27034,7 +27034,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -27073,13 +27073,13 @@
       "AddReaderGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17507",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "ReaderGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15520",
+              "dov:typeRef": "org.opcfoundation.UA.ReaderGroupDataType",
               "required": [ "TransportSettings", "MessageSettings", "DataSetReaders" ],
               "properties": {
                 "TransportSettings": {
@@ -27093,7 +27093,7 @@
                   "items": {
                     "title": "DataSetReaderDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
                     "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
                     "properties": {
                       "Name": {
@@ -27119,7 +27119,7 @@
                       "DataSetMetaData": {
                         "title": "DataSetMetaDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                         "properties": {
                           "Name": {
@@ -27133,7 +27133,7 @@
                             "items": {
                               "title": "FieldMetaData",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                               "properties": {
                                 "Name": {
@@ -27144,7 +27144,7 @@
                                 },
                                 "FieldFlags": {
                                   "title": "DataSetFieldFlags",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -27184,7 +27184,7 @@
                                   "items": {
                                     "title": "KeyValuePair",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                                     "required": [ "Key", "Value" ],
                                     "properties": {
                                       "Key": {
@@ -27207,7 +27207,7 @@
                           "ConfigurationVersion": {
                             "title": "ConfigurationVersionDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                             "required": [ "MajorVersion", "MinorVersion" ],
                             "properties": {
                               "MajorVersion": {
@@ -27226,7 +27226,7 @@
                       },
                       "DataSetFieldContentMask": {
                         "title": "DataSetFieldContentMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -27245,7 +27245,7 @@
                       },
                       "SecurityMode": {
                         "title": "MessageSecurityMode",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -27258,7 +27258,7 @@
                         "items": {
                           "title": "EndpointDescription",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                           "properties": {
                             "EndpointUrl": {
@@ -27267,7 +27267,7 @@
                             "Server": {
                               "title": "ApplicationDescription",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                               "properties": {
                                 "ApplicationUri": {
@@ -27281,7 +27281,7 @@
                                 },
                                 "ApplicationType": {
                                   "title": "ApplicationType",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -27306,7 +27306,7 @@
                             },
                             "SecurityMode": {
                               "title": "MessageSecurityMode",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -27319,7 +27319,7 @@
                               "items": {
                                 "title": "UserTokenPolicy",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                                 "properties": {
                                   "PolicyId": {
@@ -27327,7 +27327,7 @@
                                   },
                                   "TokenType": {
                                     "title": "UserTokenType",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -27360,7 +27360,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -27391,7 +27391,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17508",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -27410,13 +27410,13 @@
       "AddWriterGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17428",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "WriterGroupDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15480",
+              "dov:typeRef": "org.opcfoundation.UA.WriterGroupDataType",
               "required": [ "WriterGroupId", "PublishingInterval", "KeepAliveTime", "Priority", "LocaleIds", "HeaderLayoutUri", "TransportSettings", "MessageSettings", "DataSetWriters" ],
               "properties": {
                 "WriterGroupId": {
@@ -27457,7 +27457,7 @@
                   "items": {
                     "title": "DataSetWriterDataType",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+                    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
                     "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
                     "properties": {
                       "Name": {
@@ -27473,7 +27473,7 @@
                       },
                       "DataSetFieldContentMask": {
                         "title": "DataSetFieldContentMask",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -27491,7 +27491,7 @@
                         "items": {
                           "title": "KeyValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                           "required": [ "Key", "Value" ],
                           "properties": {
                             "Key": {
@@ -27519,7 +27519,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17456",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -27538,7 +27538,7 @@
       "RemoveGroup": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14226",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "GroupId" ],
           "properties": {
             "GroupId": {
@@ -27561,7 +27561,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -27630,7 +27630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17721",
+    "dov:typeRef": "org.opcfoundation.UA.ConnectionTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27656,7 +27656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14232",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27673,7 +27673,7 @@
     "schemaDefinitions": {
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -27697,7 +27697,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -27721,7 +27721,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -27759,7 +27759,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -27809,7 +27809,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -27818,7 +27818,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -27832,7 +27832,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -27857,7 +27857,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -27870,7 +27870,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -27878,7 +27878,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -27916,7 +27916,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -27942,7 +27942,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17725",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -27971,7 +27971,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -28013,13 +28013,13 @@
       "AddDataSetWriter": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17976",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "DataSetWriterDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15597",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetWriterDataType",
               "required": [ "Name", "Enabled", "DataSetWriterId", "DataSetFieldContentMask", "KeyFrameCount", "DataSetName", "DataSetWriterProperties", "TransportSettings", "MessageSettings" ],
               "properties": {
                 "Name": {
@@ -28035,7 +28035,7 @@
                 },
                 "DataSetFieldContentMask": {
                   "title": "DataSetFieldContentMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -28053,7 +28053,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -28078,7 +28078,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17987",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetWriterNodeId" ],
           "properties": {
             "DataSetWriterNodeId": {
@@ -28097,7 +28097,7 @@
       "RemoveDataSetWriter": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17993",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetWriterNodeId" ],
           "properties": {
             "DataSetWriterNodeId": {
@@ -28203,7 +28203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17997",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28229,7 +28229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_WriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17998",
+    "dov:typeRef": "org.opcfoundation.UA.WriterGroupMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28255,7 +28255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17999",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28284,7 +28284,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -28296,7 +28296,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -28328,7 +28328,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -28352,7 +28352,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -28376,7 +28376,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -28403,13 +28403,13 @@
       "AddDataSetReader": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21083",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Configuration" ],
           "properties": {
             "Configuration": {
               "title": "DataSetReaderDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15623",
+              "dov:typeRef": "org.opcfoundation.UA.DataSetReaderDataType",
               "required": [ "Name", "Enabled", "PublisherId", "WriterGroupId", "DataSetWriterId", "DataSetMetaData", "DataSetFieldContentMask", "MessageReceiveTimeout", "KeyFrameCount", "HeaderLayoutUri", "SecurityMode", "SecurityGroupId", "SecurityKeyServices", "DataSetReaderProperties", "TransportSettings", "MessageSettings", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -28435,7 +28435,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -28449,7 +28449,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -28460,7 +28460,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -28500,7 +28500,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -28523,7 +28523,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -28542,7 +28542,7 @@
                 },
                 "DataSetFieldContentMask": {
                   "title": "DataSetFieldContentMask",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -28561,7 +28561,7 @@
                 },
                 "SecurityMode": {
                   "title": "MessageSecurityMode",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                  "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -28574,7 +28574,7 @@
                   "items": {
                     "title": "EndpointDescription",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+                    "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
                     "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
                     "properties": {
                       "EndpointUrl": {
@@ -28583,7 +28583,7 @@
                       "Server": {
                         "title": "ApplicationDescription",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                        "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                         "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                         "properties": {
                           "ApplicationUri": {
@@ -28597,7 +28597,7 @@
                           },
                           "ApplicationType": {
                             "title": "ApplicationType",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                            "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -28622,7 +28622,7 @@
                       },
                       "SecurityMode": {
                         "title": "MessageSecurityMode",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+                        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -28635,7 +28635,7 @@
                         "items": {
                           "title": "UserTokenPolicy",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                          "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                           "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                           "properties": {
                             "PolicyId": {
@@ -28643,7 +28643,7 @@
                             },
                             "TokenType": {
                               "title": "UserTokenType",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                              "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -28676,7 +28676,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -28704,7 +28704,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21084",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetReaderNodeId" ],
           "properties": {
             "DataSetReaderNodeId": {
@@ -28723,7 +28723,7 @@
       "RemoveDataSetReader": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetReaderNodeId" ],
           "properties": {
             "DataSetReaderNodeId": {
@@ -28754,7 +28754,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21090",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28780,7 +28780,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ReaderGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21091",
+    "dov:typeRef": "org.opcfoundation.UA.ReaderGroupMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28806,7 +28806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15298",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28841,7 +28841,7 @@
     "schemaDefinitions": {
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -28884,7 +28884,7 @@
     "properties": {
       "DataSetFieldContentMask": {
         "title": "DataSetFieldContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -28915,7 +28915,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -28962,7 +28962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15305",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -28988,7 +28988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21096",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetWriterMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29014,7 +29014,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15306",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29055,7 +29055,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -29067,7 +29067,7 @@
       },
       "DataSetFieldContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "const": {
           "StatusCode": 0,
           "SourceTimestamp": 1,
@@ -29099,7 +29099,7 @@
       },
       "MessageSecurityMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "const": {
           "Invalid": 0,
           "None": 1,
@@ -29123,7 +29123,7 @@
       },
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -29147,7 +29147,7 @@
       },
       "UserTokenType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+        "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
         "const": {
           "Anonymous": 0,
           "UserName": 1,
@@ -29171,7 +29171,7 @@
       },
       "OverrideValueHandling": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+        "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
         "const": {
           "Disabled": 0,
           "LastUsableValue": 1,
@@ -29191,7 +29191,7 @@
       },
       "PermissionType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+        "dov:typeRef": "org.opcfoundation.UA.PermissionType",
         "const": {
           "Browse": 0,
           "ReadRolePermissions": 1,
@@ -29277,7 +29277,7 @@
       "CreateDataSetMirror": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17390",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ParentNodeName", "RolePermissions" ],
           "properties": {
             "ParentNodeName": {
@@ -29288,7 +29288,7 @@
               "items": {
                 "title": "RolePermissionType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=96",
+                "dov:typeRef": "org.opcfoundation.UA.RolePermissionType",
                 "required": [ "RoleId", "Permissions" ],
                 "properties": {
                   "RoleId": {
@@ -29296,7 +29296,7 @@
                   },
                   "Permissions": {
                     "title": "PermissionType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=94",
+                    "dov:typeRef": "org.opcfoundation.UA.PermissionType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -29308,7 +29308,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17391",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ParentNodeId" ],
           "properties": {
             "ParentNodeId": {
@@ -29327,13 +29327,13 @@
       "CreateTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17387",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetVariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -29353,7 +29353,7 @@
               "items": {
                 "title": "FieldTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+                "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
                 "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
                 "properties": {
                   "DataSetFieldId": {
@@ -29376,7 +29376,7 @@
                   },
                   "OverrideValueHandling": {
                     "title": "OverrideValueHandling",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+                    "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -29392,7 +29392,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=17388",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AddResults" ],
           "properties": {
             "AddResults": {
@@ -29415,7 +29415,7 @@
     "properties": {
       "DataSetFieldContentMask": {
         "title": "DataSetFieldContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15583",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -29431,7 +29431,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -29445,7 +29445,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -29456,7 +29456,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -29496,7 +29496,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -29519,7 +29519,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -29549,7 +29549,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -29647,7 +29647,7 @@
         "items": {
           "title": "EndpointDescription",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=312",
+          "dov:typeRef": "org.opcfoundation.UA.EndpointDescription",
           "required": [ "EndpointUrl", "Server", "ServerCertificate", "SecurityMode", "SecurityPolicyUri", "UserIdentityTokens", "TransportProfileUri", "SecurityLevel" ],
           "properties": {
             "EndpointUrl": {
@@ -29656,7 +29656,7 @@
             "Server": {
               "title": "ApplicationDescription",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+              "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
               "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
               "properties": {
                 "ApplicationUri": {
@@ -29670,7 +29670,7 @@
                 },
                 "ApplicationType": {
                   "title": "ApplicationType",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                  "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -29695,7 +29695,7 @@
             },
             "SecurityMode": {
               "title": "MessageSecurityMode",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+              "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -29708,7 +29708,7 @@
               "items": {
                 "title": "UserTokenPolicy",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=304",
+                "dov:typeRef": "org.opcfoundation.UA.UserTokenPolicy",
                 "required": [ "PolicyId", "TokenType", "IssuedTokenType", "IssuerEndpointUrl", "SecurityPolicyUri" ],
                 "properties": {
                   "PolicyId": {
@@ -29716,7 +29716,7 @@
                   },
                   "TokenType": {
                     "title": "UserTokenType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=303",
+                    "dov:typeRef": "org.opcfoundation.UA.UserTokenType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -29754,7 +29754,7 @@
       },
       "SecurityMode": {
         "title": "MessageSecurityMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=302",
+        "dov:typeRef": "org.opcfoundation.UA.MessageSecurityMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -29793,7 +29793,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15319",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderTransportType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29819,7 +29819,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21104",
+    "dov:typeRef": "org.opcfoundation.UA.DataSetReaderMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29845,7 +29845,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15108",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29871,7 +29871,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_TargetVariablesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15111",
+    "dov:typeRef": "org.opcfoundation.UA.TargetVariablesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -29883,7 +29883,7 @@
     "schemaDefinitions": {
       "OverrideValueHandling": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+        "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
         "const": {
           "Disabled": 0,
           "LastUsableValue": 1,
@@ -29913,13 +29913,13 @@
       "AddTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15116",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetVariablesToAdd" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -29939,7 +29939,7 @@
               "items": {
                 "title": "FieldTargetDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+                "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
                 "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
                 "properties": {
                   "DataSetFieldId": {
@@ -29962,7 +29962,7 @@
                   },
                   "OverrideValueHandling": {
                     "title": "OverrideValueHandling",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+                    "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -29978,7 +29978,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15117",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AddResults" ],
           "properties": {
             "AddResults": {
@@ -30000,13 +30000,13 @@
       "RemoveTargetVariables": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15119",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ConfigurationVersion", "TargetsToRemove" ],
           "properties": {
             "ConfigurationVersion": {
               "title": "ConfigurationVersionDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+              "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
               "required": [ "MajorVersion", "MinorVersion" ],
               "properties": {
                 "MajorVersion": {
@@ -30033,7 +30033,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15120",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RemoveResults" ],
           "properties": {
             "RemoveResults": {
@@ -30059,7 +30059,7 @@
         "items": {
           "title": "FieldTargetDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14744",
+          "dov:typeRef": "org.opcfoundation.UA.FieldTargetDataType",
           "required": [ "DataSetFieldId", "ReceiverIndexRange", "TargetNodeId", "AttributeId", "WriteIndexRange", "OverrideValueHandling", "OverrideValue" ],
           "properties": {
             "DataSetFieldId": {
@@ -30082,7 +30082,7 @@
             },
             "OverrideValueHandling": {
               "title": "OverrideValueHandling",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15874",
+              "dov:typeRef": "org.opcfoundation.UA.OverrideValueHandling",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -30115,7 +30115,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetMirrorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15127",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetMirrorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -30142,7 +30142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SubscribedDataSetFolderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23795",
+    "dov:typeRef": "org.opcfoundation.UA.SubscribedDataSetFolderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30159,7 +30159,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -30174,7 +30174,7 @@
       "AddDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23817",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -30184,7 +30184,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23818",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -30203,13 +30203,13 @@
       "AddSubscribedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23812",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscribedDataSet" ],
           "properties": {
             "SubscribedDataSet": {
               "title": "StandaloneSubscribedDataSetDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23600",
+              "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetDataType",
               "required": [ "Name", "DataSetFolder", "DataSetMetaData", "SubscribedDataSet" ],
               "properties": {
                 "Name": {
@@ -30224,7 +30224,7 @@
                 "DataSetMetaData": {
                   "title": "DataSetMetaDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
                   "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
                   "properties": {
                     "Name": {
@@ -30238,7 +30238,7 @@
                       "items": {
                         "title": "FieldMetaData",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+                        "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
                         "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
                         "properties": {
                           "Name": {
@@ -30249,7 +30249,7 @@
                           },
                           "FieldFlags": {
                             "title": "DataSetFieldFlags",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                            "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -30289,7 +30289,7 @@
                             "items": {
                               "title": "KeyValuePair",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                              "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                               "required": [ "Key", "Value" ],
                               "properties": {
                                 "Key": {
@@ -30312,7 +30312,7 @@
                     "ConfigurationVersion": {
                       "title": "ConfigurationVersionDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+                      "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
                       "required": [ "MajorVersion", "MinorVersion" ],
                       "properties": {
                         "MajorVersion": {
@@ -30338,7 +30338,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23813",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SubscribedDataSetNodeId" ],
           "properties": {
             "SubscribedDataSetNodeId": {
@@ -30357,7 +30357,7 @@
       "RemoveDataSetFolder": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23820",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSetFolderNodeId" ],
           "properties": {
             "DataSetFolderNodeId": {
@@ -30376,7 +30376,7 @@
       "RemoveSubscribedDataSet": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23815",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SubscribedDataSetNodeId" ],
           "properties": {
             "SubscribedDataSetNodeId": {
@@ -30407,7 +30407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_StandaloneSubscribedDataSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23828",
+    "dov:typeRef": "org.opcfoundation.UA.StandaloneSubscribedDataSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30424,7 +30424,7 @@
     "schemaDefinitions": {
       "DataSetFieldFlags": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
         "const": {
           "PromotedField": 0
         },
@@ -30448,7 +30448,7 @@
       "DataSetMetaData": {
         "title": "DataSetMetaDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14523",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetMetaDataType",
         "required": [ "Name", "Description", "Fields", "DataSetClassId", "ConfigurationVersion" ],
         "properties": {
           "Name": {
@@ -30462,7 +30462,7 @@
             "items": {
               "title": "FieldMetaData",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14524",
+              "dov:typeRef": "org.opcfoundation.UA.FieldMetaData",
               "required": [ "Name", "Description", "FieldFlags", "BuiltInType", "DataType", "ValueRank", "ArrayDimensions", "MaxStringLength", "DataSetFieldId", "Properties" ],
               "properties": {
                 "Name": {
@@ -30473,7 +30473,7 @@
                 },
                 "FieldFlags": {
                   "title": "DataSetFieldFlags",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15904",
+                  "dov:typeRef": "org.opcfoundation.UA.DataSetFieldFlags",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -30513,7 +30513,7 @@
                   "items": {
                     "title": "KeyValuePair",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                    "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                     "required": [ "Key", "Value" ],
                     "properties": {
                       "Key": {
@@ -30536,7 +30536,7 @@
           "ConfigurationVersion": {
             "title": "ConfigurationVersionDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14593",
+            "dov:typeRef": "org.opcfoundation.UA.ConfigurationVersionDataType",
             "required": [ "MajorVersion", "MinorVersion" ],
             "properties": {
               "MajorVersion": {
@@ -30585,7 +30585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14643",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30596,7 +30596,7 @@
     "schemaDefinitions": {
       "PubSubState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "const": {
           "Disabled": 0,
           "Paused": 1,
@@ -30658,7 +30658,7 @@
     "properties": {
       "State": {
         "title": "PubSubState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -30676,7 +30676,7 @@
       "State": {
         "data": {
           "title": "PubSubState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+          "dov:typeRef": "org.opcfoundation.UA.PubSubState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -30700,7 +30700,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19677",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30723,7 +30723,7 @@
     "schemaDefinitions": {
       "DiagnosticsLevel": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+        "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
         "const": {
           "Basic": 0,
           "Advanced": 1,
@@ -30776,7 +30776,7 @@
     "properties": {
       "DiagnosticsLevel": {
         "title": "DiagnosticsLevel",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+        "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -30831,7 +30831,7 @@
       "DiagnosticsLevel": {
         "data": {
           "title": "DiagnosticsLevel",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19723",
+          "dov:typeRef": "org.opcfoundation.UA.DiagnosticsLevel",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -30895,7 +30895,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsRootType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19732",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsRootType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30927,7 +30927,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19786",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30959,7 +30959,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsWriterGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19834",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsWriterGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -30997,7 +30997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsReaderGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19903",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsReaderGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31035,7 +31035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsDataSetWriterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19968",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsDataSetWriterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31073,7 +31073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubDiagnosticsDataSetReaderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20027",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubDiagnosticsDataSetReaderType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31111,7 +31111,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23832",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31346,7 +31346,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubStatusEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15535",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubStatusEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31358,7 +31358,7 @@
     "schemaDefinitions": {
       "PubSubState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "const": {
           "Disabled": 0,
           "Paused": 1,
@@ -31419,7 +31419,7 @@
       },
       "State": {
         "title": "PubSubState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14647",
+        "dov:typeRef": "org.opcfoundation.UA.PubSubState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31445,7 +31445,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubTransportLimitsExceedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15548",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubTransportLimitsExceedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31505,7 +31505,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PubSubCommunicationFailureEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15563",
+    "dov:typeRef": "org.opcfoundation.UA.PubSubCommunicationFailureEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -31550,7 +31550,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpWriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21105",
+    "dov:typeRef": "org.opcfoundation.UA.UadpWriterGroupMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31562,7 +31562,7 @@
     "schemaDefinitions": {
       "DataSetOrderingType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20408",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetOrderingType",
         "const": {
           "Undefined": 0,
           "AscendingWriterId": 1,
@@ -31582,7 +31582,7 @@
       },
       "UadpNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "const": {
           "PublisherId": 0,
           "GroupHeader": 1,
@@ -31645,7 +31645,7 @@
     "properties": {
       "DataSetOrdering": {
         "title": "DataSetOrderingType",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=20408",
+        "dov:typeRef": "org.opcfoundation.UA.DataSetOrderingType",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31673,7 +31673,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "UadpNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31726,7 +31726,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpDataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21111",
+    "dov:typeRef": "org.opcfoundation.UA.UadpDataSetWriterMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31738,7 +31738,7 @@
     "schemaDefinitions": {
       "UadpDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "const": {
           "Timestamp": 0,
           "PicoSeconds": 1,
@@ -31794,7 +31794,7 @@
       },
       "DataSetMessageContentMask": {
         "title": "UadpDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -31846,7 +31846,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UadpDataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21116",
+    "dov:typeRef": "org.opcfoundation.UA.UadpDataSetReaderMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -31858,7 +31858,7 @@
     "schemaDefinitions": {
       "UadpNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "const": {
           "PublisherId": 0,
           "GroupHeader": 1,
@@ -31910,7 +31910,7 @@
       },
       "UadpDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "const": {
           "Timestamp": 0,
           "PicoSeconds": 1,
@@ -31965,7 +31965,7 @@
       },
       "DataSetMessageContentMask": {
         "title": "UadpDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15646",
+        "dov:typeRef": "org.opcfoundation.UA.UadpDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32006,7 +32006,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "UadpNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15642",
+        "dov:typeRef": "org.opcfoundation.UA.UadpNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32081,7 +32081,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonWriterGroupMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21126",
+    "dov:typeRef": "org.opcfoundation.UA.JsonWriterGroupMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32093,7 +32093,7 @@
     "schemaDefinitions": {
       "JsonNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "const": {
           "NetworkMessageHeader": 0,
           "DataSetMessageHeader": 1,
@@ -32140,7 +32140,7 @@
     "properties": {
       "NetworkMessageContentMask": {
         "title": "JsonNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32166,7 +32166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonDataSetWriterMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21128",
+    "dov:typeRef": "org.opcfoundation.UA.JsonDataSetWriterMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32178,7 +32178,7 @@
     "schemaDefinitions": {
       "JsonDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "const": {
           "DataSetWriterId": 0,
           "MetaDataVersion": 1,
@@ -32245,7 +32245,7 @@
     "properties": {
       "DataSetMessageContentMask": {
         "title": "JsonDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32271,7 +32271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_JsonDataSetReaderMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21130",
+    "dov:typeRef": "org.opcfoundation.UA.JsonDataSetReaderMessageType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32283,7 +32283,7 @@
     "schemaDefinitions": {
       "JsonNetworkMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "const": {
           "NetworkMessageHeader": 0,
           "DataSetMessageHeader": 1,
@@ -32319,7 +32319,7 @@
       },
       "JsonDataSetMessageContentMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "const": {
           "DataSetWriterId": 0,
           "MetaDataVersion": 1,
@@ -32386,7 +32386,7 @@
     "properties": {
       "DataSetMessageContentMask": {
         "title": "JsonDataSetMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15658",
+        "dov:typeRef": "org.opcfoundation.UA.JsonDataSetMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32401,7 +32401,7 @@
       },
       "NetworkMessageContentMask": {
         "title": "JsonNetworkMessageContentMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15654",
+        "dov:typeRef": "org.opcfoundation.UA.JsonNetworkMessageContentMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32427,7 +32427,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15064",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramConnectionTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32518,7 +32518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramWriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21133",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramWriterGroupTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32632,7 +32632,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_DatagramDataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24016",
+    "dov:typeRef": "org.opcfoundation.UA.DatagramDataSetReaderTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32708,7 +32708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerConnectionTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15155",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerConnectionTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32764,7 +32764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerWriterGroupTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21136",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerWriterGroupTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32776,7 +32776,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -32837,7 +32837,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -32874,7 +32874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerDataSetWriterTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21138",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerDataSetWriterTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -32886,7 +32886,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -32970,7 +32970,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33007,7 +33007,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BrokerDataSetReaderTransportType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21142",
+    "dov:typeRef": "org.opcfoundation.UA.BrokerDataSetReaderTransportType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33019,7 +33019,7 @@
     "schemaDefinitions": {
       "BrokerTransportQualityOfService": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "const": {
           "NotSpecified": 0,
           "BestEffort": 1,
@@ -33091,7 +33091,7 @@
       },
       "RequestedDeliveryGuarantee": {
         "title": "BrokerTransportQualityOfService",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=15008",
+        "dov:typeRef": "org.opcfoundation.UA.BrokerTransportQualityOfService",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33128,7 +33128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NetworkAddressType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21145",
+    "dov:typeRef": "org.opcfoundation.UA.NetworkAddressType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33189,7 +33189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_NetworkAddressUrlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=21147",
+    "dov:typeRef": "org.opcfoundation.UA.NetworkAddressUrlType",
     "dov:isComposite": true,
     "links": [
       {
@@ -33251,7 +33251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AliasNameType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23455",
+    "dov:typeRef": "org.opcfoundation.UA.AliasNameType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33277,7 +33277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_AliasNameCategoryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23456",
+    "dov:typeRef": "org.opcfoundation.UA.AliasNameCategoryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33298,7 +33298,7 @@
       "FindAlias": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23463",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AliasNameSearchPattern", "ReferenceTypeFilter" ],
           "properties": {
             "AliasNameSearchPattern": {
@@ -33311,7 +33311,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23464",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AliasNodeList" ],
           "properties": {
             "AliasNodeList": {
@@ -33319,7 +33319,7 @@
               "items": {
                 "title": "AliasNameDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=23468",
+                "dov:typeRef": "org.opcfoundation.UA.AliasNameDataType",
                 "required": [ "AliasName", "ReferencedNodes" ],
                 "properties": {
                   "AliasName": {
@@ -33372,7 +33372,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_UserManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24264",
+    "dov:typeRef": "org.opcfoundation.UA.UserManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33383,7 +33383,7 @@
     "schemaDefinitions": {
       "UserConfigurationMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+        "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
         "const": {
           "NoDelete": 0,
           "Disabled": 1,
@@ -33411,7 +33411,7 @@
       },
       "PasswordOptionsMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24277",
+        "dov:typeRef": "org.opcfoundation.UA.PasswordOptionsMask",
         "const": {
           "SupportInitialPasswordChange": 0,
           "SupportDisableUser": 1,
@@ -33474,7 +33474,7 @@
       "AddUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24270",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName", "Password", "UserConfiguration", "Description" ],
           "properties": {
             "UserName": {
@@ -33485,7 +33485,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33506,7 +33506,7 @@
       "ChangePassword": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24276",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "OldPassword", "NewPassword" ],
           "properties": {
             "OldPassword": {
@@ -33528,7 +33528,7 @@
       "ModifyUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24272",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName", "ModifyPassword", "Password", "ModifyUserConfiguration", "UserConfiguration", "ModifyDescription", "Description" ],
           "properties": {
             "UserName": {
@@ -33545,7 +33545,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33569,7 +33569,7 @@
       "RemoveUser": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24274",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "UserName" ],
           "properties": {
             "UserName": {
@@ -33590,7 +33590,7 @@
       "PasswordLength": {
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -33615,7 +33615,7 @@
       },
       "PasswordOptions": {
         "title": "PasswordOptionsMask",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24277",
+        "dov:typeRef": "org.opcfoundation.UA.PasswordOptionsMask",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33644,7 +33644,7 @@
         "items": {
           "title": "UserManagementDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24281",
+          "dov:typeRef": "org.opcfoundation.UA.UserManagementDataType",
           "required": [ "UserName", "UserConfiguration", "Description" ],
           "properties": {
             "UserName": {
@@ -33652,7 +33652,7 @@
             },
             "UserConfiguration": {
               "title": "UserConfigurationMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24279",
+              "dov:typeRef": "org.opcfoundation.UA.UserConfigurationMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -33684,7 +33684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ProvisionableDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26871",
+    "dov:typeRef": "org.opcfoundation.UA.ProvisionableDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33701,7 +33701,7 @@
     "schemaDefinitions": {
       "ApplicationType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+        "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
         "const": {
           "Server": 0,
           "Client": 1,
@@ -33735,7 +33735,7 @@
       "RequestTickets": {
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26874",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Tickets" ],
           "properties": {
             "Tickets": {
@@ -33757,7 +33757,7 @@
       "SetRegistrarEndpoints": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=26876",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Registrars" ],
           "properties": {
             "Registrars": {
@@ -33765,7 +33765,7 @@
               "items": {
                 "title": "ApplicationDescription",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=308",
+                "dov:typeRef": "org.opcfoundation.UA.ApplicationDescription",
                 "required": [ "ApplicationUri", "ProductUri", "ApplicationName", "ApplicationType", "GatewayServerUri", "DiscoveryProfileUri", "DiscoveryUrls" ],
                 "properties": {
                   "ApplicationUri": {
@@ -33779,7 +33779,7 @@
                   },
                   "ApplicationType": {
                     "title": "ApplicationType",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=307",
+                    "dov:typeRef": "org.opcfoundation.UA.ApplicationType",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -33835,7 +33835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIetfBaseNetworkInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24148",
+    "dov:typeRef": "org.opcfoundation.UA.IIetfBaseNetworkInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -33846,7 +33846,7 @@
     "schemaDefinitions": {
       "InterfaceAdminStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -33869,7 +33869,7 @@
       },
       "InterfaceOperStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -33928,7 +33928,7 @@
     "properties": {
       "AdminStatus": {
         "title": "InterfaceAdminStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33943,7 +33943,7 @@
       },
       "OperStatus": {
         "title": "InterfaceOperStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -33985,7 +33985,7 @@
       "AdminStatus": {
         "data": {
           "title": "InterfaceAdminStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34001,7 +34001,7 @@
       "OperStatus": {
         "data": {
           "title": "InterfaceOperStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34051,7 +34051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseEthernetPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24158",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseEthernetPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34062,7 +34062,7 @@
     "schemaDefinitions": {
       "Duplex": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+        "dov:typeRef": "org.opcfoundation.UA.Duplex",
         "const": {
           "Full": 0,
           "Half": 1,
@@ -34101,7 +34101,7 @@
     "properties": {
       "Duplex": {
         "title": "Duplex",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+        "dov:typeRef": "org.opcfoundation.UA.Duplex",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34145,7 +34145,7 @@
       "Duplex": {
         "data": {
           "title": "Duplex",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24210",
+          "dov:typeRef": "org.opcfoundation.UA.Duplex",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34197,7 +34197,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeAutoNegotiationStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24233",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeAutoNegotiationStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34208,7 +34208,7 @@
     "schemaDefinitions": {
       "NegotiationStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+        "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
         "const": {
           "InProgress": 0,
           "Complete": 1,
@@ -34257,7 +34257,7 @@
     "properties": {
       "NegotiationStatus": {
         "title": "NegotiationStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+        "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34275,7 +34275,7 @@
       "NegotiationStatus": {
         "data": {
           "title": "NegotiationStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24216",
+          "dov:typeRef": "org.opcfoundation.UA.NegotiationStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34299,7 +34299,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IBaseEthernetCapabilitiesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24167",
+    "dov:typeRef": "org.opcfoundation.UA.IBaseEthernetCapabilitiesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34360,7 +34360,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IVlanIdType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25218",
+    "dov:typeRef": "org.opcfoundation.UA.IVlanIdType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34425,7 +34425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_ISrClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24169",
+    "dov:typeRef": "org.opcfoundation.UA.ISrClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34544,7 +34544,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24173",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnStreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34555,7 +34555,7 @@
     "schemaDefinitions": {
       "TsnStreamState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+        "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
         "const": {
           "Disabled": 0,
           "Configuring": 1,
@@ -34630,7 +34630,7 @@
       },
       "State": {
         "title": "TsnStreamState",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+        "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -34703,7 +34703,7 @@
       "State": {
         "data": {
           "title": "TsnStreamState",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24220",
+          "dov:typeRef": "org.opcfoundation.UA.TsnStreamState",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -34756,7 +34756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnTrafficSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24179",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnTrafficSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34784,7 +34784,7 @@
       "Interval": {
         "title": "UnsignedRationalNumber",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24107",
+        "dov:typeRef": "org.opcfoundation.UA.UnsignedRationalNumber",
         "required": [ "Numerator", "Denominator" ],
         "properties": {
           "Numerator": {
@@ -34839,7 +34839,7 @@
         "data": {
           "title": "UnsignedRationalNumber",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24107",
+          "dov:typeRef": "org.opcfoundation.UA.UnsignedRationalNumber",
           "required": [ "Numerator", "Denominator" ],
           "properties": {
             "Numerator": {
@@ -34901,7 +34901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeBaseTsnStatusStreamType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24183",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeBaseTsnStatusStreamType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34912,7 +34912,7 @@
     "schemaDefinitions": {
       "TsnTalkerStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+        "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
         "const": {
           "None": 0,
           "Ready": 1,
@@ -34935,7 +34935,7 @@
       },
       "TsnListenerStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+        "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
         "const": {
           "None": 0,
           "Ready": 1,
@@ -34963,7 +34963,7 @@
       },
       "TsnFailureCode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+        "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
         "const": {
           "NoFailure": 0,
           "InsufficientBandwidth": 1,
@@ -35117,7 +35117,7 @@
     "properties": {
       "FailureCode": {
         "title": "TsnFailureCode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+        "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35151,7 +35151,7 @@
       },
       "ListenerStatus": {
         "title": "TsnListenerStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+        "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35166,7 +35166,7 @@
       },
       "TalkerStatus": {
         "title": "TsnTalkerStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+        "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35184,7 +35184,7 @@
       "FailureCode": {
         "data": {
           "title": "TsnFailureCode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24218",
+          "dov:typeRef": "org.opcfoundation.UA.TsnFailureCode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35220,7 +35220,7 @@
       "ListenerStatus": {
         "data": {
           "title": "TsnListenerStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24224",
+          "dov:typeRef": "org.opcfoundation.UA.TsnListenerStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35236,7 +35236,7 @@
       "TalkerStatus": {
         "data": {
           "title": "TsnTalkerStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24222",
+          "dov:typeRef": "org.opcfoundation.UA.TsnTalkerStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35260,7 +35260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24188",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35344,7 +35344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationTalkerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24191",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationTalkerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35409,7 +35409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnInterfaceConfigurationListenerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24195",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnInterfaceConfigurationListenerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35474,7 +35474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnMacAddressType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24199",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnMacAddressType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35578,7 +35578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IIeeeTsnVlanTagType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24202",
+    "dov:typeRef": "org.opcfoundation.UA.IIeeeTsnVlanTagType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35670,7 +35670,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IPriorityMappingEntryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24205",
+    "dov:typeRef": "org.opcfoundation.UA.IPriorityMappingEntryType",
     "links": [
       {
         "rel": "tm:extends",
@@ -35808,7 +35808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_IetfBaseNetworkInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25221",
+    "dov:typeRef": "org.opcfoundation.UA.IetfBaseNetworkInterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35820,7 +35820,7 @@
     "schemaDefinitions": {
       "InterfaceAdminStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -35843,7 +35843,7 @@
       },
       "InterfaceOperStatus": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "const": {
           "Up": 0,
           "Down": 1,
@@ -35902,7 +35902,7 @@
     "properties": {
       "AdminStatus": {
         "title": "InterfaceAdminStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35917,7 +35917,7 @@
       },
       "OperStatus": {
         "title": "InterfaceOperStatus",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+        "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -35959,7 +35959,7 @@
       "AdminStatus": {
         "data": {
           "title": "InterfaceAdminStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24212",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceAdminStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -35975,7 +35975,7 @@
       "OperStatus": {
         "data": {
           "title": "InterfaceOperStatus",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=24214",
+          "dov:typeRef": "org.opcfoundation.UA.InterfaceOperStatus",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -36025,7 +36025,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_PriorityMappingTableType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25227",
+    "dov:typeRef": "org.opcfoundation.UA.PriorityMappingTableType",
     "dov:isComposite": true,
     "links": [
       {
@@ -36047,7 +36047,7 @@
       "AddPriorityMappingEntry": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25230",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MappingUri", "PriorityLabel", "PriorityValue_PCP", "PriorityValue_DSCP" ],
           "properties": {
             "MappingUri": {
@@ -36079,7 +36079,7 @@
       "DeletePriorityMappingEntry": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MappingUri", "PriorityLabel" ],
           "properties": {
             "MappingUri": {
@@ -36105,7 +36105,7 @@
         "items": {
           "title": "PriorityMappingEntryType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=25220",
+          "dov:typeRef": "org.opcfoundation.UA.PriorityMappingEntryType",
           "required": [ "MappingUri", "PriorityLabel", "PriorityValue_PCP", "PriorityValue_DSCP" ],
           "properties": {
             "MappingUri": {
@@ -36148,7 +36148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18973",
+    "dov:typeRef": "org.opcfoundation.UA.LldpInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36192,7 +36192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpRemoteStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18996",
+    "dov:typeRef": "org.opcfoundation.UA.LldpRemoteStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36365,7 +36365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpLocalSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19002",
+    "dov:typeRef": "org.opcfoundation.UA.LldpLocalSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36376,7 +36376,7 @@
     "schemaDefinitions": {
       "ChassisIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "const": {
           "ChassisComponent": 1,
           "InterfaceAlias": 2,
@@ -36419,7 +36419,7 @@
       },
       "LldpSystemCapabilitiesMap": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "const": {
           "Other": 0,
           "Repeater": 1,
@@ -36504,7 +36504,7 @@
       },
       "ChassisIdSubtype": {
         "title": "ChassisIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36519,7 +36519,7 @@
       },
       "SystemCapabilitiesEnabled": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36534,7 +36534,7 @@
       },
       "SystemCapabilitiesSupported": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36582,7 +36582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpPortInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19009",
+    "dov:typeRef": "org.opcfoundation.UA.LldpPortInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36599,7 +36599,7 @@
     "schemaDefinitions": {
       "PortIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "const": {
           "InterfaceAlias": 1,
           "PortComponent": 2,
@@ -36642,7 +36642,7 @@
       },
       "ManAddrIfSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+        "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
         "const": {
           "None": 0,
           "Unknown": 1,
@@ -36711,7 +36711,7 @@
         "items": {
           "title": "LldpManagementAddressTxPortType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18953",
+          "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressTxPortType",
           "required": [ "AddressSubtype", "ManAddress", "TxEnable", "AddrLen", "IfSubtype", "IfId" ],
           "properties": {
             "AddressSubtype": {
@@ -36732,7 +36732,7 @@
             },
             "IfSubtype": {
               "title": "ManAddrIfSubtype",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+              "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -36777,7 +36777,7 @@
       },
       "PortIdSubtype": {
         "title": "PortIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -36803,7 +36803,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LldpRemoteSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19033",
+    "dov:typeRef": "org.opcfoundation.UA.LldpRemoteSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36814,7 +36814,7 @@
     "schemaDefinitions": {
       "ChassisIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "const": {
           "ChassisComponent": 1,
           "InterfaceAlias": 2,
@@ -36857,7 +36857,7 @@
       },
       "PortIdSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "const": {
           "InterfaceAlias": 1,
           "PortComponent": 2,
@@ -36900,7 +36900,7 @@
       },
       "LldpSystemCapabilitiesMap": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "const": {
           "Other": 0,
           "Repeater": 1,
@@ -36963,7 +36963,7 @@
       },
       "ManAddrIfSubtype": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+        "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
         "const": {
           "None": 0,
           "Unknown": 1,
@@ -37018,7 +37018,7 @@
       },
       "ChassisIdSubtype": {
         "title": "ChassisIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+        "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37036,7 +37036,7 @@
         "items": {
           "title": "LldpManagementAddressType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18954",
+          "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressType",
           "required": [ "AddressSubtype", "Address", "IfSubtype", "IfId" ],
           "properties": {
             "AddressSubtype": {
@@ -37049,7 +37049,7 @@
             },
             "IfSubtype": {
               "title": "ManAddrIfSubtype",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+              "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -37094,7 +37094,7 @@
       },
       "PortIdSubtype": {
         "title": "PortIdSubtype",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+        "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37147,7 +37147,7 @@
         "items": {
           "title": "LldpTlvType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18955",
+          "dov:typeRef": "org.opcfoundation.UA.LldpTlvType",
           "required": [ "TlvType", "TlvInfo" ],
           "properties": {
             "TlvType": {
@@ -37172,7 +37172,7 @@
       },
       "SystemCapabilitiesEnabled": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37187,7 +37187,7 @@
       },
       "SystemCapabilitiesSupported": {
         "title": "LldpSystemCapabilitiesMap",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+        "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -37252,7 +37252,7 @@
       "ChassisIdSubtype": {
         "data": {
           "title": "ChassisIdSubtype",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18947",
+          "dov:typeRef": "org.opcfoundation.UA.ChassisIdSubtype",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37271,7 +37271,7 @@
           "items": {
             "title": "LldpManagementAddressType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18954",
+            "dov:typeRef": "org.opcfoundation.UA.LldpManagementAddressType",
             "required": [ "AddressSubtype", "Address", "IfSubtype", "IfId" ],
             "properties": {
               "AddressSubtype": {
@@ -37284,7 +37284,7 @@
               },
               "IfSubtype": {
                 "title": "ManAddrIfSubtype",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18951",
+                "dov:typeRef": "org.opcfoundation.UA.ManAddrIfSubtype",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -37332,7 +37332,7 @@
       "PortIdSubtype": {
         "data": {
           "title": "PortIdSubtype",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18949",
+          "dov:typeRef": "org.opcfoundation.UA.PortIdSubtype",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37389,7 +37389,7 @@
           "items": {
             "title": "LldpTlvType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18955",
+            "dov:typeRef": "org.opcfoundation.UA.LldpTlvType",
             "required": [ "TlvType", "TlvInfo" ],
             "properties": {
               "TlvType": {
@@ -37415,7 +37415,7 @@
       "SystemCapabilitiesEnabled": {
         "data": {
           "title": "LldpSystemCapabilitiesMap",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+          "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37431,7 +37431,7 @@
       "SystemCapabilitiesSupported": {
         "data": {
           "title": "LldpSystemCapabilitiesMap",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18956",
+          "dov:typeRef": "org.opcfoundation.UA.LldpSystemCapabilitiesMap",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -37493,7 +37493,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_SerializationEntityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19824",
+    "dov:typeRef": "org.opcfoundation.UA.SerializationEntityType",
     "dov:isComposite": true,
     "links": [
       {
@@ -37520,7 +37520,7 @@
       "ConfigureSerialization": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19840",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SerializationFilterProperties" ],
           "properties": {
             "SerializationFilterProperties": {
@@ -37528,7 +37528,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -37545,7 +37545,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19841",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results" ],
           "properties": {
             "Results": {
@@ -37584,7 +37584,7 @@
         "items": {
           "title": "KeyValuePair",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+          "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
           "required": [ "Key", "Value" ],
           "properties": {
             "Key": {
@@ -37726,7 +37726,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19352",
+    "dov:typeRef": "org.opcfoundation.UA.LogObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -37737,7 +37737,7 @@
     "schemaDefinitions": {
       "LogRecordMask": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+        "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
         "const": {
           "EventType": 0,
           "SourceNode": 1,
@@ -37775,7 +37775,7 @@
       "GetRecords": {
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19354",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StartTime", "EndTime", "MaxReturnRecords", "MinimumSeverity", "RequestMask", "ContinuationPointIn" ],
           "properties": {
             "StartTime": {
@@ -37798,7 +37798,7 @@
             },
             "RequestMask": {
               "title": "LogRecordMask",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19749",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordMask",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -37811,13 +37811,13 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19355",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Results", "ContinuationPointOut" ],
           "properties": {
             "Results": {
               "title": "LogRecordsDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19745",
+              "dov:typeRef": "org.opcfoundation.UA.LogRecordsDataType",
               "required": [ "LogRecordArray" ],
               "properties": {
                 "LogRecordArray": {
@@ -37825,7 +37825,7 @@
                   "items": {
                     "title": "LogRecord",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19361",
+                    "dov:typeRef": "org.opcfoundation.UA.LogRecord",
                     "required": [ "Time", "Severity", "Message" ],
                     "properties": {
                       "Time": {
@@ -37852,7 +37852,7 @@
                       "TraceContext": {
                         "title": "TraceContextDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19747",
+                        "dov:typeRef": "org.opcfoundation.UA.TraceContextDataType",
                         "required": [ "ParentSpanId", "ParentIdentifier" ],
                         "properties": {
                           "ParentSpanId": {
@@ -37870,7 +37870,7 @@
                         "items": {
                           "title": "NameValuePair",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19748",
+                          "dov:typeRef": "org.opcfoundation.UA.NameValuePair",
                           "required": [ "Name", "Value" ],
                           "properties": {
                             "Name": {
@@ -37955,7 +37955,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_BaseLogEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19362",
+    "dov:typeRef": "org.opcfoundation.UA.BaseLogEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38033,7 +38033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogOverflowEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19369",
+    "dov:typeRef": "org.opcfoundation.UA.LogOverflowEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -38060,7 +38060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "OpcUaCore_LogEntryConditionClassType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=19370",
+    "dov:typeRef": "org.opcfoundation.UA.LogEntryConditionClassType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PADIM.TM.json
+++ b/wot-codegen/opc-output-simple/PADIM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PADIMType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PADIMType",
     "dov:isComposite": true,
     "links": [
       {
@@ -44,7 +44,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -77,7 +77,7 @@
       },
       "ResetModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
         "const": {
           "Application": 1,
           "Communication": 2712,
@@ -118,12 +118,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1030",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResetMode" ],
           "properties": {
             "ResetMode": {
               "title": "ResetModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -184,7 +184,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -356,7 +356,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -393,7 +393,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -425,7 +425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAdministrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAdministrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -436,7 +436,7 @@
     "schemaDefinitions": {
       "ResetModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
         "const": {
           "Application": 1,
           "Communication": 2712,
@@ -477,12 +477,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1080",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResetMode" ],
           "properties": {
             "ResetMode": {
               "title": "ResetModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1156",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ResetModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -569,7 +569,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ISignalSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ISignalSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -601,7 +601,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_SignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.SignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -656,7 +656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalogSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalogSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -752,7 +752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -764,7 +764,7 @@
     "schemaDefinitions": {
       "ExecutionModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1158",
+        "dov:typeRef": "org.opcfoundation.UA.PADIM.ExecutionModeEnum",
         "const": {
           "Start": 2,
           "Abort": 255
@@ -801,12 +801,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PADIM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1119",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ExecutionMode" ],
           "properties": {
             "ExecutionMode": {
               "title": "ExecutionModeEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1158",
+              "dov:typeRef": "org.opcfoundation.UA.PADIM.ExecutionModeEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -980,7 +980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_DiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.DiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1056,7 +1056,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TwoStateDiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TwoStateDiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1130,7 +1130,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_MultiStateDiscreteSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.MultiStateDiscreteSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1208,7 +1208,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TwoStateDiscreteControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1223",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TwoStateDiscreteControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1352,7 +1352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_MultiStateDiscreteControlSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1239",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.MultiStateDiscreteControlSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1468,7 +1468,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_CalibrationPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.CalibrationPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1564,7 +1564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_CalibrationPointSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.CalibrationPointSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1596,7 +1596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_GeneralDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.GeneralDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1719,7 +1719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IGeneralDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IGeneralDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1757,7 +1757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ICalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ICalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1858,7 +1858,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IPhCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IPhCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1968,7 +1968,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IConductivityCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IConductivityCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2035,7 +2035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAmperometricCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAmperometricCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2174,7 +2174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IOpticalFluorescenseQuenchingCalibrationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IOpticalFluorescenseQuenchingCalibrationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2313,7 +2313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITocDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITocDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2554,7 +2554,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IFlameIonisationDeviceConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IFlameIonisationDeviceConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2708,7 +2708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_INonDispersiveInfraredSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.INonDispersiveInfraredSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2847,7 +2847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITocSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITocSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3073,7 +3073,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IParamagneticSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IParamagneticSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3169,7 +3169,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IThermalConductivitySignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IThermalConductivitySignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3236,7 +3236,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ITunableDiodeLaserSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ITunableDiodeLaserSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3458,7 +3458,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IZirconiumDioxideSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IZirconiumDioxideSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3583,7 +3583,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IPhSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IPhSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3794,7 +3794,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IConductivitySignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IConductivitySignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3947,7 +3947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IOpticalFluorescenseQuenchingSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IOpticalFluorescenseQuenchingSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4071,7 +4071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_IAmperometricSignalConditionSetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.IAmperometricSignalConditionSetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4195,7 +4195,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AnalyticalSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AnalyticalSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4273,7 +4273,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AmperometricSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AmperometricSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4312,7 +4312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ConductivitySignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1067",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ConductivitySignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4351,7 +4351,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_FlameIonisationSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.FlameIonisationSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4378,7 +4378,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_NonDispersiveInfraredSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1071",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.NonDispersiveInfraredSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4411,7 +4411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_OpticalFluorescenseQuenchingSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1073",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.OpticalFluorescenseQuenchingSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4450,7 +4450,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ParamagneticSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1075",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ParamagneticSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4483,7 +4483,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PhSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1076",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PhSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4522,7 +4522,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ThermalConductivitySignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1077",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ThermalConductivitySignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4555,7 +4555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TocSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TocSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4588,7 +4588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TunableDiodeLaserSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TunableDiodeLaserSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4621,7 +4621,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ZirconiumDioxideSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ZirconiumDioxideSignalType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4654,7 +4654,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ProcessAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1082",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ProcessAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4681,7 +4681,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_AmperometricAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1083",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.AmperometricAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4708,7 +4708,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ConductivityMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ConductivityMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4735,7 +4735,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_FlameIonisationDetectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1085",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.FlameIonisationDetectorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4768,7 +4768,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_NonDispersiveInfraredGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1086",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.NonDispersiveInfraredGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4795,7 +4795,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_OpticalFluorescenseQuenchingSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.OpticalFluorescenseQuenchingSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4822,7 +4822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ParamagneticGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1088",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ParamagneticGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4849,7 +4849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_PhMeterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1089",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.PhMeterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4876,7 +4876,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ThermalConductivityGasAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ThermalConductivityGasAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4903,7 +4903,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TocAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1091",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TocAnalyserType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4936,7 +4936,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_TunableDiodeLaserSpectrometerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1092",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.TunableDiodeLaserSpectrometerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4963,7 +4963,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PADIM_ZirconiumDioxideAnalyserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PADIM/;i=1093",
+    "dov:typeRef": "org.opcfoundation.UA.PADIM.ZirconiumDioxideAnalyserType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PAEFS.TM.json
+++ b/wot-codegen/opc-output-simple/PAEFS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AirConnectionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -49,7 +49,7 @@
     "schemaDefinitions": {
       "AirConnectionOpenEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "const": {
           "Open": 0,
           "Closed": 1,
@@ -109,7 +109,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AirConnectionOpenEnum",
         "description": "Indicates the connections status (open, closed, or a state in between)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -148,7 +148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CompressedAirSupplyInterruptedAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CompressedAirSupplyInterruptedAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -175,7 +175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_EndOfFilterRollAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.EndOfFilterRollAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -202,7 +202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -229,7 +229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SafetySystemTriggeredAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SafetySystemTriggeredAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentDrainMalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentDrainMalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -283,7 +283,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentInflowMalfunctionAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentInflowMalfunctionAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -310,7 +310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningRecommendedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningRecommendedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -357,7 +357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MaintenanceRequestedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MaintenanceRequestedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -404,7 +404,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AirConnectionStatusChangedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionStatusChangedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -416,7 +416,7 @@
     "schemaDefinitions": {
       "AirConnectionOpenEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "const": {
           "Open": 0,
           "Closed": 1,
@@ -454,7 +454,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AirConnectionOpenEnum",
         "description": "Reflects the value of the ConnectionOpen property at the time the event is triggered",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AirConnectionOpenEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -480,7 +480,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitActiveConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitActiveConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -527,7 +527,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ContainerOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ContainerOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -574,7 +574,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_DischargeContainerInstalledConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.DischargeContainerInstalledConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -621,7 +621,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterAidDeviceStatusChangedConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusChangedConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -633,7 +633,7 @@
     "schemaDefinitions": {
       "FilterAidDeviceStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "const": {
           "DeviceActive": 0,
           "DeviceInactive": 1,
@@ -671,7 +671,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "FilterAidDeviceStatusEnum",
         "description": "Reflects the value of the FilterAidDeviceStatus property at the time the condition was triggered",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -697,7 +697,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_MaintenanceSwitchConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.MaintenanceSwitchConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -744,7 +744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentDrainOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentDrainOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -791,7 +791,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WashingAgentInflowOpenConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WashingAgentInflowOpenConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -838,7 +838,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_HighVoltageUnitSupplyActiveEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.HighVoltageUnitSupplyActiveEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -885,7 +885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1042,7 +1042,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CleaningUnitValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CleaningUnitValveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1101,7 +1101,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CollectorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CollectorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1133,7 +1133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ConsumptionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ConsumptionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1208,7 +1208,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_DischargeSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.DischargeSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1321,7 +1321,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FanType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FanType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1398,7 +1398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterAidDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1439,7 +1439,7 @@
     "schemaDefinitions": {
       "FilterAidDeviceStatusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "const": {
           "DeviceActive": 0,
           "DeviceInactive": 1,
@@ -1561,7 +1561,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "FilterAidDeviceStatusEnum",
         "description": "Describes the action performed by the dosage unit (see FilterAidDeviceStatusEnum).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterAidDeviceStatusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1600,7 +1600,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1678,7 +1678,7 @@
     "schemaDefinitions": {
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.ControlModeEnum",
         "const": {
           "Automatic": 0,
           "Manual": 1,
@@ -1734,7 +1734,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "ControlModeEnum",
         "description": "Operating mode that describes whether the system can be controlled externally. Possible values are manual, auto and other.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1825,7 +1825,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1942,7 +1942,7 @@
         "description": "The Method SetAirflowSetpoint sets a setpoint for the airflow. The value’s unit is the same as the one specified in object Airflow. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for pressure and rotational speed to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6277",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -1965,7 +1965,7 @@
         "description": "The Method SetPressureSetpoint sets a setpoint for the pressure. The value’s unit is the same as the one specified in object Pressure. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for airflow and rotational speed to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6278",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -1988,7 +1988,7 @@
         "description": "The Method SetRotationalSpeedSetpoint sets a setpoint for the rotational speed. The value’s unit is the same as the one specified in object RotationalSpeed. Since setpoints are mutually exclusive, the method also sets the boolean IsActiveSetpoint of the setpoints for airflow and pressure to false.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=6279",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value" ],
           "properties": {
             "Value": {
@@ -2086,7 +2086,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_FilterMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.FilterMachineIdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2215,7 +2215,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_HighVoltageUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.HighVoltageUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2374,7 +2374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_IonizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.IonizerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2406,7 +2406,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SafetySystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SafetySystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2471,7 +2471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2494,7 +2494,7 @@
     "schemaDefinitions": {
       "AnalogDigitalEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AnalogDigitalEnum",
         "const": {
           "Analog": 0,
           "Digital": 1
@@ -2524,7 +2524,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PAEFS/",
         "title": "AnalogDigitalEnum",
         "description": "Specifies whether the sensor is an analog or a digital sensor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PAEFS.AnalogDigitalEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2550,7 +2550,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorSetpointReadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorSetpointReadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2602,7 +2602,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SensorSetpointWriteType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SensorSetpointWriteType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2634,7 +2634,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_SeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.SeparatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2706,7 +2706,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_AutomaticRollFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.AutomaticRollFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2753,7 +2753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_CartridgeFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.CartridgeFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2780,7 +2780,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_ElectrostaticPrecipitatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.ElectrostaticPrecipitatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2813,7 +2813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_WetSeparatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.WetSeparatorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2899,7 +2899,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PAEFS_TemperatureRegulatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PAEFS/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PAEFS.TemperatureRegulatorType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PDRV.TM.json
+++ b/wot-codegen/opc-output-simple/PDRV.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_DriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.DriveAxisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -90,7 +90,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PDRV/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=6038",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -147,7 +147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_VelocityDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.VelocityDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -192,7 +192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_FrequencyDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.FrequencyDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -237,7 +237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_PositioningDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.PositioningDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -306,7 +306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_TraversingTaskType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.TraversingTaskType",
     "links": [
       {
         "rel": "tm:extends",
@@ -518,7 +518,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_VelocityServoDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.VelocityServoDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -581,7 +581,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_PositionServoDriveAxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.PositionServoDriveAxisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -656,7 +656,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_DiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.DiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -668,7 +668,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -704,7 +704,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PDRV/",
         "title": "LogEntryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
         "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
         "properties": {
           "FaultSituationNumber": {
@@ -722,7 +722,7 @@
           "EventType": {
             "title": "EventTypeEnumeration",
             "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -775,7 +775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisSwOvertravelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisSwOvertravelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -821,7 +821,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisHwOvertravelEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisHwOvertravelEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -867,7 +867,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_SafetyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.SafetyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -941,7 +941,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_TorqueLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.TorqueLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1003,7 +1003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_MotorCurrentLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.MotorCurrentLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1065,7 +1065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_SafetyFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.SafetyFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1175,7 +1175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_ForceLimitEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.ForceLimitEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1237,7 +1237,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PDRV_AxisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PDRV/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.PDRV.AxisEventType",
     "dov:isEvent": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PNEM.TM.json
+++ b/wot-codegen/opc-output-simple/PNEM.TM.json
@@ -9,7 +9,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileD0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileD0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -103,7 +103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE0Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE0Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -137,7 +137,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -191,7 +191,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -233,7 +233,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE1Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE1Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -327,7 +327,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE2Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE2Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -521,7 +521,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_IEnergyProfileE3Type",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.IEnergyProfileE3Type",
     "links": [
       {
         "rel": "tm:extends",
@@ -597,7 +597,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -636,7 +636,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -675,7 +675,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -750,7 +750,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -789,7 +789,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPeDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -828,7 +828,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "AcPpDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPpDataType",
         "required": [ "A_b", "B_c", "C_a" ],
         "properties": {
           "A_b": {
@@ -988,7 +988,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1023,7 +1023,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1058,7 +1058,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1121,7 +1121,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1156,7 +1156,7 @@
         "data": {
           "title": "AcPeDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPeDataType",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -1191,7 +1191,7 @@
         "data": {
           "title": "AcPpDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.AcPpDataType",
           "required": [ "A_b", "B_c", "C_a" ],
           "properties": {
             "A_b": {
@@ -1232,7 +1232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyDevicePowerOffType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyDevicePowerOffType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1260,7 +1260,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6110",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -1411,7 +1411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyMeasurementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1501,7 +1501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModesContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModesContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1533,7 +1533,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModeStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModeStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1562,7 +1562,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "StandbyModeTransitionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.StandbyModeTransitionDataType",
         "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
         "properties": {
           "IDDestination": {
@@ -1601,7 +1601,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "EnergyStateInformationDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStateInformationDataType",
         "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
         "properties": {
           "IDSource": {
@@ -1644,7 +1644,7 @@
         "data": {
           "title": "StandbyModeTransitionDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.StandbyModeTransitionDataType",
           "required": [ "IDDestination", "CurrentTimeToDestination", "CurrentTimeToOperate", "EnergyConsumptionToDestination" ],
           "properties": {
             "IDDestination": {
@@ -1684,7 +1684,7 @@
         "data": {
           "title": "EnergyStateInformationDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStateInformationDataType",
           "required": [ "IDSource", "IDDestination", "RegularTimeToOperate", "ModePowerConsumption" ],
           "properties": {
             "IDSource": {
@@ -1731,7 +1731,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergySavingModeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergySavingModeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2017,7 +2017,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_EnergyStandbyManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.EnergyStandbyManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2063,7 +2063,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentTimeToOperate", "ReturnCode" ],
           "properties": {
             "CurrentTimeToOperate": {
@@ -2091,7 +2091,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PauseTime" ],
           "properties": {
             "PauseTime": {
@@ -2103,7 +2103,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthToStay", "ReturnCode" ],
           "properties": {
             "ModeID": {
@@ -2147,7 +2147,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ModeID" ],
           "properties": {
             "ModeID": {
@@ -2160,7 +2160,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EffectiveModeID", "CurrentTimeToDestination", "RegularTimeToOperate", "TimeMinLengthOfStay", "ReturnCode" ],
           "properties": {
             "EffectiveModeID": {
@@ -2271,7 +2271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNEM_PeServiceAccessPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNEM.PeServiceAccessPointType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2283,7 +2283,7 @@
     "schemaDefinitions": {
       "PeClassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeClassEnumeration",
         "const": {
           "PE_CLASS1": 0,
           "PE_CLASS2": 1,
@@ -2306,7 +2306,7 @@
       },
       "PeSubclassEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeSubclassEnumeration",
         "const": {
           "PE_SUBCLASS1": 0,
           "PE_SUBCLASS2": 1
@@ -2341,7 +2341,7 @@
       "PeClass": {
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeClassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeClassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2362,7 +2362,7 @@
       "PeSubclass": {
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeSubclassEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeSubclassEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2384,7 +2384,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNEM/",
         "title": "PeVersionDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNEM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNEM.PeVersionDataType",
         "required": [ "MajorVersion", "MinorVersion", "Revision" ],
         "properties": {
           "MajorVersion": {

--- a/wot-codegen/opc-output-simple/PNENC.TM.json
+++ b/wot-codegen/opc-output-simple/PNENC.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderDiagnosisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -43,7 +43,7 @@
       },
       "EncoderDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -83,7 +83,7 @@
       "DiagnosisType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EventTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -123,7 +123,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -149,7 +149,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbeLatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbeLatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -219,7 +219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderRefLatchEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderRefLatchEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -277,7 +277,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -289,7 +289,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -325,7 +325,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "LogEntryDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
         "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
         "properties": {
           "FaultSituationNumber": {
@@ -343,7 +343,7 @@
           "EventType": {
             "title": "EventTypeEnumeration",
             "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -396,7 +396,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderAxisConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -407,7 +407,7 @@
     "schemaDefinitions": {
       "EncoderAxisTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "const": {
           "ROTARY": 0,
           "LINEAR": 1
@@ -425,7 +425,7 @@
       },
       "EncoderCodeSequenceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "const": {
           "INCREASING_CLOCKWISE": 0,
           "INCREASING_COUNTERCLOCKWISE": 1
@@ -459,7 +459,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AxisConfigParameters" ],
           "properties": {
             "AxisConfigParameters": {
@@ -467,7 +467,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -484,7 +484,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AxisConfigParametersResult" ],
           "properties": {
             "AxisConfigParametersResult": {
@@ -492,7 +492,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -534,7 +534,7 @@
       "AxisType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAxisTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAxisTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -550,7 +550,7 @@
       "CodeSequence": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderCodeSequenceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderCodeSequenceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -677,7 +677,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -731,7 +731,7 @@
     "schemaDefinitions": {
       "EncoderChannelStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "const": {
           "NORMAL_OPERATION": 0,
           "ERROR_ACKNOWLEDGEMENT": 1,
@@ -810,7 +810,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6002",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -857,7 +857,7 @@
       "EncoderChannelState": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderChannelStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1157,7 +1157,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "data": {
           "title": "EncoderChannelStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderChannelStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1453,7 +1453,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderControlConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderControlConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1464,7 +1464,7 @@
     "schemaDefinitions": {
       "EncoderAlarmChannelControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "const": {
           "ALARM_CHANNEL_DISABLED": 0,
           "ALARM_CHANNEL_ENABLED": 1
@@ -1482,7 +1482,7 @@
       },
       "EncoderPresetControlEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "const": {
           "ENABLE_PRESET_CONTROL": 0,
           "DISABLE_PRESET_CONTROL": 1
@@ -1511,7 +1511,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlConfigParameters" ],
           "properties": {
             "ControlConfigParameters": {
@@ -1519,7 +1519,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1536,7 +1536,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ControlConfigParametersResult" ],
           "properties": {
             "ControlConfigParametersResult": {
@@ -1544,7 +1544,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1572,7 +1572,7 @@
       "AlarmChannelControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderAlarmChannelControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderAlarmChannelControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1602,7 +1602,7 @@
       "XIST1PresetControl": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderPresetControlEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderPresetControlEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1628,7 +1628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1660,7 +1660,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderProbeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderProbeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1764,7 +1764,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1775,7 +1775,7 @@
     "schemaDefinitions": {
       "EncoderConfigTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "const": {
           "STATIC": 0,
           "DYNAMIC": 1
@@ -1793,7 +1793,7 @@
       },
       "EncoderSensorAbsoluteTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "const": {
           "SINGLETURN": 0,
           "MULTITURN": 1
@@ -1822,7 +1822,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SensorConfigParameters" ],
           "properties": {
             "SensorConfigParameters": {
@@ -1830,7 +1830,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1847,7 +1847,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "SensorConfigParametersResult" ],
           "properties": {
             "SensorConfigParametersResult": {
@@ -1855,7 +1855,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -1907,7 +1907,7 @@
       "ConfigType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderConfigTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderConfigTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1923,7 +1923,7 @@
       "SensorAbsoluteType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "title": "EncoderSensorAbsoluteTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorAbsoluteTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1997,7 +1997,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_EncoderSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.EncoderSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2024,7 +2024,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6086",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PresetValue" ],
           "properties": {
             "PresetValue": {
@@ -2140,7 +2140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNENC_LogbookType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNENC.LogbookType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2151,7 +2151,7 @@
     "schemaDefinitions": {
       "EventTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
         "const": {
           "FAULT": 0,
           "WARNING": 1,
@@ -2200,7 +2200,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6074",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ActiveDiagnosis" ],
           "properties": {
             "ActiveDiagnosis": {
@@ -2208,7 +2208,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -2226,7 +2226,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2273,7 +2273,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6071",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CurrentLogEntries" ],
           "properties": {
             "CurrentLogEntries": {
@@ -2281,7 +2281,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -2299,7 +2299,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2346,7 +2346,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "LogbookFilterOptions", "FaultSituationNumber", "EventType", "EventCode", "EventAppearanceInterval" ],
           "properties": {
             "LogbookFilterOptions": {
@@ -2361,7 +2361,7 @@
             },
             "EventType": {
               "title": "EventTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2379,7 +2379,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6033",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FilteredLogEntries" ],
           "properties": {
             "FilteredLogEntries": {
@@ -2387,7 +2387,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -2405,7 +2405,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2452,7 +2452,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNENC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FaultSituationNumber" ],
           "properties": {
             "FaultSituationNumber": {
@@ -2464,7 +2464,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=6073",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "HistoricLogEntries" ],
           "properties": {
             "HistoricLogEntries": {
@@ -2472,7 +2472,7 @@
               "items": {
                 "title": "LogEntryDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
                 "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
                 "properties": {
                   "FaultSituationNumber": {
@@ -2490,7 +2490,7 @@
                   "EventType": {
                     "title": "EventTypeEnumeration",
                     "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -2555,7 +2555,7 @@
         "items": {
           "title": "LogEntryDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
           "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
           "properties": {
             "FaultSituationNumber": {
@@ -2573,7 +2573,7 @@
             "EventType": {
               "title": "EventTypeEnumeration",
               "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2623,7 +2623,7 @@
           "items": {
             "title": "LogEntryDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.PNENC.LogEntryDataType",
             "required": [ "FaultSituationNumber", "EventNumber", "EventType", "EventCode", "EventText", "EventComing", "EventGoing", "EventAcknowledged" ],
             "properties": {
               "FaultSituationNumber": {
@@ -2641,7 +2641,7 @@
               "EventType": {
                 "title": "EventTypeEnumeration",
                 "description": "Characterization of the event (fault, warning, etc.). Must never have the value “UNSPECIFIED”",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNENC/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PNENC.EventTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647

--- a/wot-codegen/opc-output-simple/PNGSDGM.TM.json
+++ b/wot-codegen/opc-output-simple/PNGSDGM.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenAlarmEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenAlarmEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "GsdGenChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -38,7 +38,7 @@
       },
       "GsdGenChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -66,7 +66,7 @@
       },
       "GsdGenChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -94,7 +94,7 @@
       },
       "GsdGenChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -134,7 +134,7 @@
       "Accumulative": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelAccumulativeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelAccumulativeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -192,7 +192,7 @@
       "Direction": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelDirectionEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -248,7 +248,7 @@
       "Maintenance": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelMaintenanceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelMaintenanceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -305,7 +305,7 @@
       "Specifier": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenChannelSpecifierEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenChannelSpecifierEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -359,7 +359,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -420,7 +420,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelQualityType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelQualityType",
     "links": [
       {
         "rel": "tm:extends",
@@ -431,7 +431,7 @@
     "schemaDefinitions": {
       "GsdGenIoQualityFormatEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoQualityFormatEnumeration",
         "const": {
           "QUALIFIER": 0,
           "EMBEDDED_STATUS": 1,
@@ -480,7 +480,7 @@
       "Format": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoQualityFormatEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoQualityFormatEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -506,7 +506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -565,7 +565,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenIoDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -588,7 +588,7 @@
     "schemaDefinitions": {
       "GsdGenIoConsistencyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConsistencyEnumeration",
         "const": {
           "ITEM_CONSISTENCY": 0,
           "ALL_ITEMS_CONSISTENCY": 1
@@ -623,7 +623,7 @@
       "Consistency": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoConsistencyEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConsistencyEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -678,7 +678,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNGSDGM_GsdGenSubmoduleApplicationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenSubmoduleApplicationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -726,7 +726,7 @@
     "schemaDefinitions": {
       "GsdGenIoCommunicationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoCommunicationStatusEnumeration",
         "const": {
           "INDATA": 0,
           "OFFLINE": 1
@@ -744,7 +744,7 @@
       },
       "GsdGenIoConfigurationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConfigurationStatusEnumeration",
         "const": {
           "OK": 0,
           "SUBSTITUTE": 1,
@@ -788,7 +788,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=6074",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -834,7 +834,7 @@
       "CommunicationStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoCommunicationStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoCommunicationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -850,7 +850,7 @@
       "ConfigurationStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNGSDGM/",
         "title": "GsdGenIoConfigurationStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNGSDGM/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNGSDGM.GsdGenIoConfigurationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,

--- a/wot-codegen/opc-output-simple/PNRIO.TM.json
+++ b/wot-codegen/opc-output-simple/PNRIO.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelDiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "RioChannelDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -48,7 +48,7 @@
       },
       "RioChannelDiagnosisStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "const": {
           "HI_LIM_EXCEEDED": 0,
           "LO_LIM_EXCEEDED": 1,
@@ -154,7 +154,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -184,7 +184,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -210,7 +210,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelDiagnosisEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -222,7 +222,7 @@
     "schemaDefinitions": {
       "RioChannelDiagnosisReasonEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 1,
@@ -250,7 +250,7 @@
       },
       "RioChannelDiagnosisStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "const": {
           "HI_LIM_EXCEEDED": 0,
           "LO_LIM_EXCEEDED": 1,
@@ -356,7 +356,7 @@
       "Reason": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisReasonEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisReasonEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -386,7 +386,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelDiagnosisStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelDiagnosisStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -412,7 +412,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnIoSignalType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoSignalType",
     "links": [
       {
         "rel": "tm:extends",
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnIoTelegramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramType",
     "links": [
       {
         "rel": "tm:extends",
@@ -490,7 +490,7 @@
     "schemaDefinitions": {
       "PnIoTelegramStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "const": {
           "GOOD": 0,
           "BAD_BY_SUBSLOT": 1,
@@ -535,7 +535,7 @@
       "ConsumerStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "PnIoTelegramStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -578,7 +578,7 @@
       "ProviderStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "PnIoTelegramStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnIoTelegramStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -604,7 +604,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_PnTelegramType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.PnTelegramType",
     "dov:isComposite": true,
     "links": [
       {
@@ -643,7 +643,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelGroupConfigType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelGroupConfigType",
     "links": [
       {
         "rel": "tm:extends",
@@ -654,7 +654,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -702,7 +702,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -764,7 +764,7 @@
         "items": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -806,7 +806,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioBitFieldDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
         "required": [ "BitData", "BitUsed" ],
         "properties": {
           "BitData": {
@@ -833,7 +833,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -898,7 +898,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -941,7 +941,7 @@
         "items": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -983,7 +983,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioBitFieldDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
         "required": [ "BitData", "BitUsed" ],
         "properties": {
           "BitData": {
@@ -1021,7 +1021,7 @@
       "SignalType": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioSignalTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1037,7 +1037,7 @@
       "SubstitutePolicy": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioSubstitutePolicyEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1095,7 +1095,7 @@
         "data": {
           "title": "RioBitFieldDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
           "required": [ "BitData", "BitUsed" ],
           "properties": {
             "BitData": {
@@ -1123,7 +1123,7 @@
         "data": {
           "title": "RioBitFieldDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioBitFieldDataType",
           "required": [ "BitData", "BitUsed" ],
           "properties": {
             "BitData": {
@@ -1157,7 +1157,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1206,7 +1206,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6072",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -1279,7 +1279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1306,7 +1306,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1333,7 +1333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1361,7 +1361,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6133",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled", "Index" ],
           "properties": {
             "SimulationEnabled": {
@@ -1388,14 +1388,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6292",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier", "Index" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Value used to set the Value member of the array element.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -1469,14 +1469,14 @@
         "items": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -1551,7 +1551,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalChannelGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalChannelGroupType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1579,7 +1579,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled", "Index" ],
           "properties": {
             "SimulationEnabled": {
@@ -1606,7 +1606,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier", "Index" ],
           "properties": {
             "Value": {
@@ -1658,7 +1658,7 @@
         "items": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -1711,7 +1711,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1739,7 +1739,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ApplicationTag" ],
           "properties": {
             "ApplicationTag": {
@@ -1809,7 +1809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1821,7 +1821,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -1869,7 +1869,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -1915,7 +1915,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputConfigDataType",
         "required": [ "Damping", "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "Damping": {
@@ -1925,7 +1925,7 @@
           },
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1938,7 +1938,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -1946,7 +1946,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -1989,7 +1989,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2043,7 +2043,7 @@
         "data": {
           "title": "RioFaAnalogInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogInputConfigDataType",
           "required": [ "Damping", "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "Damping": {
@@ -2053,7 +2053,7 @@
             },
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2066,7 +2066,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2074,7 +2074,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -2118,7 +2118,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2178,7 +2178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaAnalogOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2190,7 +2190,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2238,7 +2238,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -2284,12 +2284,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2305,7 +2305,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2313,7 +2313,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -2361,7 +2361,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2398,7 +2398,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2466,12 +2466,12 @@
         "data": {
           "title": "RioFaAnalogOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2487,7 +2487,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2495,7 +2495,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -2544,7 +2544,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2583,7 +2583,7 @@
         "data": {
           "title": "RioFaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaAnalogProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2658,7 +2658,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2670,7 +2670,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2718,7 +2718,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -2764,12 +2764,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2782,7 +2782,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -2804,7 +2804,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -2844,12 +2844,12 @@
         "data": {
           "title": "RioFaDigitalInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalInputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2862,7 +2862,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2885,7 +2885,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -2930,7 +2930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioFaDigitalOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2942,7 +2942,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -2990,7 +2990,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -3036,12 +3036,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3057,7 +3057,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3084,7 +3084,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -3107,7 +3107,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioFaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
         "required": [ "Quality" ],
         "properties": {
           "Quality": {
@@ -3161,12 +3161,12 @@
         "data": {
           "title": "RioFaDigitalOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SupplyVoltageCheckEnabled", "LoadVoltageCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3182,7 +3182,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3210,7 +3210,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -3234,7 +3234,7 @@
         "data": {
           "title": "RioFaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3022",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioFaDigitalProcessValueDataType",
           "required": [ "Quality" ],
           "properties": {
             "Quality": {
@@ -3294,7 +3294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3306,7 +3306,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -3354,7 +3354,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -3382,7 +3382,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -3421,14 +3421,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6294",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualProcessValue" ],
           "properties": {
             "ManualProcessValue": {
               "title": "RioAnalogDataType",
               "description": "Desired Value of the ManualProcessValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3471,13 +3471,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6293",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3496,7 +3496,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6295",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -3517,14 +3517,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6296",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Desired content of the Value struct member of the SimulationValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3575,7 +3575,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputConfigDataType",
         "required": [ "Damping", "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "HighLimit", "LowLimit" ],
         "properties": {
           "Damping": {
@@ -3585,7 +3585,7 @@
           },
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3595,7 +3595,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -3603,7 +3603,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3635,7 +3635,7 @@
           "HighLimit": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3667,7 +3667,7 @@
           "LowLimit": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3710,7 +3710,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -3750,7 +3750,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3767,7 +3767,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -3828,14 +3828,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
             "title": "RioAnalogDataType",
             "description": "Current value.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -3887,7 +3887,7 @@
         "data": {
           "title": "RioPaAnalogInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogInputConfigDataType",
           "required": [ "Damping", "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "HighLimit", "LowLimit" ],
           "properties": {
             "Damping": {
@@ -3897,7 +3897,7 @@
             },
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3907,7 +3907,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3915,7 +3915,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3947,7 +3947,7 @@
             "HighLimit": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -3979,7 +3979,7 @@
             "LowLimit": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4023,7 +4023,7 @@
         "data": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -4064,7 +4064,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4082,7 +4082,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -4146,14 +4146,14 @@
         "data": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4209,7 +4209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaAnalogOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4221,7 +4221,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -4269,7 +4269,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -4297,7 +4297,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -4336,14 +4336,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6298",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualOutValue" ],
           "properties": {
             "ManualOutValue": {
               "title": "RioAnalogDataType",
               "description": "Desired Value of the ManualOutValue Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4386,13 +4386,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6297",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4411,7 +4411,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6299",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -4432,14 +4432,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6300",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Desired content of the SimulationEnabled Variable.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4490,12 +4490,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -4505,7 +4505,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -4513,7 +4513,7 @@
           "SubstituteValue": {
             "title": "RioAnalogDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -4561,7 +4561,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioAnalogDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
         "properties": {
           "Float_32": {
             "type": "number",
@@ -4601,7 +4601,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4618,7 +4618,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -4653,7 +4653,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -4728,14 +4728,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaAnalogValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
             "title": "RioAnalogDataType",
             "description": "Current value.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
             "properties": {
               "Float_32": {
                 "type": "number",
@@ -4787,12 +4787,12 @@
         "data": {
           "title": "RioPaAnalogOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4802,7 +4802,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -4810,7 +4810,7 @@
             "SubstituteValue": {
               "title": "RioAnalogDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -4859,7 +4859,7 @@
         "data": {
           "title": "RioAnalogDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
           "properties": {
             "Float_32": {
               "type": "number",
@@ -4900,7 +4900,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4918,7 +4918,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -4954,7 +4954,7 @@
         "data": {
           "title": "RioPaAnalogProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -5033,14 +5033,14 @@
         "data": {
           "title": "RioPaAnalogValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3027",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaAnalogValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
               "title": "RioAnalogDataType",
               "description": "Current value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3020",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioAnalogDataType",
               "properties": {
                 "Float_32": {
                   "type": "number",
@@ -5096,7 +5096,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalInputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5108,7 +5108,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -5156,7 +5156,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -5184,7 +5184,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -5223,7 +5223,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6302",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualProcessValue" ],
           "properties": {
             "ManualProcessValue": {
@@ -5244,13 +5244,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6301",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5269,7 +5269,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6303",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -5290,7 +5290,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6304",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5319,12 +5319,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalInputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5337,7 +5337,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5370,7 +5370,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5387,7 +5387,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -5448,7 +5448,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
@@ -5478,12 +5478,12 @@
         "data": {
           "title": "RioPaDigitalInputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalInputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5496,7 +5496,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5531,7 +5531,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -5549,7 +5549,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -5613,7 +5613,7 @@
         "data": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5647,7 +5647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PNRIO_RioPaDigitalOutputChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputChannelType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5659,7 +5659,7 @@
     "schemaDefinitions": {
       "RioSignalTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
         "const": {
           "CURRENT_4_20_mA": 0,
           "CURRENT_0_20_mA": 1,
@@ -5707,7 +5707,7 @@
       },
       "RioSubstitutePolicyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
         "const": {
           "USE_SUBSTITUTE_VALUE": 0,
           "USE_LAST_VALID_VALUE": 1,
@@ -5735,7 +5735,7 @@
       },
       "RioChannelModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "const": {
           "AUTO": 0,
           "MANUAL": 1,
@@ -5774,7 +5774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6071",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ManualOutValue" ],
           "properties": {
             "ManualOutValue": {
@@ -5795,13 +5795,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Mode" ],
           "properties": {
             "Mode": {
               "title": "RioChannelModeEnumeration",
               "description": "Desired content of the Mode Variable.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -5820,7 +5820,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SimulationEnabled" ],
           "properties": {
             "SimulationEnabled": {
@@ -5841,7 +5841,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {
@@ -5870,12 +5870,12 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalOutputConfigDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputConfigDataType",
         "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
         "properties": {
           "SignalType": {
             "title": "RioSignalTypeEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5888,7 +5888,7 @@
           },
           "SubstitutePolicy": {
             "title": "RioSubstitutePolicyEnumeration",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+            "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -5926,7 +5926,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioChannelModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5943,7 +5943,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -5978,7 +5978,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalProcessValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
         "required": [ "Quality", "NE_107", "Status_full" ],
         "properties": {
           "Quality": {
@@ -6053,7 +6053,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "title": "RioPaDigitalValueDataType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
         "required": [ "Value", "Qualifier" ],
         "properties": {
           "Value": {
@@ -6083,12 +6083,12 @@
         "data": {
           "title": "RioPaDigitalOutputConfigDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalOutputConfigDataType",
           "required": [ "SignalType", "WireCheckEnabled", "InversionEnabled", "SubstitutePolicy", "SubstituteValue", "SubstituteTime" ],
           "properties": {
             "SignalType": {
               "title": "RioSignalTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSignalTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6101,7 +6101,7 @@
             },
             "SubstitutePolicy": {
               "title": "RioSubstitutePolicyEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioSubstitutePolicyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -6141,7 +6141,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PNRIO/",
         "data": {
           "title": "RioChannelModeEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioChannelModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6159,7 +6159,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -6195,7 +6195,7 @@
         "data": {
           "title": "RioPaDigitalProcessValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalProcessValueDataType",
           "required": [ "Quality", "NE_107", "Status_full" ],
           "properties": {
             "Quality": {
@@ -6274,7 +6274,7 @@
         "data": {
           "title": "RioPaDigitalValueDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PNRIO/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PNRIO.RioPaDigitalValueDataType",
           "required": [ "Value", "Qualifier" ],
           "properties": {
             "Value": {

--- a/wot-codegen/opc-output-simple/POWERLINK.TM.json
+++ b/wot-codegen/opc-output-simple/POWERLINK.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkProtocolType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkProtocolType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -120,7 +120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkCnConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkCnConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkMnConnectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkMnConnectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -214,7 +214,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -253,7 +253,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "POWERLINK_PowerlinkDeviceProfileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/POWERLINK/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.POWERLINK.PowerlinkDeviceProfileType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PROFINET.TM.json
+++ b/wot-codegen/opc-output-simple/PROFINET.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnDiagnosisAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDiagnosisAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -38,7 +38,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -66,7 +66,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -94,7 +94,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -122,7 +122,7 @@
       },
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -182,7 +182,7 @@
       "Accumulative": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelAccumulativeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -240,7 +240,7 @@
       "Direction": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelDirectionEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -296,7 +296,7 @@
       "Maintenance": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelMaintenanceEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -353,7 +353,7 @@
       "Specifier": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelSpecifierEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -383,7 +383,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnChannelTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -423,7 +423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -435,7 +435,7 @@
     "schemaDefinitions": {
       "PnAssetChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangeEnumeration",
         "const": {
           "INSERTED": 0,
           "REMOVED": 1,
@@ -458,7 +458,7 @@
       },
       "PnAssetTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetTypeEnumeration",
         "const": {
           "DEVICE": 0,
           "MODULE": 1,
@@ -498,7 +498,7 @@
       "AssetChange": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnAssetChangeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -514,7 +514,7 @@
       "AssetType": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnAssetTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -540,7 +540,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnTopologyChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnTopologyChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -567,7 +567,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnDomainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnDomainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -599,7 +599,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnEquipmentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnEquipmentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -640,7 +640,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -688,7 +688,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -706,7 +706,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -734,7 +734,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -762,7 +762,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -820,7 +820,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -845,35 +845,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -948,7 +948,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -973,35 +973,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1066,7 +1066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1098,7 +1098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1109,7 +1109,7 @@
     "schemaDefinitions": {
       "PnDeviceStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
         "const": {
           "OFFLINE": 0,
           "OFFLINE_DOCKING": 1,
@@ -1166,7 +1166,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnDeviceStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1185,7 +1185,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnDeviceStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1209,7 +1209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1239,7 +1239,7 @@
     "schemaDefinitions": {
       "PnDeviceRoleOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceRoleOptionSet",
         "const": {
           "IO_DEVICE": 0,
           "IO_CONTROLLER": 1,
@@ -1283,7 +1283,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6095",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameOfStation" ],
           "properties": {
             "NameOfStation": {
@@ -1333,7 +1333,7 @@
       "DeviceRole": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnDeviceRoleOptionSet",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceRoleOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1425,7 +1425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1510,7 +1510,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnExpectedModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnExpectedModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1527,7 +1527,7 @@
     "schemaDefinitions": {
       "PnModuleStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
         "const": {
           "NO_MODULE": 0,
           "WRONG_MODULE": 1,
@@ -1577,7 +1577,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnModuleStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1596,7 +1596,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnModuleStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnModuleStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1620,7 +1620,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnRealModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnRealModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1649,7 +1649,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -1697,7 +1697,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -1715,7 +1715,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -1743,7 +1743,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -1771,7 +1771,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -1819,7 +1819,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -1844,35 +1844,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1935,7 +1935,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -1960,35 +1960,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2053,7 +2053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2152,7 +2152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnExpectedSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnExpectedSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2184,7 +2184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPnRealSubmoduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPnRealSubmoduleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2207,7 +2207,7 @@
     "schemaDefinitions": {
       "PnChannelTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
         "const": {
           "UNSPECIFIC": 0,
           "S1BIT": 1,
@@ -2255,7 +2255,7 @@
       },
       "PnChannelAccumulativeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
         "const": {
           "SINGLE": 0,
           "ACCUMULATIVE": 256
@@ -2273,7 +2273,7 @@
       },
       "PnChannelMaintenanceEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
         "const": {
           "FAULT": 0,
           "MAINTENANCE_REQUIRED": 512,
@@ -2301,7 +2301,7 @@
       },
       "PnChannelSpecifierEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
         "const": {
           "ALL_DISAPPEARS": 0,
           "APPEARS": 2048,
@@ -2329,7 +2329,7 @@
       },
       "PnChannelDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
         "const": {
           "MANUFACTURER_SPECIFIC": 0,
           "INPUT_CHANNEL": 8192,
@@ -2377,7 +2377,7 @@
         "items": {
           "title": "PnDeviceDiagnosisDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
           "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
           "properties": {
             "API": {
@@ -2402,35 +2402,35 @@
             },
             "Type": {
               "title": "PnChannelTypeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Accumulative": {
               "title": "PnChannelAccumulativeEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Maintenance": {
               "title": "PnChannelMaintenanceEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Specifier": {
               "title": "PnChannelSpecifierEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
             },
             "Direction": {
               "title": "PnChannelDirectionEnumeration",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -2493,7 +2493,7 @@
           "items": {
             "title": "PnDeviceDiagnosisDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3019",
+            "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnDeviceDiagnosisDataType",
             "required": [ "API", "Slot", "Subslot", "ChannelNumber", "Type", "Accumulative", "Maintenance", "Specifier", "Direction", "UserStructureIdentifier", "ChannelErrorType", "ExtChannelErrorType", "ExtChannelAddValue", "QualifiedChannelQualifier", "ManufacturerData", "Message", "HelpText" ],
             "properties": {
               "API": {
@@ -2518,35 +2518,35 @@
               },
               "Type": {
                 "title": "PnChannelTypeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelTypeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Accumulative": {
                 "title": "PnChannelAccumulativeEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelAccumulativeEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Maintenance": {
                 "title": "PnChannelMaintenanceEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelMaintenanceEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Specifier": {
                 "title": "PnChannelSpecifierEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelSpecifierEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "Direction": {
                 "title": "PnChannelDirectionEnumeration",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnChannelDirectionEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2611,7 +2611,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_NetworkComponentFeatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.NetworkComponentFeatureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2637,7 +2637,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_IPv4FeatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.IPv4FeatureType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2806,7 +2806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_NetworkComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.NetworkComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2882,7 +2882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_EthernetInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.EthernetInterfaceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2962,7 +2962,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_EthernetPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.EthernetPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3042,7 +3042,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnApplicationRelationContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnApplicationRelationContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3075,7 +3075,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnApplicationRelationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnApplicationRelationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3092,7 +3092,7 @@
     "schemaDefinitions": {
       "PnARStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
         "const": {
           "CONNECTED": 0,
           "UNCONNECTED": 1,
@@ -3125,7 +3125,7 @@
       },
       "PnARTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARTypeEnumeration",
         "const": {
           "IOCARSingle": 0,
           "IOSAR": 6,
@@ -3229,7 +3229,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnARStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3250,7 +3250,7 @@
       "Type": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnARTypeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3269,7 +3269,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnARStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnARStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -3293,7 +3293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3326,7 +3326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3514,7 +3514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnEquipmentContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnEquipmentContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3546,7 +3546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnExpectedModuleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnExpectedModuleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3579,7 +3579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnExpectedSubmoduleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnExpectedSubmoduleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3612,7 +3612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3623,7 +3623,7 @@
     "schemaDefinitions": {
       "IMTagSelectorEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.IMTagSelectorEnumeration",
         "const": {
           "FUNCTION": 0,
           "LOCATION": 1,
@@ -3654,7 +3654,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Date" ],
           "properties": {
             "Date": {
@@ -3676,7 +3676,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Descriptor" ],
           "properties": {
             "Descriptor": {
@@ -3697,13 +3697,13 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Tag_Selector", "Tag_Function", "Tag_Location" ],
           "properties": {
             "Tag_Selector": {
               "title": "IMTagSelectorEnumeration",
               "description": "If 1, Tag_Function shall be written, If 2, Tag_Location shall be written, if 3 both.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.PROFINET.IMTagSelectorEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -3772,7 +3772,7 @@
           "title": "PnIM5DataType",
           "description": "Contains the fields of the APDU element I&M5 | I&M5Data",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnIM5DataType",
           "required": [ "Annotation", "OrderId", "VendorId", "SerialNumber", "HardwareRevision", "SoftwareRevision" ],
           "properties": {
             "Annotation": {
@@ -3980,7 +3980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnInterfaceContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnInterfaceContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4013,7 +4013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4046,7 +4046,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4258,7 +4258,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4282,7 +4282,7 @@
     "schemaDefinitions": {
       "PnLinkStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
         "const": {
           "UP": 1,
           "DOWN": 2,
@@ -4325,7 +4325,7 @@
       },
       "PnPortStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
         "const": {
           "UNKNOWN": 0,
           "DISABLED_DISCARDING": 1,
@@ -4408,7 +4408,7 @@
       "LinkState": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnLinkStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4438,7 +4438,7 @@
       "PortState": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnPortStateEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4499,7 +4499,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnLinkStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnLinkStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4531,7 +4531,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnPortStateEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnPortStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4570,7 +4570,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnRealModuleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnRealModuleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4603,7 +4603,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnRealSubmoduleContainerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnRealSubmoduleContainerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4636,7 +4636,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PROFINET_PnSubmoduleStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4647,7 +4647,7 @@
     "schemaDefinitions": {
       "PnSubmoduleAddInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
         "const": {
           "NO_ADD_INFO": 0,
           "TAKEOVER_NOT_ALLOWED": 1
@@ -4664,7 +4664,7 @@
       },
       "PnSubmoduleARInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
         "const": {
           "OWN": 0,
           "APPLICATION_READY_PENDING": 128,
@@ -4697,7 +4697,7 @@
       },
       "PnSubmoduleIdentInfoEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
         "const": {
           "OK": 0,
           "SUBSTITUTE": 2048,
@@ -4742,7 +4742,7 @@
       "AddInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleAddInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4758,7 +4758,7 @@
       "ARInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleARInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4786,7 +4786,7 @@
       "IdentInfo": {
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "title": "PnSubmoduleIdentInfoEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4841,7 +4841,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleAddInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleAddInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4858,7 +4858,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleARInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleARInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -4888,7 +4888,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PROFINET/",
         "data": {
           "title": "PnSubmoduleIdentInfoEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PROFINET/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PROFINET.PnSubmoduleIdentInfoEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647

--- a/wot-codegen/opc-output-simple/PackML.TM.json
+++ b/wot-codegen/opc-output-simple/PackML.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLAdminObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLAdminObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -129,7 +129,7 @@
         "items": {
           "title": "PackMLDescriptorDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
           "required": [ "ID", "Name", "Unit", "Value" ],
           "properties": {
             "ID": {
@@ -146,7 +146,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -188,7 +188,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -205,7 +205,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -253,7 +253,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -270,7 +270,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -318,7 +318,7 @@
         "items": {
           "title": "PackMLCountDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
           "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
           "properties": {
             "ID": {
@@ -335,7 +335,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information for the count.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -550,7 +550,7 @@
           "items": {
             "title": "PackMLDescriptorDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
             "required": [ "ID", "Name", "Unit", "Value" ],
             "properties": {
               "ID": {
@@ -567,7 +567,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -610,7 +610,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -627,7 +627,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -676,7 +676,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -693,7 +693,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -742,7 +742,7 @@
           "items": {
             "title": "PackMLCountDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=14",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLCountDataType",
             "required": [ "ID", "Name", "Unit", "Count", "AccCount" ],
             "properties": {
               "ID": {
@@ -759,7 +759,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information for the count.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -884,7 +884,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -925,7 +925,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=350",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RemoteInterface" ],
           "properties": {
             "RemoteInterface": {
@@ -934,7 +934,7 @@
               "items": {
                 "title": "PackMLRemoteInterfaceDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
                 "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
                 "properties": {
                   "Number": {
@@ -961,7 +961,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -978,7 +978,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1023,7 +1023,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=351",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "InterlockId", "State" ],
           "properties": {
             "InterlockId": {
@@ -1050,7 +1050,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=348",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestedMachineSpeed" ],
           "properties": {
             "RequestedMachineSpeed": {
@@ -1073,7 +1073,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=352",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -1082,7 +1082,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1099,7 +1099,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1141,7 +1141,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=349",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Product" ],
           "properties": {
             "Product": {
@@ -1150,7 +1150,7 @@
               "items": {
                 "title": "PackMLProductDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
                 "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
                 "properties": {
                   "ProductID": {
@@ -1165,7 +1165,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -1182,7 +1182,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1216,7 +1216,7 @@
                     "items": {
                       "title": "PackMLIngredientsDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                       "required": [ "IngredientID", "Parameter" ],
                       "properties": {
                         "IngredientID": {
@@ -1231,7 +1231,7 @@
                           "items": {
                             "title": "PackMLDescriptorDataType",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                             "required": [ "ID", "Name", "Unit", "Value" ],
                             "properties": {
                               "ID": {
@@ -1248,7 +1248,7 @@
                                 "title": "EUInformation",
                                 "description": "OPC UA engineering unit information",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -1296,7 +1296,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=118",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RequestedMode" ],
           "properties": {
             "RequestedMode": {
@@ -1354,7 +1354,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLStatusObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLStatusObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1449,7 +1449,7 @@
         "items": {
           "title": "PackMLDescriptorDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
           "required": [ "ID", "Name", "Unit", "Value" ],
           "properties": {
             "ID": {
@@ -1466,7 +1466,7 @@
               "title": "EUInformation",
               "description": "OPC UA engineering unit information",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1508,7 +1508,7 @@
         "items": {
           "title": "PackMLProductDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
           "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
           "properties": {
             "ProductID": {
@@ -1523,7 +1523,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1540,7 +1540,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1574,7 +1574,7 @@
               "items": {
                 "title": "PackMLIngredientsDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                 "required": [ "IngredientID", "Parameter" ],
                 "properties": {
                   "IngredientID": {
@@ -1589,7 +1589,7 @@
                     "items": {
                       "title": "PackMLDescriptorDataType",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                      "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                       "required": [ "ID", "Name", "Unit", "Value" ],
                       "properties": {
                         "ID": {
@@ -1606,7 +1606,7 @@
                           "title": "EUInformation",
                           "description": "OPC UA engineering unit information",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1654,7 +1654,7 @@
         "items": {
           "title": "PackMLRemoteInterfaceDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+          "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
           "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
           "properties": {
             "Number": {
@@ -1681,7 +1681,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -1698,7 +1698,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1889,7 +1889,7 @@
           "items": {
             "title": "PackMLDescriptorDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
             "required": [ "ID", "Name", "Unit", "Value" ],
             "properties": {
               "ID": {
@@ -1906,7 +1906,7 @@
                 "title": "EUInformation",
                 "description": "OPC UA engineering unit information",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -1949,7 +1949,7 @@
           "items": {
             "title": "PackMLProductDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=18",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLProductDataType",
             "required": [ "ProductID", "ProcessVariables", "Ingredients" ],
             "properties": {
               "ProductID": {
@@ -1964,7 +1964,7 @@
                 "items": {
                   "title": "PackMLDescriptorDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                   "required": [ "ID", "Name", "Unit", "Value" ],
                   "properties": {
                     "ID": {
@@ -1981,7 +1981,7 @@
                       "title": "EUInformation",
                       "description": "OPC UA engineering unit information",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2015,7 +2015,7 @@
                 "items": {
                   "title": "PackMLIngredientsDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=17",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLIngredientsDataType",
                   "required": [ "IngredientID", "Parameter" ],
                   "properties": {
                     "IngredientID": {
@@ -2030,7 +2030,7 @@
                       "items": {
                         "title": "PackMLDescriptorDataType",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                        "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                         "required": [ "ID", "Name", "Unit", "Value" ],
                         "properties": {
                           "ID": {
@@ -2047,7 +2047,7 @@
                             "title": "EUInformation",
                             "description": "OPC UA engineering unit information",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -2096,7 +2096,7 @@
           "items": {
             "title": "PackMLRemoteInterfaceDataType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=19",
+            "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLRemoteInterfaceDataType",
             "required": [ "Number", "ControlCmdNumber", "CmdValue", "Parameter" ],
             "properties": {
               "Number": {
@@ -2123,7 +2123,7 @@
                 "items": {
                   "title": "PackMLDescriptorDataType",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                  "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                   "required": [ "ID", "Name", "Unit", "Value" ],
                   "properties": {
                     "ID": {
@@ -2140,7 +2140,7 @@
                       "title": "EUInformation",
                       "description": "OPC UA engineering unit information",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2257,7 +2257,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLBaseStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2415,7 +2415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2648,7 +2648,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=342",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -2657,7 +2657,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -2674,7 +2674,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2825,7 +2825,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PackML_PackMLMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Calender.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Calender.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_CouplingProductForcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.CouplingProductForcesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_CouplingProductTensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.CouplingProductTensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -108,7 +108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calender_Calender_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calender/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calender.Calender_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Calibrator.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Calibrator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_CalibrationZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.CalibrationZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_CalibrationZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.CalibrationZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -209,7 +209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Calibrator_Calibrator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Calibrator/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Calibrator.Calibrator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Corrugator.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Corrugator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Corrugator_Corrugator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Corrugator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Corrugator.Corrugator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Cutter.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Cutter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CutEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CutEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CuttingProductsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CuttingProductsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_CuttingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.CuttingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -172,7 +172,7 @@
     "schemaDefinitions": {
       "WallThickeningEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.WallThickeningEnumeration",
         "const": {
           "NO": 0,
           "FRONT": 1,
@@ -344,7 +344,7 @@
       "WallThickeningPosition": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/",
         "title": "WallThickeningEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.WallThickeningEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Cutter_Cutter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Cutter/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Cutter.Cutter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Die.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Die.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Die_Die_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Die/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Die.Die_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Extruder.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Extruder.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "FeedingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedingModeEnumeration",
         "const": {
           "ONLY_CONVEYING": 0,
           "OTHER": 1,
@@ -111,7 +111,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/",
         "title": "FeedingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_Extruder_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.Extruder_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -313,7 +313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_FeedersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.FeedersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -363,7 +363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Extruder_HopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Extruder/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Extruder.HopperType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.ExtrusionLine.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.ExtrusionLine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -101,7 +101,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -129,7 +129,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -167,7 +167,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -248,7 +248,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -288,7 +288,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_LotFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.LotFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_UnitFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.UnitFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -526,7 +526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_ExtrusionLine_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.ExtrusionLine_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -592,7 +592,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -657,7 +657,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Message2" ],
           "properties": {
             "Id": {
@@ -689,7 +689,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -710,7 +710,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -760,7 +760,7 @@
       "LineStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "ProductionStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -786,7 +786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -814,7 +814,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "EquipmentDescription", "ProductionDatasetName", "MaterialMapping", "Priority", "PlannedStart", "PlannedProductionTime", "PlannedSetUpTime", "LatestEnd" ],
           "properties": {
             "Id": {
@@ -834,7 +834,7 @@
               "items": {
                 "title": "MaterialMappingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.MaterialMappingType",
                 "required": [ "MaterialId", "MaterialLot", "HopperId" ],
                 "properties": {
                   "MaterialId": {
@@ -874,7 +874,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobGroupNodeId" ],
           "properties": {
             "JobGroupNodeId": {
@@ -894,7 +894,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6216",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -914,7 +914,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6215",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -934,7 +934,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -954,7 +954,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -996,7 +996,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1013,7 +1013,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1098,7 +1098,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "CustomerName", "ProductName", "ProductDescription", "Strand", "Sequence", "ParameterSetting", "SetOutput", "LotSize" ],
           "properties": {
             "Id": {
@@ -1131,7 +1131,7 @@
               "items": {
                 "title": "ParameterSettingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
                 "required": [ "Id", "Value" ],
                 "properties": {
                   "Id": {
@@ -1160,7 +1160,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -1180,7 +1180,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1200,7 +1200,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1220,7 +1220,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1240,7 +1240,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=6175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1264,7 +1264,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -1285,7 +1285,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1398,7 +1398,7 @@
         "items": {
           "title": "MaterialMappingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.MaterialMappingType",
           "required": [ "MaterialId", "MaterialLot", "HopperId" ],
           "properties": {
             "MaterialId": {
@@ -1514,7 +1514,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1585,7 +1585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_JobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.JobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1596,7 +1596,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1867,7 +1867,7 @@
         "items": {
           "title": "ParameterSettingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
           "required": [ "Id", "Value" ],
           "properties": {
             "Id": {
@@ -1959,7 +1959,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2174,7 +2174,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_ExtrusionLine_ProductionParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/ExtrusionLine/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.ExtrusionLine.ProductionParametersType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Filter.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Filter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_Filter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.Filter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -198,7 +198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_FilterPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -215,7 +215,7 @@
     "schemaDefinitions": {
       "FilterPackageStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageStatusEnumeration",
         "const": {
           "NOT_ACTIVE": 0,
           "ACTIVE": 1,
@@ -323,7 +323,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/",
         "title": "FilterPackageStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.FilterPackageStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -364,7 +364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Filter_ScreenPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Filter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Filter.ScreenPackageType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -73,7 +73,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "const": {
           "OFFLINE": 0,
           "IDLE": 1,
@@ -159,7 +159,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/",
         "title": "ComponentStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -274,7 +274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -325,7 +325,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -454,7 +454,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -585,7 +585,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -635,7 +635,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -691,7 +691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -742,7 +742,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.HaulOff.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.HaulOff.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.MeltPump.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.MeltPump.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_MeltPump_MeltPump_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/MeltPump/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.MeltPump.MeltPump_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Pelletizer.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion.Pelletizer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_DiePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.DiePlateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_Pelletizer_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.Pelletizer_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -188,7 +188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_Pelletizer_KnifePackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion/Pelletizer/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion.Pelletizer.KnifePackageType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Calender.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Calender.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_CouplingProductForcesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.CouplingProductForcesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_CouplingProductTensionsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.CouplingProductTensionsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -108,7 +108,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calender_Calender_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calender/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calender.Calender_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Calibrator.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Calibrator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_CalibrationZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.CalibrationZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_CalibrationZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.CalibrationZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -209,7 +209,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Calibrator_Calibrator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Calibrator/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Calibrator.Calibrator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Corrugator.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Corrugator.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Corrugator_Corrugator_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Corrugator/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Corrugator.Corrugator_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Cutter.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Cutter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CutEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CutEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -82,7 +82,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CuttingProductsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CuttingProductsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_CuttingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.CuttingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -172,7 +172,7 @@
     "schemaDefinitions": {
       "WallThickeningEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.WallThickeningEnumeration",
         "const": {
           "NO": 0,
           "FRONT": 1,
@@ -344,7 +344,7 @@
       "WallThickeningPosition": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/",
         "title": "WallThickeningEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.WallThickeningEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Cutter_Cutter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Cutter/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Cutter.Cutter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Die.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Die.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Die_Die_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Die/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Die.Die_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Extruder.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Extruder.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_FeederType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeederType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "FeedingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedingModeEnumeration",
         "const": {
           "ONLY_CONVEYING": 0,
           "OTHER": 1,
@@ -111,7 +111,7 @@
       "Mode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/",
         "title": "FeedingModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -161,7 +161,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_Extruder_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.Extruder_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -313,7 +313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_FeedersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.FeedersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -363,7 +363,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Extruder_HopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Extruder/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Extruder.HopperType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.ExtrusionLine.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.ExtrusionLine.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -101,7 +101,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -129,7 +129,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobStatusChangedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobStatusChangedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -167,7 +167,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -248,7 +248,7 @@
       "ActiveStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -288,7 +288,7 @@
       "LastStatus": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -314,7 +314,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_LotFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.LotFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -386,7 +386,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -442,7 +442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_UnitFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.UnitFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -526,7 +526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_ExtrusionLine_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.ExtrusionLine_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -595,7 +595,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Message2" ],
           "properties": {
             "Id": {
@@ -627,7 +627,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -648,7 +648,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -691,7 +691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -719,7 +719,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6217",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "EquipmentDescription", "ProductionDatasetName", "MaterialMapping", "Priority", "PlannedStart", "PlannedProductionTime", "PlannedSetUpTime", "LatestEnd" ],
           "properties": {
             "Id": {
@@ -739,7 +739,7 @@
               "items": {
                 "title": "MaterialMappingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.MaterialMappingType",
                 "required": [ "MaterialId", "MaterialLot", "HopperId" ],
                 "properties": {
                   "MaterialId": {
@@ -779,7 +779,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6218",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobGroupNodeId" ],
           "properties": {
             "JobGroupNodeId": {
@@ -799,7 +799,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6216",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -819,7 +819,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6215",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -839,7 +839,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6214",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -859,7 +859,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6213",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -901,7 +901,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -918,7 +918,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1003,7 +1003,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6171",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Description", "CustomerName", "ProductName", "ProductDescription", "Strand", "Sequence", "ParameterSetting", "SetOutput", "LotSize" ],
           "properties": {
             "Id": {
@@ -1036,7 +1036,7 @@
               "items": {
                 "title": "ParameterSettingType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
                 "required": [ "Id", "Value" ],
                 "properties": {
                   "Id": {
@@ -1065,7 +1065,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6173",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobNodeId" ],
           "properties": {
             "JobNodeId": {
@@ -1085,7 +1085,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6177",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1105,7 +1105,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1125,7 +1125,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1145,7 +1145,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=6175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1169,7 +1169,7 @@
         "items": {
           "title": "ConfigurationParameterType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3024",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ConfigurationParameterType",
           "required": [ "Id", "Description", "DefaultValue", "Unit" ],
           "properties": {
             "Id": {
@@ -1190,7 +1190,7 @@
               "title": "EUInformation",
               "description": "Engineering unit of the parameter. If the Type of Defaultvalue is not a Number, then the Unit shall be empty",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1303,7 +1303,7 @@
         "items": {
           "title": "MaterialMappingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.MaterialMappingType",
           "required": [ "MaterialId", "MaterialLot", "HopperId" ],
           "properties": {
             "MaterialId": {
@@ -1419,7 +1419,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1490,7 +1490,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_JobType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.JobType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1501,7 +1501,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1772,7 +1772,7 @@
         "items": {
           "title": "ParameterSettingType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterSettingType",
           "required": [ "Id", "Value" ],
           "properties": {
             "Id": {
@@ -1864,7 +1864,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/",
         "title": "JobStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2079,7 +2079,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_ExtrusionLine_ProductionParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/ExtrusionLine/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.ExtrusionLine.ProductionParametersType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Filter.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Filter.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_Filter_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.Filter_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -198,7 +198,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_FilterPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -215,7 +215,7 @@
     "schemaDefinitions": {
       "FilterPackageStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageStatusEnumeration",
         "const": {
           "NOT_ACTIVE": 0,
           "ACTIVE": 1,
@@ -323,7 +323,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/",
         "title": "FilterPackageStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.FilterPackageStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -364,7 +364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Filter_ScreenPackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Filter/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Filter.ScreenPackageType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -73,7 +73,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -199,7 +199,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -238,7 +238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZonesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -301,7 +301,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -352,7 +352,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_GapType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.GapType",
     "links": [
       {
         "rel": "tm:extends",
@@ -481,7 +481,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionTemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -612,7 +612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollBendingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollBendingType",
     "links": [
       {
         "rel": "tm:extends",
@@ -662,7 +662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollPeripheralDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollPeripheralDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -718,7 +718,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -769,7 +769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_RollType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.RollType",
     "links": [
       {
         "rel": "tm:extends",
@@ -874,7 +874,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -954,7 +954,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_GeneralTypes_ExtrusionMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/GeneralTypes/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.GeneralTypes.ExtrusionMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.HaulOff.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.HaulOff.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_HaulOff_HaulOff_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/HaulOff/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.HaulOff.HaulOff_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.MeltPump.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.MeltPump.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_MeltPump_MeltPump_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/MeltPump/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.MeltPump.MeltPump_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Pelletizer.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.Extrusion_v2.Pelletizer.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_DiePlateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.DiePlateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -66,7 +66,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_Pelletizer_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.Pelletizer_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -188,7 +188,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_Extrusion_v2_Pelletizer_KnifePackageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/Extrusion_v2/Pelletizer/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.Extrusion_v2.Pelletizer.KnifePackageType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.GeneralTypes.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.GeneralTypes.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ActiveJobValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveJobValuesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19,7 +19,7 @@
     "schemaDefinitions": {
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -175,7 +175,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "JobStatusEnumeration",
         "description": "Current status of the job",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ActiveCyclicJobValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveCyclicJobValuesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -716,7 +716,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -763,7 +763,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1070",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -831,7 +831,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MessageConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MessageConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -904,7 +904,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_CycleParametersEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleParametersEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -916,7 +916,7 @@
     "schemaDefinitions": {
       "CavityCycleQualityEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CavityCycleQualityEnumeration",
         "const": {
           "NO_PART": 0,
           "GOOD_PART": 1,
@@ -945,7 +945,7 @@
       },
       "CycleQualityEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleQualityEnumeration",
         "const": {
           "GOOD_CYCLE": 0,
           "BAD_CYCLE": 1,
@@ -974,7 +974,7 @@
       },
       "JobStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "const": {
           "OTHER": 0,
           "TRANSFERRED_ASSIGNED": 1,
@@ -1158,7 +1158,7 @@
         "type": "array",
         "items": {
           "title": "CavityCycleQualityEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3020",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CavityCycleQualityEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1189,7 +1189,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "CycleQualityEnumeration",
         "description": "Quality of the whole cycle",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CycleQualityEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1293,7 +1293,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "JobStatusEnumeration",
         "description": "Current status of the job",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1365,7 +1365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosisEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1060",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosisEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1377,7 +1377,7 @@
     "schemaDefinitions": {
       "DiagnosticsStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "const": {
           "OFF": 0,
           "ACTIVE_OK": 1,
@@ -1422,7 +1422,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "DiagnosticsStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1448,7 +1448,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosisStepEndEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosisStepEndEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1506,7 +1506,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1524,7 +1524,7 @@
     "schemaDefinitions": {
       "EventOriginatorEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EventOriginatorEnumeration",
         "const": {
           "OTHER": 0,
           "MACHINE": 1,
@@ -1571,7 +1571,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EventOriginatorEnumeration",
         "description": "Originator of a logbook event",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EventOriginatorEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1612,7 +1612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1624,7 +1624,7 @@
     "schemaDefinitions": {
       "MachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -1676,7 +1676,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "New machine mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1693,7 +1693,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "Old machine mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1719,7 +1719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MessageLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MessageLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1792,7 +1792,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ParameterChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ParameterChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1831,7 +1831,7 @@
         "title": "EUInformation",
         "description": "New unit of the changed parameter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -1876,7 +1876,7 @@
         "title": "EUInformation",
         "description": "Old unit of the changed parameter",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -1929,7 +1929,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1989,7 +1989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetFrozenLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetFrozenLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2049,7 +2049,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionStatusChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2061,7 +2061,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -2113,7 +2113,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "New production status",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2130,7 +2130,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "Old production status",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2156,7 +2156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RemoteAccessLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RemoteAccessLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2168,7 +2168,7 @@
     "schemaDefinitions": {
       "UserChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "const": {
           "LOG_ON": 0,
           "LOG_OFF": 1
@@ -2226,7 +2226,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "UserChangeEnumeration",
         "description": "Information if the user logs in or off",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2252,7 +2252,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_SequenceChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2264,7 +2264,7 @@
     "schemaDefinitions": {
       "SequenceChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeEnumeration",
         "const": {
           "UPDATE": 0,
           "ADD": 1,
@@ -2311,7 +2311,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "SequenceChangeEnumeration",
         "description": "Classification of production sequence change",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.SequenceChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2337,7 +2337,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StandstillReasonLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2384,7 +2384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserFeedbackLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserFeedbackLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2431,7 +2431,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2443,7 +2443,7 @@
     "schemaDefinitions": {
       "UserChangeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "const": {
           "LOG_ON": 0,
           "LOG_OFF": 1
@@ -2475,7 +2475,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "UserChangeEnumeration",
         "description": "Information if the user logs in or off",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserChangeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2501,7 +2501,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestAddMaterialEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1061",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestAddMaterialEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2557,7 +2557,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestCyclicJobListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestCyclicJobListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2584,7 +2584,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestCyclicJobWriteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestCyclicJobWriteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2630,7 +2630,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestJobListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestJobListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2657,7 +2657,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetListEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetListEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2717,7 +2717,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetReadEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetReadEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2729,7 +2729,7 @@
     "schemaDefinitions": {
       "StorageEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "const": {
           "PRODUCTION": 1,
           "PREPARATION": 2,
@@ -2779,7 +2779,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StorageEnumeration",
         "description": "Indication from where the dataset is read",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2805,7 +2805,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_RequestProductionDatasetWriteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.RequestProductionDatasetWriteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2817,7 +2817,7 @@
     "schemaDefinitions": {
       "StorageEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "const": {
           "PRODUCTION": 1,
           "PREPARATION": 2,
@@ -2885,7 +2885,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StorageEnumeration",
         "description": "Indication where the dataset is written to",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StorageEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2911,7 +2911,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ClosedLoopControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClosedLoopControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2997,7 +2997,7 @@
           "title": "PIDParametersDataType",
           "description": "Structure for storing the parameters of a PID controller",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3023",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PIDParametersDataType",
           "required": [ "P", "I", "D" ],
           "properties": {
             "P": {
@@ -3047,7 +3047,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DiagnosticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3059,7 +3059,7 @@
     "schemaDefinitions": {
       "DiagnosticsStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "const": {
           "OFF": 0,
           "ACTIVE_OK": 1,
@@ -3124,7 +3124,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "DiagnosticsStatusEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3027",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DiagnosticsStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3150,7 +3150,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DrivesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DrivesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3201,7 +3201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.DriveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3282,7 +3282,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_EnergyType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.EnergyType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3436,7 +3436,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3605,7 +3605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_CyclicJobInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CyclicJobInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3634,7 +3634,7 @@
         "description": "Method for setting the data for cyclic jobs",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6268",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobName", "JobDescription", "CustomerName", "ProductionDatasetName", "ProductionDatasetDescription", "Material", "ProductName", "ProductDescription", "ContinueAtJobEnd", "NominalParts", "NominalBoxParts", "ExpectedCycleTime", "MouldId", "NumCavities" ],
           "properties": {
             "JobName": {
@@ -3807,7 +3807,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_JobsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3842,7 +3842,7 @@
         "description": "Sends a list of jobs for cyclic processes available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6389",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -3851,7 +3851,7 @@
                 "title": "CyclicJobListElementType",
                 "description": "Description of a job in a cyclic job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3022",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.CyclicJobListElementType",
                 "required": [ "NominalParts", "NominalBoxParts", "ExpectedCycleTime", "MouldId", "NumCavities" ],
                 "properties": {
                   "NominalParts": {
@@ -3899,7 +3899,7 @@
         "description": "Sends a list of jobs available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6384",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobList" ],
           "properties": {
             "JobList": {
@@ -3908,7 +3908,7 @@
                 "title": "JobListElementType",
                 "description": "Description of a job in a job list",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3021",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.JobListElementType",
                 "required": [ "JobName", "JobDescription", "JobClassification", "CustomerName", "ProductionDatasetName", "ProductionDatasetDescription", "Material", "ProductName", "ProductDescription", "JobPriority", "PlannedStart", "PlannedProductionTime", "LatestEnd" ],
                 "properties": {
                   "JobName": {
@@ -4003,7 +4003,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4032,7 +4032,7 @@
         "description": "Method for retrieving a screenshot of the control system with the currently shown contents",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6191",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VisualisationUnit" ],
           "properties": {
             "VisualisationUnit": {
@@ -4044,7 +4044,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6192",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -4066,7 +4066,7 @@
         "description": "Method for retrieving the image of a page of the control system",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6193",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4076,7 +4076,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6194",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Page" ],
           "properties": {
             "Page": {
@@ -4098,7 +4098,7 @@
         "description": "Method for setting the server time together with TimeZoneOffset",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6198",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DateTime", "TimeZoneOffset" ],
           "properties": {
             "DateTime": {
@@ -4108,7 +4108,7 @@
             "TimeZoneOffset": {
               "title": "TimeZoneDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+              "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
               "required": [ "Offset", "DaylightSavingInOffset" ],
               "properties": {
                 "Offset": {
@@ -4159,7 +4159,7 @@
           "title": "PageEntryDataType",
           "description": "Information on a page that is implemented in the machine control system and shown on the screen of the machine",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PageEntryDataType",
           "required": [ "Id", "Title" ],
           "properties": {
             "Id": {
@@ -4186,7 +4186,7 @@
         "title": "TimeZoneDataType",
         "description": "Difference of the local time to Coordinated Universal Time (UTC) given by the machine operator or OPC client",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -4243,7 +4243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESConfigurationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4295,7 +4295,7 @@
           "title": "StandstillReasonType",
           "description": "Description of a standstill reason",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillReasonType",
           "required": [ "Id", "Text", "LockedByMES" ],
           "properties": {
             "Id": {
@@ -4357,7 +4357,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineMESStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineMESStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4410,7 +4410,7 @@
         "description": "Method for setting the MESMessage",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Message", "Severity" ],
           "properties": {
             "Id": {
@@ -4462,7 +4462,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineStatusType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4480,7 +4480,7 @@
     "schemaDefinitions": {
       "MachineModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -4567,7 +4567,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MachineModeEnumeration",
         "description": "Current machine mode (as defined by mode selector on the machine)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4593,7 +4593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4604,7 +4604,7 @@
     "schemaDefinitions": {
       "MaintenanceStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "const": {
           "NOT_DUE": 0,
           "WARNING": 1,
@@ -4700,7 +4700,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MaintenanceStatusEnumeration",
         "description": "Maintenance status of the machine/device/component (represented by the parent element)",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaintenanceStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4789,7 +4789,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4818,7 +4818,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id", "Name", "Density" ],
           "properties": {
             "Id": {
@@ -4846,7 +4846,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6307",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -4868,7 +4868,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "EUInformation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
         "properties": {
           "NamespaceUri": {
@@ -4919,7 +4919,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5010,7 +5010,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDevicesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDevicesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5060,7 +5060,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MESMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MESMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5133,7 +5133,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MonitoredParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MonitoredParameterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5653,7 +5653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ControlledParameterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlledParameterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5775,7 +5775,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MeasuringDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MeasuringDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5798,7 +5798,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -5854,7 +5854,7 @@
       "ControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5928,7 +5928,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldCycleParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5976,7 +5976,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6027,7 +6027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6044,7 +6044,7 @@
     "schemaDefinitions": {
       "MouldStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "const": {
           "OTHER": 0,
           "MOULD_NOT_INSTALLED": 1,
@@ -6140,7 +6140,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "MouldStatusEnumeration",
         "description": "Current (physical) status of the mould",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6166,7 +6166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6217,7 +6217,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_PowerUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.PowerUnitType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6340,7 +6340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ElectricDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ElectricDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6367,7 +6367,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_HydraulicUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.HydraulicUnitType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6437,7 +6437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6448,7 +6448,7 @@
     "schemaDefinitions": {
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "const": {
           "OTHER": 0,
           "NO_PRODUCTION": 1,
@@ -6548,7 +6548,7 @@
         "description": "Release of production for a given time",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6222",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "WatchDogTime" ],
           "properties": {
             "WatchDogTime": {
@@ -6618,7 +6618,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ProductionStatusEnumeration",
         "description": "Production status when the machine is in automatic or semi-automatic mode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6644,7 +6644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetListsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetListsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6660,7 +6660,7 @@
         "description": "This Method is used to read a list from the server, which production datasets that are available on the machine's file system ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NameFilter", "MouldId" ],
           "properties": {
             "NameFilter": {
@@ -6673,7 +6673,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6019",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -6682,7 +6682,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -6784,7 +6784,7 @@
         "description": "This Method is used to send a list of production datasets available on the client to the server",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductionDatasetList" ],
           "properties": {
             "ProductionDatasetList": {
@@ -6793,7 +6793,7 @@
                 "title": "ProductionDatasetInformationType",
                 "description": "Information on a production dataset",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
                 "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
                 "properties": {
                   "Name": {
@@ -6905,7 +6905,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetManagementType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6946,7 +6946,7 @@
         "description": "This Method allows reading the description of a production dataset during the file transfer from the server to the client with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6283",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle" ],
           "properties": {
             "fileHandle": {
@@ -6958,14 +6958,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6284",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Information" ],
           "properties": {
             "Information": {
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -7066,7 +7066,7 @@
         "description": "This Method allows sending of the description of a production dataset during the file transfer from the client to the server with ProductionDatasetTransfer",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6285",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "fileHandle", "Information" ],
           "properties": {
             "fileHandle": {
@@ -7078,7 +7078,7 @@
               "title": "ProductionDatasetInformationType",
               "description": "Information on a production dataset",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
               "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
               "properties": {
                 "Name": {
@@ -7189,7 +7189,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_ProductionDatasetStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7217,7 +7217,7 @@
         "description": "Loads a production dataset from the file system of the machine to the control of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6275",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name", "Components" ],
           "properties": {
             "Name": {
@@ -7246,7 +7246,7 @@
         "description": "Stores a production dataset from the control of the machine to the file system of the machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=6187",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -7287,7 +7287,7 @@
         "title": "ProductionDatasetInformationType",
         "description": "Information on a production dataset",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ProductionDatasetInformationType",
         "required": [ "Name", "Description", "MESId", "CreationTimestamp", "LastModificationTimestamp", "LastSaveTimestamp", "UserName", "Components", "Manufacturer", "SerialNumber", "Model", "ControllerName", "UserMachineName", "LocationName", "ProductName", "MouldId", "NumCavities" ],
         "properties": {
           "Name": {
@@ -7407,7 +7407,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StandstillMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StandstillMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7492,7 +7492,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_StartDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7503,7 +7503,7 @@
     "schemaDefinitions": {
       "StartEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "const": {
           "NOT_READY_TO_START": 0,
           "START_BLOCKED_BY_CLIENT": 1,
@@ -7589,7 +7589,7 @@
       "Status": {
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "StartEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.StartEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7615,7 +7615,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZoneCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneCycleParametersType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7627,7 +7627,7 @@
     "schemaDefinitions": {
       "TemperatureZoneClassificationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "const": {
           "OTHER": 0,
           "HEATING": 1,
@@ -7699,7 +7699,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "TemperatureZoneClassificationEnumeration",
         "description": "Type of the temperature zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7769,7 +7769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7819,7 +7819,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_TemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7830,7 +7830,7 @@
     "schemaDefinitions": {
       "TemperatureZoneClassificationEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "const": {
           "OTHER": 0,
           "HEATING": 1,
@@ -7869,7 +7869,7 @@
       },
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "OFF": 1,
@@ -7946,7 +7946,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "TemperatureZoneClassificationEnumeration",
         "description": "Type of the temperature zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3029",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.TemperatureZoneClassificationEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7963,7 +7963,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/",
         "title": "ControlModeEnumeration",
         "description": "Indication how the temperature is currently controlled",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3001",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8232,7 +8232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_BarrelTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.BarrelTemperatureZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8281,7 +8281,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MouldTemperatureZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MouldTemperatureZoneType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8308,7 +8308,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_IdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.IdentificationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8409,7 +8409,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_MachineInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.MachineInformationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -8421,7 +8421,7 @@
     "schemaDefinitions": {
       "LogbookEventsEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
         "const": {
           "PARAMETER_CHANGE": 0,
           "USER": 1,
@@ -8565,7 +8565,7 @@
         "type": "array",
         "items": {
           "title": "LogbookEventsEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.LogbookEventsEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8592,7 +8592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UsersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UsersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8642,7 +8642,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_GeneralTypes_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.UserType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.HotRunner.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.HotRunner.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZoneAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZoneAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -58,7 +58,7 @@
     "schemaDefinitions": {
       "ControllerTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerTypeEnumeration",
         "const": {
           "CLOSED_LOOP_CONTROL": 0,
           "MANUAL": 1,
@@ -132,7 +132,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/HotRunner/",
         "title": "ControllerTypeEnumeration",
         "description": "Actual value for the controller type used by the zone",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ControllerTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -473,7 +473,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HeatUpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HeatUpType",
     "links": [
       {
         "rel": "tm:extends",
@@ -663,7 +663,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HRD_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HRD_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -756,7 +756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_MaintenanceInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.MaintenanceInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -800,7 +800,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_HRDTemperatureType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.HRDTemperatureType",
     "links": [
       {
         "rel": "tm:extends",
@@ -931,7 +931,7 @@
         "items": {
           "title": "TimeMethodPIDParametersDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.TimeMethodPIDParametersDataType",
           "required": [ "Xp", "Tn", "Tv", "Ts" ],
           "properties": {
             "Xp": {
@@ -1051,7 +1051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1106,7 +1106,7 @@
         "description": "Method to reset one error of the device",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=6378",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1127,7 +1127,7 @@
         "description": "Method to set ReactionOnDisconnect and SessionNameForReactionOnDisconnect",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=6651",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReactionOnDisconnect" ],
           "properties": {
             "ReactionOnDisconnect": {
@@ -1155,7 +1155,7 @@
           "title": "ClassifiedActiveErrorDataType",
           "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
           "required": [ "SourceNodes", "Classification" ],
           "properties": {
             "SourceNodes": {
@@ -1314,7 +1314,7 @@
             "title": "ClassifiedActiveErrorDataType",
             "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
             "required": [ "SourceNodes", "Classification" ],
             "properties": {
               "SourceNodes": {
@@ -1400,7 +1400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_TemperatureRiseMonitoringType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.TemperatureRiseMonitoringType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1529,7 +1529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZonesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZonesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1579,7 +1579,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_HotRunner_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/HotRunner/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.HotRunner.ZoneType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.IMM2MES.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.IMM2MES.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_IMM_MES_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.IMM_MES_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -95,7 +95,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitCycleParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitCycleParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1167,7 +1167,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1217,7 +1217,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_IMM2MES_InjectionUnitType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/IMM2MES/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.IMM2MES.InjectionUnitType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/PlasticsRubber.LDS.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.LDS.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_AdditiveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -31,7 +31,7 @@
     "schemaDefinitions": {
       "AdditiveStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveStatusEnumeration",
         "const": {
           "GOOD": 0,
           "WARNING": 1,
@@ -158,7 +158,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "AdditiveStatusEnumeration",
         "description": "Actual status of the additive provides a minimal error handling for devices without event support.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -184,7 +184,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_AdditiveAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.AdditiveAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -211,7 +211,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_ComponentAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -238,7 +238,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_LDSCycleParametersEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.LDSCycleParametersEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -857,7 +857,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_ComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentType",
     "links": [
       {
         "rel": "tm:extends",
@@ -868,7 +868,7 @@
     "schemaDefinitions": {
       "ComponentStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentStatusEnumeration",
         "const": {
           "GOOD": 0,
           "WARNING": 1,
@@ -934,7 +934,7 @@
         "description": "This optional method is used to modify SetValueDensity if allowed by the device.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Density" ],
           "properties": {
             "Density": {
@@ -1082,7 +1082,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "ComponentStatusEnumeration",
         "description": "Actual status of the component provides a minimal error handling for devices without event support.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.ComponentStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1219,7 +1219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_LDS_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.LDS_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1312,7 +1312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_LDS_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1353,7 +1353,7 @@
     "schemaDefinitions": {
       "MaterialBalanceSystemTypeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.MaterialBalanceSystemTypeEnumeration",
         "const": {
           "NOT_AVAILABLE": 0,
           "ALWAYS_ACTIVE": 1,
@@ -1373,7 +1373,7 @@
       },
       "PurgeStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.PurgeStatusEnumeration",
         "const": {
           "OFF": 0,
           "COMPONENT_A": 1,
@@ -1445,7 +1445,7 @@
         "description": "Method to reset one error of the device",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1466,7 +1466,7 @@
         "description": "Method to set the cycle number of the LDS to synchronize it with the cycle number of the injection moulding machine",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=6039",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CycleNumber" ],
           "properties": {
             "CycleNumber": {
@@ -1553,7 +1553,7 @@
           "title": "ClassifiedActiveErrorDataType",
           "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
           "required": [ "SourceNodes", "Classification" ],
           "properties": {
             "SourceNodes": {
@@ -1701,7 +1701,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "MaterialBalanceSystemTypeEnumeration",
         "description": "Type of the material balance system",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.MaterialBalanceSystemTypeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1850,7 +1850,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/LDS/",
         "title": "PurgeStatusEnumeration",
         "description": "Actual status of the purge function",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/LDS/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.LDS.PurgeStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1993,7 +1993,7 @@
             "title": "ClassifiedActiveErrorDataType",
             "description": "Iinformation about an active error in a device including the SoureNodes and a Classification",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3003",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ClassifiedActiveErrorDataType",
             "required": [ "SourceNodes", "Classification" ],
             "properties": {
               "SourceNodes": {

--- a/wot-codegen/opc-output-simple/PlasticsRubber.TCD.TM.json
+++ b/wot-codegen/opc-output-simple/PlasticsRubber.TCD.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCDHelpOffNormalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCDHelpOffNormalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -58,7 +58,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_DeviceZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.DeviceZoneType",
     "links": [
       {
         "rel": "tm:extends",
@@ -705,7 +705,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalChannelsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalChannelsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -755,7 +755,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalChannelType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalChannelType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1022,7 +1022,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_ExternalSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.ExternalSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1230,7 +1230,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_LeakStopperType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.LeakStopperType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1278,7 +1278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_MaintenanceInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.MaintenanceInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1329,7 +1329,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_MouldEvacuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.MouldEvacuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1555,7 +1555,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_OperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1566,7 +1566,7 @@
     "schemaDefinitions": {
       "OperatingModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperatingModeEnumeration",
         "const": {
           "OTHER": 0,
           "READY_TO_OPERATE": 1,
@@ -1690,7 +1690,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/TCD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=6510",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1739,7 +1739,7 @@
           "title": "ActiveErrorDataType",
           "description": "Iinformation about an active error in a device",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3028",
+          "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveErrorDataType",
           "required": [ "Id", "Severity", "Message" ],
           "properties": {
             "Id": {
@@ -1823,7 +1823,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PlasticsRubber/TCD/",
         "title": "OperatingModeEnumeration",
         "description": "Actual operating mode of the TCD",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.OperatingModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1859,7 +1859,7 @@
             "title": "ActiveErrorDataType",
             "description": "Iinformation about an active error in a device",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/GeneralTypes/;i=3028",
+            "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.GeneralTypes.ActiveErrorDataType",
             "required": [ "Id", "Severity", "Message" ],
             "properties": {
               "Id": {
@@ -1916,7 +1916,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCD_InterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCD_InterfaceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2004,7 +2004,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "PlasticsRubber_TCD_TCDSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/PlasticsRubber/TCD/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.PlasticsRubber.TCD.TCDSpecificationType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Powertrain.TM.json
+++ b/wot-codegen/opc-output-simple/Powertrain.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_IPtTagNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15898",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.IPtTagNameplateType",
     "dov:isComposite": true,
     "links": [
       {
@@ -98,7 +98,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16337",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -152,7 +152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtBleedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtBleedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -271,7 +271,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtBrakeAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16609",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtBrakeAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -990,7 +990,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCapacitanceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCapacitanceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1078,7 +1078,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCommonAssetAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16873",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCommonAssetAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1132,7 +1132,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAmbientAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16875",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAmbientAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1394,7 +1394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAnalogInputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16907",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAnalogInputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1470,7 +1470,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1497,7 +1497,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1584,7 +1584,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1612,7 +1612,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1661,7 +1661,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAnalogOutputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16913",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAnalogOutputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1725,7 +1725,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -1798,7 +1798,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -1847,7 +1847,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAuxiliarySupplyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16928",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAuxiliarySupplyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2051,7 +2051,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCertificateAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16960",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCertificateAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2120,7 +2120,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCommunicationInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16963",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCommunicationInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2310,7 +2310,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtCoolingAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16970",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtCoolingAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2398,7 +2398,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDigitalInputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17000",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDigitalInputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2512,7 +2512,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDigitalOutputElectricalAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17009",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDigitalOutputElectricalAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2655,7 +2655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtFunctionalSafetyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17144",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtFunctionalSafetyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2743,7 +2743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtFuseAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17024",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtFuseAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2930,7 +2930,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtHardwareAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16973",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtHardwareAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3178,7 +3178,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17046",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3270,7 +3270,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -3339,7 +3339,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -3442,7 +3442,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -3515,7 +3515,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -3564,7 +3564,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMechanicalStrengthAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17136",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMechanicalStrengthAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3648,7 +3648,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17085",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3838,7 +3838,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4017,7 +4017,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -4066,7 +4066,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtProtectionClassAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17140",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtProtectionClassAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4166,7 +4166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtSafetyFunctionsAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17149",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtSafetyFunctionsAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4356,7 +4356,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtStandardAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=17156",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtStandardAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4425,7 +4425,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtContactorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16847",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtContactorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4454,7 +4454,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4562,7 +4562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtDcBusAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16798",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtDcBusAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4596,7 +4596,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4657,7 +4657,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -4707,7 +4707,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtElectronicOverloadRelayAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtElectronicOverloadRelayAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4795,7 +4795,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -4898,7 +4898,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16553",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5016,7 +5016,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderLinearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderLinearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5219,7 +5219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderRotaryAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderRotaryAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5596,7 +5596,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderInterfaceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderInterfaceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5691,7 +5691,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtEncoderInterfaceProtocolAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16605",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtEncoderInterfaceProtocolAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5779,7 +5779,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtGearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16503",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtGearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6146,7 +6146,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputConverterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16806",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputConverterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6364,7 +6364,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtInputFilterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16827",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtInputFilterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6539,7 +6539,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16383",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6628,7 +6628,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorLinearAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorLinearAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6774,7 +6774,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRotaryAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRotaryAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6905,7 +6905,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorDutyAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16499",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorDutyAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7008,7 +7008,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorManagementDeviceAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorManagementDeviceAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7042,7 +7042,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -7213,7 +7213,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -7362,7 +7362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16399",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRatedAttributesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7591,7 +7591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorLinearRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorLinearRatedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7824,7 +7824,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorRotaryRatedAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorRotaryRatedAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8057,7 +8057,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtMotorStarterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16854",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtMotorStarterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8091,7 +8091,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8190,7 +8190,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8255,7 +8255,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputConverterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16818",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputConverterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8374,7 +8374,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtOutputFilterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16838",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtOutputFilterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8491,7 +8491,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtPrechargeAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtPrechargeAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8724,7 +8724,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtReactorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtReactorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8812,7 +8812,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtSoftStarterAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtSoftStarterAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8895,7 +8895,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8931,7 +8931,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtTemperatureSensorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16708",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtTemperatureSensorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9118,7 +9118,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtVibrationSensorAttributesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=16747",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtVibrationSensorAttributesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9238,7 +9238,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -9279,7 +9279,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Powertrain/",
         "title": "Range",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -9426,7 +9426,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -9469,7 +9469,7 @@
         "data": {
           "title": "Range",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -9548,7 +9548,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15912",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9662,7 +9662,7 @@
     "schemaDefinitions": {
       "DeviceHealthEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "const": {
           "NORMAL": 0,
           "FAILURE": 1,
@@ -9695,7 +9695,7 @@
       },
       "AssetVerificationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
         "const": {
           "AssetCompatibility": 0,
           "AssetIdentity": 1,
@@ -9718,7 +9718,7 @@
       },
       "AssetVerificationResultEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+        "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
         "const": {
           "NotSet": 0,
           "Match": 1,
@@ -9767,14 +9767,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/FX/AC/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1422",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VerificationMode", "ExpectedVerificationVariables" ],
           "properties": {
             "VerificationMode": {
               "type": "array",
               "items": {
                 "title": "AssetVerificationModeEnum",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1029",
+                "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationModeEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -9785,7 +9785,7 @@
               "items": {
                 "title": "KeyValuePair",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=14533",
+                "dov:typeRef": "org.opcfoundation.UA.KeyValuePair",
                 "required": [ "Key", "Value" ],
                 "properties": {
                   "Key": {
@@ -9802,12 +9802,12 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/AC/;i=1423",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "VerificationResult", "VerificationVariablesErrors" ],
           "properties": {
             "VerificationResult": {
               "title": "AssetVerificationResultEnum",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/FX/Data/;i=1037",
+              "dov:typeRef": "org.opcfoundation.UA.FX.Data.AssetVerificationResultEnum",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -9948,7 +9948,7 @@
       "DeviceHealth": {
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "title": "DeviceHealthEnumeration",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+        "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10267,7 +10267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/DI/",
         "data": {
           "title": "DeviceHealthEnumeration",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/DI/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.DI.DeviceHealthEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -10291,7 +10291,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetBleedType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetBleedType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10353,7 +10353,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetBrakeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15116",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetBrakeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10415,7 +10415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetCommunicationModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15430",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetCommunicationModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10484,7 +10484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetContactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15549",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetContactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10546,7 +10546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetControlModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15447",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetControlModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10622,7 +10622,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetCoolingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15541",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetCoolingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10684,7 +10684,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDcBusModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDcBusModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10753,7 +10753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10892,7 +10892,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetFrequencyConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetFrequencyConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -10947,7 +10947,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetServoDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetServoDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11009,7 +11009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetVariableSpeedDriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetVariableSpeedDriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11071,7 +11071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetElectricalBrakingModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15148",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetElectricalBrakingModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11147,7 +11147,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetElectricOverloadRelayType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetElectricOverloadRelayType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11216,7 +11216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderInterfaceModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderInterfaceModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11285,7 +11285,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15108",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11361,7 +11361,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11423,7 +11423,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetEncoderRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetEncoderRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11485,7 +11485,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15122",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11561,7 +11561,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15168",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11693,7 +11693,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15196",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11769,7 +11769,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputOutputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputOutputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11915,7 +11915,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetInputReactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15241",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetInputReactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -11984,7 +11984,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetIoModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15468",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetIoModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12053,7 +12053,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorManagementDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorManagementDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12122,7 +12122,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorStarterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15561",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorStarterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12191,7 +12191,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15083",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12274,7 +12274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12350,7 +12350,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12447,7 +12447,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedGearMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedGearMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12509,7 +12509,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearMotorLinearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearMotorLinearType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12571,7 +12571,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12647,7 +12647,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12744,7 +12744,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetDriveIntegratedGearMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetDriveIntegratedGearMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12806,7 +12806,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetGearMotorRotaryType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetGearMotorRotaryType",
     "dov:isComposite": true,
     "links": [
       {
@@ -12868,7 +12868,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputConverterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15182",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputConverterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13000,7 +13000,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15303",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13076,7 +13076,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetOutputReactorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15368",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetOutputReactorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13145,7 +13145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetPrechargeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetPrechargeType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13235,7 +13235,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetReactorFilterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetReactorFilterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13304,7 +13304,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetSafetyModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15527",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetSafetyModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13373,7 +13373,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetSoftStarterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetSoftStarterType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13442,7 +13442,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetTemperatureSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15130",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetTemperatureSensorType",
     "dov:isComposite": true,
     "links": [
       {
@@ -13504,7 +13504,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Powertrain_PtAssetVibrationSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Powertrain/;i=15136",
+    "dov:typeRef": "org.opcfoundation.UA.Powertrain.PtAssetVibrationSensorType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/Pumps.TM.json
+++ b/wot-codegen/opc-output-simple/Pumps.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_IPumpVendorNameplateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.IPumpVendorNameplateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -136,7 +136,7 @@
         "title": "PhysicalAddressDataType",
         "description": "Physical address of the manufacturer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PhysicalAddressDataType",
         "properties": {
           "Street": {
             "description": "Street name where the manufacturer is located.",
@@ -216,7 +216,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -312,7 +312,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteInputObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteInputObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -377,7 +377,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DiscreteOutputObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DiscreteOutputObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -517,7 +517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpKickObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickObjectType",
     "links": [
       {
         "rel": "tm:extends",
@@ -528,7 +528,7 @@
     "schemaDefinitions": {
       "PumpKickModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "Disabled": 1,
@@ -575,7 +575,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PumpKickModeEnum",
         "description": "This property describes the pump kick mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -654,7 +654,7 @@
         "data": {
           "title": "PumpKickModeEnum",
           "description": "This property describes the pump kick mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpKickModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -713,7 +713,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ActuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ActuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1013,7 +1013,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpActuationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpActuationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1078,7 +1078,7 @@
     "schemaDefinitions": {
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "const": {
           "ConstantPressureControl": 0,
           "ConstantTemperatureControl": 1,
@@ -1147,7 +1147,7 @@
       },
       "OperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "const": {
           "AutoControl": 0,
           "ClosedLoopStandardPID": 1,
@@ -1234,7 +1234,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "This property describes the actual control mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1251,7 +1251,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperationModeEnum",
         "description": "This property describes the actual operation mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1335,7 +1335,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "This property describes the desired control mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1357,7 +1357,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperationModeEnum",
         "description": "This property describes the desired operation mode of the pump.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1382,7 +1382,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "This property describes the actual control mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1400,7 +1400,7 @@
         "data": {
           "title": "OperationModeEnum",
           "description": "This property describes the actual operation mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1474,7 +1474,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "This property describes the desired control mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1492,7 +1492,7 @@
         "data": {
           "title": "OperationModeEnum",
           "description": "This property describes the desired operation mode of the pump.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -1517,7 +1517,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_BreakdownMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.BreakdownMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1719,7 +1719,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConditionBasedMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConditionBasedMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2274,7 +2274,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConfigurationGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConfigurationGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2318,7 +2318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2384,7 +2384,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2799,7 +2799,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1042",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3166,7 +3166,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3242,7 +3242,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3494,7 +3494,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3746,7 +3746,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4250,7 +4250,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4303,7 +4303,7 @@
     "schemaDefinitions": {
       "DeclarationOfConformityOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
         "const": {
           "S2006_42_EC": 0,
           "S2009_125_EC": 1,
@@ -4352,7 +4352,7 @@
       },
       "ExplosionProtectionOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
         "const": {
           "M1": 0,
           "M2": 1,
@@ -4401,7 +4401,7 @@
       },
       "OfferedControlModesOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
         "const": {
           "Constant_pressure_control": 0,
           "Constant_temperature_control": 1,
@@ -4470,7 +4470,7 @@
       },
       "OfferedFieldbusesOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
         "const": {
           "Other": 0,
           "ARCNET": 1,
@@ -4729,7 +4729,7 @@
       },
       "DeviceTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
         "const": {
           "RotodynamicPump": 0,
           "PositiveDisplacementPump": 1,
@@ -4991,7 +4991,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DeclarationOfConformityOptionSet",
         "description": "Set of directives on the basis of which conformity was determined.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5025,7 +5025,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExplosionProtectionOptionSet",
         "description": "Device category for explosion protection according to 2014/34/EU (ATEX).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5501,7 +5501,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OfferedControlModesOptionSet",
         "description": "Control modes supported by the manufacturer for the product.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5518,7 +5518,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OfferedFieldbusesOptionSet",
         "description": "Fieldbuses supported by the manufacturer for the product.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5636,7 +5636,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DeviceTypeEnum",
         "description": "Pump type according to functional principle and pumped fluid",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6944,7 +6944,7 @@
         "data": {
           "title": "DeclarationOfConformityOptionSet",
           "description": "Set of directives on the basis of which conformity was determined.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3019",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DeclarationOfConformityOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6980,7 +6980,7 @@
         "data": {
           "title": "ExplosionProtectionOptionSet",
           "description": "Device category for explosion protection according to 2014/34/EU (ATEX).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3016",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionProtectionOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7484,7 +7484,7 @@
         "data": {
           "title": "OfferedControlModesOptionSet",
           "description": "Control modes supported by the manufacturer for the product.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3017",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedControlModesOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7502,7 +7502,7 @@
         "data": {
           "title": "OfferedFieldbusesOptionSet",
           "description": "Fieldbuses supported by the manufacturer for the product.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3018",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OfferedFieldbusesOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7627,7 +7627,7 @@
         "data": {
           "title": "DeviceTypeEnum",
           "description": "Pump type according to functional principle and pumped fluid",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3021",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DeviceTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -8027,7 +8027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DocumentationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DocumentationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8792,7 +8792,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DriveDesignType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DriveDesignType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9355,7 +9355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DriveMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DriveMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9989,7 +9989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_GeneralMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.GeneralMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10000,7 +10000,7 @@
     "schemaDefinitions": {
       "MaintenanceLevelEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
         "const": {
           "Level1": 0,
           "Level2": 1,
@@ -10034,7 +10034,7 @@
       },
       "StateOfTheItemEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
         "const": {
           "IdleState": 0,
           "StandByState": 1,
@@ -10171,7 +10171,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "MaintenanceLevelEnum",
         "description": "Maintenance task categorization by complexity",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10354,7 +10354,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "StateOfTheItemEnum",
         "description": "Current state of the item",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10719,7 +10719,7 @@
         "data": {
           "title": "MaintenanceLevelEnum",
           "description": "Maintenance task categorization by complexity",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceLevelEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -10913,7 +10913,7 @@
         "data": {
           "title": "StateOfTheItemEnum",
           "description": "Current state of the item",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.StateOfTheItemEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -10992,7 +10992,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_ImplementationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.ImplementationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12752,7 +12752,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12885,7 +12885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionSystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionSystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -12980,7 +12980,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13117,7 +13117,7 @@
         "title": "PhysicalAddressDataType",
         "description": "Physical address of the manufacturer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PhysicalAddressDataType",
         "properties": {
           "Street": {
             "description": "Street name where the manufacturer is located.",
@@ -13192,7 +13192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MaintenanceGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MaintenanceGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13243,7 +13243,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15606,7 +15606,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MultiPumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15617,7 +15617,7 @@
     "schemaDefinitions": {
       "DistributionTypeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "OperatorSpecific": 1,
@@ -15646,7 +15646,7 @@
       },
       "ExchangeModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
         "const": {
           "ManufacturerSpecific": 0,
           "ExchangeDisabled": 1,
@@ -15670,7 +15670,7 @@
       },
       "MultiPumpOperationModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
         "const": {
           "Standalone": 0,
           "RedundancyOperation": 1,
@@ -15699,7 +15699,7 @@
       },
       "PumpRoleEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
         "const": {
           "Slave": 0,
           "Master": 1,
@@ -15767,7 +15767,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "DistributionTypeEnum",
         "description": "This property describes the share of operation time of different pumps of the pump system in addition operation mode.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15789,7 +15789,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExchangeModeEnum",
         "description": "This property specifies the exchange mode of the pump",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15872,7 +15872,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "MultiPumpOperationModeEnum",
         "description": "This property specifies the actual multi pump operation mode. In redundant operation mode a pump fulfils the process function of another pump. Addition operation mode characterizes the supplementary fulfilling of the process function. The mixed mode characterizes both operation tasks.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -15935,7 +15935,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PumpRoleEnum",
         "description": "This property identifies the role rsp. task of the pump within the multi pump management.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -16010,7 +16010,7 @@
         "data": {
           "title": "DistributionTypeEnum",
           "description": "This property describes the share of operation time of different pumps of the pump system in addition operation mode.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.DistributionTypeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16028,7 +16028,7 @@
         "data": {
           "title": "ExchangeModeEnum",
           "description": "This property specifies the exchange mode of the pump",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3012",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExchangeModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16095,7 +16095,7 @@
         "data": {
           "title": "MultiPumpOperationModeEnum",
           "description": "This property specifies the actual multi pump operation mode. In redundant operation mode a pump fulfils the process function of another pump. Addition operation mode characterizes the supplementary fulfilling of the process function. The mixed mode characterizes both operation tasks.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3011",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.MultiPumpOperationModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16146,7 +16146,7 @@
         "data": {
           "title": "PumpRoleEnum",
           "description": "This property identifies the role rsp. task of the pump within the multi pump management.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpRoleEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -16187,7 +16187,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OperationalGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OperationalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16256,7 +16256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionMeasurementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionMeasurementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16389,7 +16389,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionSystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionSystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16484,7 +16484,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PortsGroupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PortsGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16529,7 +16529,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PreventiveMaintenanceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PreventiveMaintenanceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16846,7 +16846,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SignalsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SignalsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -16998,7 +16998,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionAuxiliaryDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionAuxiliaryDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17981,7 +17981,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionElectronicsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionElectronicsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18559,7 +18559,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionHardwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionHardwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18921,7 +18921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionMechanicsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionMechanicsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19391,7 +19391,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionProcessFluidType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionProcessFluidType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19780,7 +19780,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionPumpOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionPumpOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20817,7 +20817,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionSoftwareType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionSoftwareType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21071,7 +21071,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SupervisionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SupervisionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21140,7 +21140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_SystemRequirementsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.SystemRequirementsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21151,7 +21151,7 @@
     "schemaDefinitions": {
       "ExplosionZoneOptionSet": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
         "const": {
           "Zone_0": 0,
           "Zone_1": 1,
@@ -21190,7 +21190,7 @@
       },
       "FieldbusEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
         "const": {
           "Other": 0,
           "ARCNET": 1,
@@ -21449,7 +21449,7 @@
       },
       "OperatingModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
         "const": {
           "SingleOperation": 0,
           "SeriesOperation": 1,
@@ -21473,7 +21473,7 @@
       },
       "ControlModeEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "const": {
           "ConstantPressureControl": 0,
           "ConstantTemperatureControl": 1,
@@ -21585,7 +21585,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ExplosionZoneOptionSet",
         "description": "Categories of explosion zones for devices according to 2014/34/EU (ATEX).",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -21607,7 +21607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "FieldbusEnum",
         "description": "Selected fieldbus for the product",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22149,7 +22149,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "OperatingModeEnum",
         "description": "Specifies whether the pump is to be operated in single, parallel or series connection.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22237,7 +22237,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "ControlModeEnum",
         "description": "Specifies which control mode is to be used for the use case.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -22748,7 +22748,7 @@
         "data": {
           "title": "ExplosionZoneOptionSet",
           "description": "Categories of explosion zones for devices according to 2014/34/EU (ATEX).",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ExplosionZoneOptionSet",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -22766,7 +22766,7 @@
         "data": {
           "title": "FieldbusEnum",
           "description": "Selected fieldbus for the product",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3005",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.FieldbusEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23208,7 +23208,7 @@
         "data": {
           "title": "OperatingModeEnum",
           "description": "Specifies whether the pump is to be operated in single, parallel or series connection.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.OperatingModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23280,7 +23280,7 @@
         "data": {
           "title": "ControlModeEnum",
           "description": "Specifies which control mode is to be used for the use case.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.ControlModeEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -23395,7 +23395,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_VibrationMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.VibrationMeasurementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24977,7 +24977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_MarkingsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.MarkingsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25009,7 +25009,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25020,7 +25020,7 @@
     "schemaDefinitions": {
       "PortDirectionEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
         "const": {
           "In": 0,
           "Out": 1,
@@ -25085,7 +25085,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Pumps/",
         "title": "PortDirectionEnum",
         "description": "Ports with the direction “In” can only be connected to ports with the direction “Out” or “InOut” and ports with the direction “Out” can only be connected with ports with the direction “In” or “InOut”. Ports with the direction “InOut” can be connected to Ports of arbitrary direction.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -25142,7 +25142,7 @@
         "data": {
           "title": "PortDirectionEnum",
           "description": "Ports with the direction “In” can only be connected to ports with the direction “Out” or “InOut” and ports with the direction “Out” can only be connected with ports with the direction “In” or “InOut”. Ports with the direction “InOut” can be connected to Ports of arbitrary direction.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.Pumps.PortDirectionEnum",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -25180,7 +25180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_DrivePortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.DrivePortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25218,7 +25218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_InletConnectionPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.InletConnectionPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25268,7 +25268,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_OutletConnectionPortType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.OutletConnectionPortType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25318,7 +25318,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Pumps_PumpType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Pumps/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.Pumps.PumpType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/RSL.TM.json
+++ b/wot-codegen/opc-output-simple/RSL.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "RSL_SpatialObjectsListType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/RSL/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.RSL.SpatialObjectsListType",
     "dov:isComposite": true,
     "links": [
       {
@@ -153,7 +153,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "RSL_SpatialObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/RSL/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.RSL.SpatialObjectType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Robotics.TM.json
+++ b/wot-codegen/opc-output-simple/Robotics.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MultiAcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MultiAcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -67,7 +67,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_EmergencyStopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17230",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.EmergencyStopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -145,7 +145,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_LoadType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.LoadType",
     "links": [
       {
         "rel": "tm:extends",
@@ -175,13 +175,13 @@
         "title": "ThreeDFrame",
         "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
         "required": [ "CartesianCoordinates", "Orientation" ],
         "properties": {
           "CartesianCoordinates": {
             "title": "ThreeDCartesianCoordinates",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
             "required": [ "X", "Y", "Z" ],
             "properties": {
               "X": {
@@ -204,7 +204,7 @@
           "Orientation": {
             "title": "ThreeDOrientation",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+            "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
             "required": [ "A", "B", "C" ],
             "properties": {
               "A": {
@@ -238,7 +238,7 @@
       "CenterOfMass_CartesianCoordinates": {
         "title": "ThreeDCartesianCoordinates",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -313,7 +313,7 @@
       "CenterOfMass_Orientation": {
         "title": "ThreeDOrientation",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
         "required": [ "A", "B", "C" ],
         "properties": {
           "A": {
@@ -390,7 +390,7 @@
         "title": "ThreeDVector",
         "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+        "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
         "required": [ "X", "Y", "Z" ],
         "properties": {
           "X": {
@@ -484,13 +484,13 @@
           "title": "ThreeDFrame",
           "description": "The position and orientation of the center of the mass related to the mounting point using a FrameType. X, Y, Z define the position of the center of gravity relative to the mounting point coordinate system. A, B, C define the orientation of the principal axes of inertia relative to the mounting point coordinate system. Orientation A, B, C can be '0' for systems which do not need these  values.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18814",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDFrame",
           "required": [ "CartesianCoordinates", "Orientation" ],
           "properties": {
             "CartesianCoordinates": {
               "title": "ThreeDCartesianCoordinates",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
               "required": [ "X", "Y", "Z" ],
               "properties": {
                 "X": {
@@ -513,7 +513,7 @@
             "Orientation": {
               "title": "ThreeDOrientation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+              "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
               "required": [ "A", "B", "C" ],
               "properties": {
                 "A": {
@@ -548,7 +548,7 @@
         "data": {
           "title": "ThreeDCartesianCoordinates",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18810",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDCartesianCoordinates",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -627,7 +627,7 @@
         "data": {
           "title": "ThreeDOrientation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18812",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDOrientation",
           "required": [ "A", "B", "C" ],
           "properties": {
             "A": {
@@ -708,7 +708,7 @@
           "title": "ThreeDVector",
           "description": "The Inertia uses the VectorType to describe the three values of the principal moments of inertia with respect to the mounting point coordinate system. If inertia values are provided for rotary axis the CenterOfMass shall be completely filled as well.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18808",
+          "dov:typeRef": "org.opcfoundation.UA.ThreeDVector",
           "required": [ "X", "Y", "Z" ],
           "properties": {
             "X": {
@@ -809,7 +809,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ProtectiveStopFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17233",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ProtectiveStopFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -914,7 +914,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ExecutingSubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ExecutingSubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1032,7 +1032,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_IdleSubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.IdleSubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1156,7 +1156,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_OperationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.OperationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1242,7 +1242,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6023",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1265,7 +1265,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -1278,7 +1278,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1354,7 +1354,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -1435,7 +1435,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -1471,7 +1471,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SystemOperationStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SystemOperationStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1569,7 +1569,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1592,7 +1592,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1615,7 +1615,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1638,7 +1638,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -1651,7 +1651,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1727,7 +1727,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -1808,7 +1808,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -1844,7 +1844,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1936,7 +1936,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6143",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -1947,7 +1947,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6144",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -1970,7 +1970,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6141",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -1981,7 +1981,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6142",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2004,7 +2004,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2027,7 +2027,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "StopMode" ],
           "properties": {
             "StopMode": {
@@ -2040,7 +2040,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6103",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2063,7 +2063,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Name" ],
           "properties": {
             "Name": {
@@ -2073,7 +2073,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2095,7 +2095,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6146",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Id" ],
           "properties": {
             "Id": {
@@ -2106,7 +2106,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6147",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2129,7 +2129,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6145",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2205,7 +2205,7 @@
         "items": {
           "title": "EnumValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+          "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
           "required": [ "Value", "DisplayName", "Description" ],
           "properties": {
             "Value": {
@@ -2286,7 +2286,7 @@
           "items": {
             "title": "EnumValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=7594",
+            "dov:typeRef": "org.opcfoundation.UA.EnumValueType",
             "required": [ "Value", "DisplayName", "Description" ],
             "properties": {
               "Value": {
@@ -2322,7 +2322,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ReadySubstateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ReadySubstateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2378,7 +2378,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Status" ],
           "properties": {
             "Status": {
@@ -2469,7 +2469,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SystemOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SystemOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2535,7 +2535,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlOperationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlOperationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2610,7 +2610,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2699,7 +2699,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_AuxiliaryComponentType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17725",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.AuxiliaryComponentType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2758,7 +2758,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_AxisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16601",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2788,7 +2788,7 @@
     "schemaDefinitions": {
       "AxisMotionProfileEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "const": {
           "OTHER": 0,
           "ROTARY": 1,
@@ -2846,7 +2846,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "AxisMotionProfileEnumeration",
         "description": "The kind of axis motion as defined with the AxisMotionProfileEnumeration.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.AxisMotionProfileEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2872,7 +2872,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_ControllerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.ControllerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3039,7 +3039,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_DriveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=17793",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.DriveType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3098,7 +3098,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_GearType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.GearType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3140,7 +3140,7 @@
         "title": "RationalNumber",
         "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+        "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
         "required": [ "Numerator", "Denominator" ],
         "properties": {
           "Numerator": {
@@ -3263,7 +3263,7 @@
           "title": "RationalNumber",
           "description": "The transmission ratio of the gear expressed as a fraction as input velocity (motor side) by output velocity (load side).",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=18806",
+          "dov:typeRef": "org.opcfoundation.UA.RationalNumber",
           "required": [ "Numerator", "Denominator" ],
           "properties": {
             "Numerator": {
@@ -3344,7 +3344,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3408,7 +3408,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3449,7 +3449,7 @@
     "schemaDefinitions": {
       "MotionDeviceCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "ARTICULATED_ROBOT": 1,
@@ -3570,7 +3570,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Robotics/",
         "title": "MotionDeviceCategoryEnumeration",
         "description": "The variable MotionDeviceCategory provides the kind of motion device defined by MotionDeviceCategoryEnumeration based on ISO 8373.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18193",
+        "dov:typeRef": "org.opcfoundation.UA.Robotics.MotionDeviceCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3645,7 +3645,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_MotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.MotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3751,7 +3751,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_PowerTrainType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=16794",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.PowerTrainType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3822,7 +3822,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_SafetyStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.SafetyStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3885,7 +3885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_TaskControlType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.TaskControlType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3950,7 +3950,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Robotics_UserType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Robotics/;i=18175",
+    "dov:typeRef": "org.opcfoundation.UA.Robotics.UserType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Safety.TM.json
+++ b/wot-codegen/opc-output-simple/Safety.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyConsumerParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyConsumerParametersType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyObjectsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyObjectsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyConsumerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyConsumerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -87,7 +87,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyProviderType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyProviderType",
     "dov:isComposite": true,
     "links": [
       {
@@ -114,7 +114,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyPDUsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyPDUsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -140,7 +140,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Safety_SafetyProviderParametersType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Safety;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Safety.SafetyProviderParametersType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Scales.V2.TM.json
+++ b/wot-codegen/opc-output-simple/Scales.V2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=21",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -183,7 +183,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -358,7 +358,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_MaterialType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=35",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.MaterialType",
     "links": [
       {
         "rel": "tm:extends",
@@ -465,7 +465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_MaterialAutomaticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=41",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.MaterialAutomaticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -498,7 +498,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ProductionPresetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=14",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ProductionPresetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -537,7 +537,7 @@
         "description": "Creates an object with the JobType from the address space.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=246",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductName", "ProductId", "ProductType" ],
           "properties": {
             "ProductName": {
@@ -553,7 +553,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=177",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductNodeId" ],
           "properties": {
             "ProductNodeId": {
@@ -573,7 +573,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=176",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -594,7 +594,7 @@
         "description": "Removes an object with the JobType from the address space.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=647",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -614,7 +614,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=175",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -634,7 +634,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=988",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ProductId" ],
           "properties": {
             "ProductId": {
@@ -701,7 +701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=11",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -938,7 +938,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticFillingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=16",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticFillingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1261,7 +1261,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CatchweigherProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=17",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CatchweigherProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1306,7 +1306,7 @@
         "description": "Adds a zone to the zone array.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=145",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ZoneName", "LowerLimit", "UpperLimit", "EngineeringUnits" ],
           "properties": {
             "ZoneName": {
@@ -1325,7 +1325,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1348,7 +1348,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=146",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ZoneNodeId" ],
           "properties": {
             "ZoneNodeId": {
@@ -1369,7 +1369,7 @@
         "description": "Removes a zone from the zone array.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=147",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ZoneNodeId" ],
           "properties": {
             "ZoneNodeId": {
@@ -1526,7 +1526,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticWeightPriceLabelerProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=47",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticWeightPriceLabelerProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1607,7 +1607,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=46",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1748,7 +1748,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ContinuousProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=18",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ContinuousProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1887,7 +1887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PieceCountingProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=12",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PieceCountingProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1920,7 +1920,7 @@
         "description": "Set the number of TargetItemCount.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=398",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetItemCount" ],
           "properties": {
             "TargetItemCount": {
@@ -1943,7 +1943,7 @@
         "description": "Sets the value of TargetPieceCount. See TargetPieceCount.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TargetPieceCount", "PlusTolerance", "MinusTolerance" ],
           "properties": {
             "TargetPieceCount": {
@@ -2258,7 +2258,7 @@
         "title": "WeightType",
         "description": "Defines the summed up number of weight. Will be reset either triggered by the user or a different product selection.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -2519,7 +2519,7 @@
           "title": "WeightType",
           "description": "Defines the summed up number of weight. Will be reset either triggered by the user or a different product selection.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -2558,7 +2558,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=19",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2619,7 +2619,7 @@
         "items": {
           "title": "RecipeReportElementType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeReportElementType",
           "required": [ "ReportMessage", "Timestamp" ],
           "properties": {
             "ReportMessage": {
@@ -2669,7 +2669,7 @@
           "items": {
             "title": "RecipeReportElementType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=59",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeReportElementType",
             "required": [ "ReportMessage", "Timestamp" ],
             "properties": {
               "ReportMessage": {
@@ -2701,7 +2701,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_SimpleProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=20",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.SimpleProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2791,7 +2791,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizingHopperProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=22",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizingHopperProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2900,7 +2900,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_VehicleProductType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=832",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.VehicleProductType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2938,7 +2938,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1208",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -3011,7 +3011,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3116,7 +3116,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3170,7 +3170,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3276,7 +3276,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "WeightType",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -3351,7 +3351,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -3384,7 +3384,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -3417,7 +3417,7 @@
         "data": {
           "title": "WeightType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -3456,7 +3456,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=32",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3482,7 +3482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ActivationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=40",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ActivationType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3593,7 +3593,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ConditionSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ConditionSleepType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3766,7 +3766,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AnalogConditionSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=38",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AnalogConditionSleepType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3778,7 +3778,7 @@
     "schemaDefinitions": {
       "EqualityAndRelationalOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=61",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EqualityAndRelationalOperator",
         "const": {
           "Equal_0": 0,
           "NotEqual_1": 1,
@@ -3834,7 +3834,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "EqualityAndRelationalOperator",
         "description": "Defines the type of condition operator that is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=61",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EqualityAndRelationalOperator",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -3897,7 +3897,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_EdgeTriggeredSleepType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=39",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeTriggeredSleepType",
     "dov:isComposite": true,
     "links": [
       {
@@ -3909,7 +3909,7 @@
     "schemaDefinitions": {
       "EdgeOperator": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeOperator",
         "const": {
           "Rising_0": 0,
           "Falling_1": 1
@@ -3948,7 +3948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "EdgeOperator",
         "description": "Defines the type of condition operator that is used.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=62",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.EdgeOperator",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4011,7 +4011,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TimerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=36",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TimerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4089,7 +4089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_UserInstructionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=33",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.UserInstructionType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4199,7 +4199,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=34",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4313,7 +4313,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4335,7 +4335,7 @@
         "description": "Method to add an additional recipe of RecipeType.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=181",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId", "RecipeName" ],
           "properties": {
             "RecipeId": {
@@ -4348,7 +4348,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=182",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -4369,7 +4369,7 @@
         "description": "Method to remove a recipe of RecipeType.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -4400,7 +4400,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=31",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4439,7 +4439,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=437",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ElementType", "ElementName", "PreviousElements" ],
           "properties": {
             "ElementType": {
@@ -4458,7 +4458,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=438",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ElementNodeId" ],
           "properties": {
             "ElementNodeId": {
@@ -4478,7 +4478,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=439",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeElementNodeId" ],
           "properties": {
             "RecipeElementNodeId": {
@@ -4545,7 +4545,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_StatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=43",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.StatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4601,7 +4601,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AcceptedStatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AcceptedStatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4627,7 +4627,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RejectedStatisticCounterType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RejectedStatisticCounterType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4653,7 +4653,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_StatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=25",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.StatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4743,7 +4743,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=48",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherStatisticType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4860,7 +4860,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_FloatingStatisticType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=26",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.FloatingStatisticType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4918,7 +4918,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_FeederModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=28",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.FeederModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4952,7 +4952,7 @@
         "description": "Allows to set a new value for the speed of the feeder system. The OPC UA server must check if the value is between the minimal and maximum allowed speed and if the unit is allowed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=337",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FeederSpeed", "EngineeringUnits" ],
           "properties": {
             "FeederSpeed": {
@@ -4963,7 +4963,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -5128,7 +5128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PrinterModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=29",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PrinterModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5307,7 +5307,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5395,7 +5395,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1353",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "PresetTare", "EngineeringUnits" ],
           "properties": {
             "PresetTare": {
@@ -5406,7 +5406,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -5463,7 +5463,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -5501,7 +5501,7 @@
         "title": "WeightType",
         "description": "Defines the current value that is measured at the sensor at the current timestamp. Might be a highly fluctuating value.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -5630,7 +5630,7 @@
         "title": "WeightType",
         "description": "Defines the last valid measurement that was recorded and will be used for further processing. This is the legal registered value of the scale.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -5671,7 +5671,7 @@
           "title": "WeightType",
           "description": "Defines the current value that is measured at the sensor at the current timestamp. Might be a highly fluctuating value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -5718,7 +5718,7 @@
           "title": "WeightType",
           "description": "Defines the last valid measurement that was recorded and will be used for further processing. This is the legal registered value of the scale.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -5757,7 +5757,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticFillingScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticFillingScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5775,7 +5775,7 @@
     "schemaDefinitions": {
       "ToleranceState": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=60",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ToleranceState",
         "const": {
           "In_0": 0,
           "Under_1": 1,
@@ -5840,7 +5840,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "ToleranceState",
         "description": "Describes the state of the tolerance deviation. The option under and over needs to be determined via TargetItemType information of TargetWeight.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=60",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ToleranceState",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -5885,7 +5885,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CatchweigherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CatchweigherType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5918,7 +5918,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_AutomaticWeightPriceLabelerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=49",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.AutomaticWeightPriceLabelerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -5951,7 +5951,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_CheckweigherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=45",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.CheckweigherType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6033,7 +6033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ContinuousScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=10",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ContinuousScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6063,7 +6063,7 @@
     "schemaDefinitions": {
       "RateControlMode": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
         "const": {
           "Gravimetric_0": 0,
           "Volumetric_1": 1
@@ -6189,7 +6189,7 @@
       "RateControlMode": {
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "title": "RateControlMode",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -6315,7 +6315,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "data": {
           "title": "RateControlMode",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=30003",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RateControlMode",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -6365,7 +6365,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_LossInWeightScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=50",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.LossInWeightScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6582,7 +6582,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PieceCountingScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PieceCountingScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6621,7 +6621,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=990",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NumberOfReferencePieces" ],
           "properties": {
             "NumberOfReferencePieces": {
@@ -6644,7 +6644,7 @@
         "description": "Sets the value for the ReferencePieceWeight (product-specific data).",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=604",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ReferencePieceWeight", "EngineeringUnits" ],
           "properties": {
             "ReferencePieceWeight": {
@@ -6655,7 +6655,7 @@
             "EngineeringUnits": {
               "title": "EUInformation",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -6689,7 +6689,7 @@
         "description": "Triggers the reference weighing process.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1013",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NumberOfReferencePieces" ],
           "properties": {
             "NumberOfReferencePieces": {
@@ -6786,7 +6786,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_RecipeScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -6837,7 +6837,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1017",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -6857,7 +6857,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1015",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -6877,7 +6877,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1016",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -6897,7 +6897,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=373",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -6917,7 +6917,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1014",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeNodeId" ],
           "properties": {
             "RecipeNodeId": {
@@ -6942,7 +6942,7 @@
         "items": {
           "title": "RecipeTargetValueType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=58",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeTargetValueType",
           "required": [ "TargetValueId", "TargetValueName" ],
           "properties": {
             "TargetValueId": {
@@ -6979,7 +6979,7 @@
         "items": {
           "title": "RecipeThresholdType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=57",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeThresholdType",
           "required": [ "ThresholdId", "ThresholdName" ],
           "properties": {
             "ThresholdId": {
@@ -7019,7 +7019,7 @@
           "items": {
             "title": "RecipeTargetValueType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=58",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeTargetValueType",
             "required": [ "TargetValueId", "TargetValueName" ],
             "properties": {
               "TargetValueId": {
@@ -7052,7 +7052,7 @@
           "items": {
             "title": "RecipeThresholdType",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=57",
+            "dov:typeRef": "org.opcfoundation.UA.Scales.V2.RecipeThresholdType",
             "required": [ "ThresholdId", "ThresholdName" ],
             "properties": {
               "ThresholdId": {
@@ -7088,7 +7088,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_SimpleScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=3",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.SimpleScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7121,7 +7121,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_HopperScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=9",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.HopperScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7284,7 +7284,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_LaboratoryScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.LaboratoryScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7296,7 +7296,7 @@
     "schemaDefinitions": {
       "DraftShieldType": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
         "const": {
           "Right_0": 0,
           "Left_1": 1,
@@ -7337,12 +7337,12 @@
         "description": "Method to close a certain or all draft shields.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=762",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Shield" ],
           "properties": {
             "Shield": {
               "title": "DraftShieldType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+              "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7362,12 +7362,12 @@
         "description": "Method to open a certain or all draft shields.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=759",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Shield" ],
           "properties": {
             "Shield": {
               "title": "DraftShieldType",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=65",
+              "dov:typeRef": "org.opcfoundation.UA.Scales.V2.DraftShieldType",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7566,7 +7566,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7592,7 +7592,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizingHopperScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizingHopperScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7625,7 +7625,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_VehicleScaleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=834",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.VehicleScaleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7647,7 +7647,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=946",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -7667,7 +7667,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=949",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -7687,7 +7687,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Scales/V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=947",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "VehicleId" ],
           "properties": {
             "VehicleId": {
@@ -7718,7 +7718,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ScaleSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=44",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ScaleSystemType",
     "dov:isComposite": true,
     "links": [
       {
@@ -7849,7 +7849,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_TotalizerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=27",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.TotalizerType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7925,7 +7925,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=24",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8032,7 +8032,7 @@
         "title": "WeightType",
         "description": "Defines the registered weight that may be unmistakeable referenced to one item.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+        "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
         "required": [ "Gross", "Net", "Tare" ],
         "properties": {
           "Gross": {
@@ -8150,7 +8150,7 @@
           "title": "WeightType",
           "description": "Defines the registered weight that may be unmistakeable referenced to one item.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeightType",
           "required": [ "Gross", "Net", "Tare" ],
           "properties": {
             "Gross": {
@@ -8203,7 +8203,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_PriceItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=833",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.PriceItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8278,7 +8278,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_WeighingRangeElementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=23",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.WeighingRangeElementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8333,7 +8333,7 @@
         "title": "Range",
         "description": "Defines the range within the scale may be operated depending on the additional parameters within this type.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+        "dov:typeRef": "org.opcfoundation.UA.Range",
         "required": [ "Low", "High" ],
         "properties": {
           "Low": {
@@ -8405,7 +8405,7 @@
           "title": "Range",
           "description": "Defines the range within the scale may be operated depending on the additional parameters within this type.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+          "dov:typeRef": "org.opcfoundation.UA.Range",
           "required": [ "Low", "High" ],
           "properties": {
             "Low": {
@@ -8455,7 +8455,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scales_V2_ZoneType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scales/V2/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.Scales.V2.ZoneType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/Scheduler.TM.json
+++ b/wot-codegen/opc-output-simple/Scheduler.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scheduler_CalendarType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=37",
+    "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarType",
     "dov:isComposite": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "Month": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
         "const": {
           "Unspecified": 0,
           "January": 1,
@@ -89,7 +89,7 @@
       },
       "DayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
         "const": {
           "Unspecified": 0,
           "Day1": 1,
@@ -238,7 +238,7 @@
       },
       "DayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
         "const": {
           "Unspecified": 0,
           "Monday": 1,
@@ -296,7 +296,7 @@
         "description": "Adds elements to the DateList",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=41",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -305,13 +305,13 @@
                 "title": "CalendarEntryType",
                 "description": "This union that defines various calendar date values",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                 "properties": {
                   "Date": {
                     "title": "DateType",
                     "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -321,21 +321,21 @@
                       },
                       "Month": {
                         "title": "Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "DayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "DayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -346,14 +346,14 @@
                     "title": "DateRangeType",
                     "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                     "required": [ "StartDate", "EndDate" ],
                     "properties": {
                       "StartDate": {
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -363,21 +363,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -388,7 +388,7 @@
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -398,21 +398,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -428,7 +428,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=42",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -454,7 +454,7 @@
         "description": "Removes elements of the DateList",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=44",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "CalendarEntries" ],
           "properties": {
             "CalendarEntries": {
@@ -463,13 +463,13 @@
                 "title": "CalendarEntryType",
                 "description": "This union that defines various calendar date values",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                 "properties": {
                   "Date": {
                     "title": "DateType",
                     "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                     "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                     "properties": {
                       "Year": {
@@ -479,21 +479,21 @@
                       },
                       "Month": {
                         "title": "Month",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfMonth": {
                         "title": "DayOfMonth",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
                       },
                       "DayOfWeek": {
                         "title": "DayOfWeek",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -504,14 +504,14 @@
                     "title": "DateRangeType",
                     "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                     "required": [ "StartDate", "EndDate" ],
                     "properties": {
                       "StartDate": {
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -521,21 +521,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -546,7 +546,7 @@
                         "title": "DateType",
                         "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                         "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                         "properties": {
                           "Year": {
@@ -556,21 +556,21 @@
                           },
                           "Month": {
                             "title": "Month",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfMonth": {
                             "title": "DayOfMonth",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
                           },
                           "DayOfWeek": {
                             "title": "DayOfWeek",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -586,7 +586,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=45",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -617,13 +617,13 @@
           "title": "CalendarEntryType",
           "description": "This union that defines various calendar date values",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
           "properties": {
             "Date": {
               "title": "DateType",
               "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
               "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
               "properties": {
                 "Year": {
@@ -633,21 +633,21 @@
                 },
                 "Month": {
                   "title": "Month",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfMonth": {
                   "title": "DayOfMonth",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
                 },
                 "DayOfWeek": {
                   "title": "DayOfWeek",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -658,14 +658,14 @@
               "title": "DateRangeType",
               "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
               "required": [ "StartDate", "EndDate" ],
               "properties": {
                 "StartDate": {
                   "title": "DateType",
                   "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -675,21 +675,21 @@
                     },
                     "Month": {
                       "title": "Month",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "DayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "DayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -700,7 +700,7 @@
                   "title": "DateType",
                   "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                   "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                   "properties": {
                     "Year": {
@@ -710,21 +710,21 @@
                     },
                     "Month": {
                       "title": "Month",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfMonth": {
                       "title": "DayOfMonth",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
                     },
                     "DayOfWeek": {
                       "title": "DayOfWeek",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -784,7 +784,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Scheduler_ScheduleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=52",
+    "dov:typeRef": "org.opcfoundation.UA.Scheduler.ScheduleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -796,7 +796,7 @@
     "schemaDefinitions": {
       "Month": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
         "const": {
           "Unspecified": 0,
           "January": 1,
@@ -865,7 +865,7 @@
       },
       "DayOfMonth": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
         "const": {
           "Unspecified": 0,
           "Day1": 1,
@@ -1014,7 +1014,7 @@
       },
       "DayOfWeek": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
         "const": {
           "Unspecified": 0,
           "Monday": 1,
@@ -1067,7 +1067,7 @@
         "description": "Adds elements to the ExceptionSchedule",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=55",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecialEvents" ],
           "properties": {
             "SpecialEvents": {
@@ -1076,26 +1076,26 @@
                 "title": "SpecialEventType",
                 "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
                 "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
                 "properties": {
                   "Period": {
                     "title": "SpecialEventPeriodType",
                     "description": "This union contains a calendar entry or a reference to a calendar object",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
                     "properties": {
                       "CalendarEntry": {
                         "title": "CalendarEntryType",
                         "description": "This union that defines various calendar date values",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                         "properties": {
                           "Date": {
                             "title": "DateType",
                             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -1105,21 +1105,21 @@
                               },
                               "Month": {
                                 "title": "Month",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "DayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "DayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -1130,14 +1130,14 @@
                             "title": "DateRangeType",
                             "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                             "required": [ "StartDate", "EndDate" ],
                             "properties": {
                               "StartDate": {
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1147,21 +1147,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1172,7 +1172,7 @@
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1182,21 +1182,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1218,14 +1218,14 @@
                       "title": "TimeActionsType",
                       "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                       "required": [ "Time", "Actions" ],
                       "properties": {
                         "Time": {
                           "title": "TimeType",
                           "description": "This structure that represents a point in time during a day",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                           "required": [ "Hour", "Minute", "Second" ],
                           "properties": {
                             "Hour": {
@@ -1251,7 +1251,7 @@
                             "title": "BaseActionType",
                             "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                             "required": [ "LastActionResult" ],
                             "properties": {
                               "LastActionResult": {
@@ -1275,7 +1275,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=56",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -1301,7 +1301,7 @@
         "description": "Removes elements from the ExceptionSchedule",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=58",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecialEvents" ],
           "properties": {
             "SpecialEvents": {
@@ -1310,26 +1310,26 @@
                 "title": "SpecialEventType",
                 "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
                 "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
                 "properties": {
                   "Period": {
                     "title": "SpecialEventPeriodType",
                     "description": "This union contains a calendar entry or a reference to a calendar object",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
                     "properties": {
                       "CalendarEntry": {
                         "title": "CalendarEntryType",
                         "description": "This union that defines various calendar date values",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                        "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                         "properties": {
                           "Date": {
                             "title": "DateType",
                             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                             "properties": {
                               "Year": {
@@ -1339,21 +1339,21 @@
                               },
                               "Month": {
                                 "title": "Month",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfMonth": {
                                 "title": "DayOfMonth",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
                               },
                               "DayOfWeek": {
                                 "title": "DayOfWeek",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -1364,14 +1364,14 @@
                             "title": "DateRangeType",
                             "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                             "required": [ "StartDate", "EndDate" ],
                             "properties": {
                               "StartDate": {
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1381,21 +1381,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1406,7 +1406,7 @@
                                 "title": "DateType",
                                 "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                                 "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                                 "properties": {
                                   "Year": {
@@ -1416,21 +1416,21 @@
                                   },
                                   "Month": {
                                     "title": "Month",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfMonth": {
                                     "title": "DayOfMonth",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
                                   },
                                   "DayOfWeek": {
                                     "title": "DayOfWeek",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -1452,14 +1452,14 @@
                       "title": "TimeActionsType",
                       "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                       "required": [ "Time", "Actions" ],
                       "properties": {
                         "Time": {
                           "title": "TimeType",
                           "description": "This structure that represents a point in time during a day",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                           "required": [ "Hour", "Minute", "Second" ],
                           "properties": {
                             "Hour": {
@@ -1485,7 +1485,7 @@
                             "title": "BaseActionType",
                             "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                            "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                             "required": [ "LastActionResult" ],
                             "properties": {
                               "LastActionResult": {
@@ -1509,7 +1509,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=59",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "EntryResults" ],
           "properties": {
             "EntryResults": {
@@ -1550,14 +1550,14 @@
         "title": "DateRangeType",
         "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+        "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
         "required": [ "StartDate", "EndDate" ],
         "properties": {
           "StartDate": {
             "title": "DateType",
             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -1567,21 +1567,21 @@
               },
               "Month": {
                 "title": "Month",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "DayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "DayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1592,7 +1592,7 @@
             "title": "DateType",
             "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+            "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
             "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
             "properties": {
               "Year": {
@@ -1602,21 +1602,21 @@
               },
               "Month": {
                 "title": "Month",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfMonth": {
                 "title": "DayOfMonth",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
               },
               "DayOfWeek": {
                 "title": "DayOfWeek",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -1641,26 +1641,26 @@
           "title": "SpecialEventType",
           "description": "This structure contains a period, a list of time values, and a priority. It is a means to identify moments in time over one or more days.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=70",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventType",
           "required": [ "Period", "ListOfTimeActions", "EventPriority" ],
           "properties": {
             "Period": {
               "title": "SpecialEventPeriodType",
               "description": "This union contains a calendar entry or a reference to a calendar object",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=71",
+              "dov:typeRef": "org.opcfoundation.UA.Scheduler.SpecialEventPeriodType",
               "properties": {
                 "CalendarEntry": {
                   "title": "CalendarEntryType",
                   "description": "This union that defines various calendar date values",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=72",
+                  "dov:typeRef": "org.opcfoundation.UA.Scheduler.CalendarEntryType",
                   "properties": {
                     "Date": {
                       "title": "DateType",
                       "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                       "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                       "properties": {
                         "Year": {
@@ -1670,21 +1670,21 @@
                         },
                         "Month": {
                           "title": "Month",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfMonth": {
                           "title": "DayOfMonth",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
                         },
                         "DayOfWeek": {
                           "title": "DayOfWeek",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -1695,14 +1695,14 @@
                       "title": "DateRangeType",
                       "description": "This structure defines a time span, with absolute start and end dates. The StartDate and EndDate are limited to specific values, i.e., wild cards like odd months are not allowed. The Year field shall not be 0; the Month field shall be a value between 1 to 12; the DayOfMonth field shall be between 1 to 31 and the DayOfMonth field shall be 'unspecified'.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=80",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateRangeType",
                       "required": [ "StartDate", "EndDate" ],
                       "properties": {
                         "StartDate": {
                           "title": "DateType",
                           "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -1712,21 +1712,21 @@
                             },
                             "Month": {
                               "title": "Month",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "DayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "DayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -1737,7 +1737,7 @@
                           "title": "DateType",
                           "description": "This structure defines a calendar date. It allows to define a concrete date, e.g. 2022-02-12. By using wildcards, it also allows to define repeating dates, like every Wednesday, every odd day of a month, every 24th of December, every last day of a month in 2023, etc.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=73",
+                          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DateType",
                           "required": [ "Year", "Month", "DayOfMonth", "DayOfWeek" ],
                           "properties": {
                             "Year": {
@@ -1747,21 +1747,21 @@
                             },
                             "Month": {
                               "title": "Month",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=74",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.Month",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfMonth": {
                               "title": "DayOfMonth",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=76",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfMonth",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
                             },
                             "DayOfWeek": {
                               "title": "DayOfWeek",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=78",
+                              "dov:typeRef": "org.opcfoundation.UA.Scheduler.DayOfWeek",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -1783,14 +1783,14 @@
                 "title": "TimeActionsType",
                 "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                 "required": [ "Time", "Actions" ],
                 "properties": {
                   "Time": {
                     "title": "TimeType",
                     "description": "This structure that represents a point in time during a day",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                     "required": [ "Hour", "Minute", "Second" ],
                     "properties": {
                       "Hour": {
@@ -1816,7 +1816,7 @@
                       "title": "BaseActionType",
                       "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                       "required": [ "LastActionResult" ],
                       "properties": {
                         "LastActionResult": {
@@ -1848,7 +1848,7 @@
         "title": "TimeZoneDataType",
         "description": "Provides information about the local time of the schedule Object. All scheduled times are UTC time. Clients need to consider this Property to calculate the local time of the schedule. If this Property is changed, it is server-specific whether the times of the schedule are adjusted or not.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -1877,7 +1877,7 @@
           "title": "DailyScheduleType",
           "description": "This structure defines a sequence of TimeActionsType structures. Each element in the sequence defines a time/actions pair that describes the actions to be executed at a given point in the day.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=86",
+          "dov:typeRef": "org.opcfoundation.UA.Scheduler.DailyScheduleType",
           "required": [ "DaySchedule" ],
           "properties": {
             "DaySchedule": {
@@ -1886,14 +1886,14 @@
                 "title": "TimeActionsType",
                 "description": "This structure contains a time and an array of actions. It is used to define actions to be executed at a specific point in time.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=81",
+                "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeActionsType",
                 "required": [ "Time", "Actions" ],
                 "properties": {
                   "Time": {
                     "title": "TimeType",
                     "description": "This structure that represents a point in time during a day",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=85",
+                    "dov:typeRef": "org.opcfoundation.UA.Scheduler.TimeType",
                     "required": [ "Hour", "Minute", "Second" ],
                     "properties": {
                       "Hour": {
@@ -1919,7 +1919,7 @@
                       "title": "BaseActionType",
                       "description": "This abstract structure defines the base of an action. The base only contains information, if the last execution of the action was successful.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Scheduler/;i=82",
+                      "dov:typeRef": "org.opcfoundation.UA.Scheduler.BaseActionType",
                       "required": [ "LastActionResult" ],
                       "properties": {
                         "LastActionResult": {

--- a/wot-codegen/opc-output-simple/SurfaceTechnology.Plasma.TM.json
+++ b/wot-codegen/opc-output-simple/SurfaceTechnology.Plasma.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_CirculationSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.CirculationSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -104,7 +104,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_GasSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.GasSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -142,7 +142,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_HeatingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.HeatingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -180,7 +180,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlantCoolingSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlantCoolingSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -218,7 +218,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaGeneratorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaGeneratorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -256,7 +256,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaJetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaJetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -294,7 +294,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -333,7 +333,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -366,7 +366,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaSurfaceMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaSurfaceMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -399,7 +399,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_PrecursorSystemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.PrecursorSystemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -437,7 +437,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_ProcessingChamberType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.ProcessingChamberType",
     "links": [
       {
         "rel": "tm:extends",
@@ -475,7 +475,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_RegulatorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.RegulatorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -808,7 +808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaNotExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaNotExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -887,7 +887,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaNotExecutingSubState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaNotExecutingSubState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -966,7 +966,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_AtmosphericPressurePlasmaMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.AtmosphericPressurePlasmaMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -998,7 +998,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_LowPressurePlasmaMachineryItemState_StateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.LowPressurePlasmaMachineryItemState_StateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1030,7 +1030,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "SurfaceTechnology_Plasma_WorkpieceMotionDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/SurfaceTechnology/Plasma/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.SurfaceTechnology.Plasma.WorkpieceMotionDeviceType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/TMC.v2.TM.json
+++ b/wot-codegen/opc-output-simple/TMC.v2.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ExternalAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1048",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ExternalAlarmType",
     "dov:isEvent": true,
     "links": [
       {
@@ -37,7 +37,7 @@
         "description": "The Method SetMessage sets the Message that the underlying system will display for the alarm.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10316",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Message" ],
           "properties": {
             "Message": {
@@ -48,14 +48,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10317",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -69,7 +69,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -128,7 +128,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_LogbookEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.LogbookEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -155,7 +155,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierEnteredLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1085",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierEnteredLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -202,7 +202,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierReleasedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1087",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierReleasedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -249,7 +249,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierSublotsChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1055",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierSublotsChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -261,7 +261,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -315,7 +315,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -330,7 +330,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -349,7 +349,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -368,7 +368,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -412,7 +412,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -435,7 +435,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -457,7 +457,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -531,7 +531,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1089",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -608,7 +608,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -620,7 +620,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -687,7 +687,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The control mode after the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -704,7 +704,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The control mode prior to the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -730,7 +730,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSpecificationChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1022",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSpecificationChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -742,7 +742,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -771,7 +771,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -812,7 +812,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -830,7 +830,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -849,7 +849,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -893,7 +893,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -941,7 +941,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -959,7 +959,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -978,7 +978,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1022,7 +1022,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1070,7 +1070,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1088,7 +1088,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1107,7 +1107,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1151,7 +1151,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1199,7 +1199,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -1210,7 +1210,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -1229,7 +1229,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1273,7 +1273,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -1297,7 +1297,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1325,7 +1325,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1333,7 +1333,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1371,7 +1371,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1389,7 +1389,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1408,7 +1408,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1452,7 +1452,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1500,7 +1500,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1518,7 +1518,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1537,7 +1537,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1581,7 +1581,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1629,7 +1629,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -1647,7 +1647,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -1666,7 +1666,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1710,7 +1710,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -1758,7 +1758,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -1769,7 +1769,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -1788,7 +1788,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1832,7 +1832,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -1856,7 +1856,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1884,7 +1884,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1892,7 +1892,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -1921,7 +1921,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1011",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -1983,7 +1983,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DataSetChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1017",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2012,7 +2012,7 @@
           "title": "DataSetEntryType",
           "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
           "required": [ "ID", "Value" ],
           "properties": {
             "ID": {
@@ -2055,7 +2055,7 @@
           "title": "DataSetEntryType",
           "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
           "required": [ "ID", "Value" ],
           "properties": {
             "ID": {
@@ -2103,7 +2103,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectDetectedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1026",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectDetectedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2131,7 +2131,7 @@
         "items": {
           "title": "EUInformation",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
           "properties": {
             "NamespaceUri": {
@@ -2204,7 +2204,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DetectionModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1045",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DetectionModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2251,7 +2251,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DowntimeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1024",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DowntimeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2294,7 +2294,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -2320,7 +2320,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -2355,7 +2355,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialContextLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1086",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialContextLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2415,7 +2415,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_IntegrityRejectedMaterialLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1039",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.IntegrityRejectedMaterialLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2427,7 +2427,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -2465,7 +2465,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -2480,7 +2480,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -2499,7 +2499,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -2518,7 +2518,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2562,7 +2562,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -2585,7 +2585,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2607,7 +2607,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -2680,7 +2680,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_LoadingPointUnloadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1032",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.LoadingPointUnloadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -2692,7 +2692,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -2730,7 +2730,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -2745,7 +2745,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -2764,7 +2764,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -2783,7 +2783,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2827,7 +2827,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -2850,7 +2850,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -2872,7 +2872,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -2945,7 +2945,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialConsumedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1033",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialConsumedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3116,7 +3116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialDispensedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1084",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDispensedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3287,7 +3287,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialOutputProducedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1030",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialOutputProducedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3458,7 +3458,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialRejectedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1027",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialRejectedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3629,7 +3629,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialUnloadingRequiredLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1034",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialUnloadingRequiredLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3641,7 +3641,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -3679,7 +3679,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -3694,7 +3694,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -3713,7 +3713,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -3732,7 +3732,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3776,7 +3776,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -3799,7 +3799,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -3821,7 +3821,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -3894,7 +3894,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_NewPresentedMaterialLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1038",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.NewPresentedMaterialLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -3906,7 +3906,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -3944,7 +3944,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -3959,7 +3959,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -3978,7 +3978,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -3997,7 +3997,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -4041,7 +4041,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -4064,7 +4064,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -4086,7 +4086,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -4159,7 +4159,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_POStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1091",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.POStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4186,7 +4186,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_POStoppedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1092",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.POStoppedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4213,7 +4213,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessItemResetLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1031",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessItemResetLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4467,7 +4467,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RejectionModeChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1029",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RejectionModeChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4514,7 +4514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_StateChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1021",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4526,7 +4526,7 @@
     "schemaDefinitions": {
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -4633,7 +4633,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state after the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4650,7 +4650,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state prior to the change.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -4676,7 +4676,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RootCauseGroupListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1036",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4705,7 +4705,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -4739,7 +4739,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -4778,7 +4778,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_RootCauseListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1014",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4807,7 +4807,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -4833,7 +4833,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -4864,7 +4864,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_StopReasonListChangeLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1015",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StopReasonListChangeLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -4893,7 +4893,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -4923,7 +4923,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -4958,7 +4958,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1078",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5018,7 +5018,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadingEndedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1079",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadingEndedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5065,7 +5065,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierLoadingStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1080",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierLoadingStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5112,7 +5112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1081",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5172,7 +5172,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadingEndedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1082",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadingEndedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5219,7 +5219,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SubCarrierUnloadingStartedLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1083",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SubCarrierUnloadingStartedLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5266,7 +5266,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderTransitionLogType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1088",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderTransitionLogType",
     "dov:isEvent": true,
     "links": [
       {
@@ -5326,7 +5326,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_CarrierType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1074",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CarrierType",
     "links": [
       {
         "rel": "tm:extends",
@@ -5349,7 +5349,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -5395,14 +5395,14 @@
         "description": "The EndSubCarrierLoading Method informs the underlying system that the loading of (sub) carriers into   the carrier is complete.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13434",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5416,7 +5416,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5447,14 +5447,14 @@
         "description": "The EndSubCarrierUnloading Method informs the underlying system that the unloading of (sub) carriers   into the carrier is complete.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13436",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5468,7 +5468,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5499,7 +5499,7 @@
         "description": "The LoadSubCarrier Method requests the underlying system to load a subcarrier into the carrier that is   currently being loaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13439",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ID", "MESID", "ParentCarrierID", "Sublots" ],
           "properties": {
             "ID": {
@@ -5521,7 +5521,7 @@
                 "title": "MaterialSublotType",
                 "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                 "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                 "properties": {
                   "ID": {
@@ -5536,7 +5536,7 @@
                     "title": "MaterialLotType",
                     "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                     "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                     "properties": {
                       "ID": {
@@ -5555,7 +5555,7 @@
                         "title": "MaterialDefinitionType",
                         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                         "properties": {
                           "ID": {
@@ -5574,7 +5574,7 @@
                             "title": "EUInformation",
                             "description": "The base unit of measure for the material definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5618,7 +5618,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -5641,7 +5641,7 @@
                       "Status": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The stock status of the material lot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -5663,7 +5663,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -5720,14 +5720,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13440",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -5741,7 +5741,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -5772,7 +5772,7 @@
         "description": "The LoadSublot Method requests the underlying system to load one or more material sublots into the   carrier that is currently being loaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6401",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Sublots" ],
           "properties": {
             "Sublots": {
@@ -5782,7 +5782,7 @@
                 "title": "MaterialSublotType",
                 "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                 "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                 "properties": {
                   "ID": {
@@ -5797,7 +5797,7 @@
                     "title": "MaterialLotType",
                     "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                     "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                     "properties": {
                       "ID": {
@@ -5816,7 +5816,7 @@
                         "title": "MaterialDefinitionType",
                         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                         "properties": {
                           "ID": {
@@ -5835,7 +5835,7 @@
                             "title": "EUInformation",
                             "description": "The base unit of measure for the material definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -5879,7 +5879,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -5902,7 +5902,7 @@
                       "Status": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The stock status of the material lot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -5924,7 +5924,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -5981,14 +5981,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9213",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6002,7 +6002,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6033,14 +6033,14 @@
         "description": "The StartSubCarrierLoading Method informs the underlying system that the loading of (sub) carriers into   the carrier has started.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13443",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6054,7 +6054,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6085,14 +6085,14 @@
         "description": "The StartSubCarrierUnLoading Method informs the underlying system that the unloading of (sub)   carriers from the carrier has started.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13445",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6106,7 +6106,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6137,7 +6137,7 @@
         "description": "The UnloadSubCarrier Method requests the underlying system to unload a subcarrier from the carrier   that is currently being unloaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13448",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -6148,14 +6148,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13449",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6169,7 +6169,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6200,7 +6200,7 @@
         "description": "The UnloadSublots Method requests the underlying system to unload one or more sublots from the   carrier that is currently being unloaded.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10821",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SublotIDs" ],
           "properties": {
             "SublotIDs": {
@@ -6214,14 +6214,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=10822",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6235,7 +6235,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6328,7 +6328,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -6343,7 +6343,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -6362,7 +6362,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -6381,7 +6381,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -6425,7 +6425,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -6448,7 +6448,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -6470,7 +6470,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -6542,7 +6542,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -6557,7 +6557,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -6576,7 +6576,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -6595,7 +6595,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6639,7 +6639,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -6662,7 +6662,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -6684,7 +6684,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -6756,7 +6756,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1051",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6784,14 +6784,14 @@
         "description": "The ResetAggregates Method resets the aggregates of the control module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6098",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -6805,7 +6805,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -6889,7 +6889,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1054",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -6989,7 +6989,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveAggregatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1053",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveAggregatesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7058,7 +7058,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1047",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7154,7 +7154,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1050",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7201,7 +7201,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -7255,7 +7255,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -7349,7 +7349,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -7420,14 +7420,14 @@
         "description": "The AcknowledgeAlarms Method acknowledges the alarms of the control module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6405",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7441,7 +7441,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7472,13 +7472,13 @@
         "description": "The Method SendCommand sends a command to change the state of the control module state   machine remotely.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7258",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7487,14 +7487,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7259",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7508,7 +7508,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7539,13 +7539,13 @@
         "description": "The SetControlMode Method sets the control mode of the control module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7279",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -7554,14 +7554,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7280",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -7575,7 +7575,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -7607,7 +7607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode describes the current control mode of the equipment module.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7629,7 +7629,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The State Property describes the status of the state machine controlling the control module. State provides   a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7655,7 +7655,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1052",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7732,7 +7732,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_AnalogInputSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1056",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.AnalogInputSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7811,7 +7811,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DigitalInputSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1057",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DigitalInputSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7886,7 +7886,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1058",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -7897,7 +7897,7 @@
     "schemaDefinitions": {
       "MotorDirectionEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
         "const": {
           "Clockwise": 0,
           "CounterClockwise": 1
@@ -7939,7 +7939,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MotorDirectionEnumeration",
         "description": "The rotation direction of the motor.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -7964,7 +7964,7 @@
         "data": {
           "title": "MotorDirectionEnumeration",
           "description": "The rotation direction of the motor.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3026",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorDirectionEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -7988,7 +7988,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1059",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8067,7 +8067,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectReasonType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1041",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectReasonType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8106,7 +8106,7 @@
         "description": "The Method SetDetectionMode enables or disables the defect reason.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6184",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -8117,14 +8117,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6189",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -8138,7 +8138,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -8259,7 +8259,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1068",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8340,7 +8340,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1069",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8369,7 +8369,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -8423,7 +8423,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -8517,7 +8517,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -8588,14 +8588,14 @@
         "description": "The AcknowledgeAlarms method acknowledges the alarms of the equipment module and control   modules belonging to it.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11663",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -8609,7 +8609,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -8640,13 +8640,13 @@
         "description": "The Method SendCommand sends a command to change the state of the equipment module   state machine remotely.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11702",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8655,14 +8655,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11703",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -8676,7 +8676,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -8707,13 +8707,13 @@
         "description": "The SetControlMode Method sets the control mode of the equipment module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11705",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8722,14 +8722,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11706",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -8743,7 +8743,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -8775,7 +8775,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode describes the current control mode of the equipment module.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8797,7 +8797,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The State Property describes the status of the state machine controlling the equipment module. State   provides a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -8823,7 +8823,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1070",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8900,7 +8900,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1013",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -8911,7 +8911,7 @@
     "schemaDefinitions": {
       "ParameterDependencyEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
         "const": {
           "Machine": 0,
           "Brand": 1,
@@ -8952,13 +8952,13 @@
         "description": "The GetDatasetList Method returns the list of descriptions for parameters of the dataset filtered   by the dependency and subset created by the user.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6425",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Dependency", "UserSubset", "CompleteSet" ],
           "properties": {
             "Dependency": {
               "title": "ParameterDependencyEnumeration",
               "description": "Dependency specifies how to select (filter) a subset of the dataset based on dependency.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -8975,14 +8975,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6429",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSetList", "ExecutionFeedback" ],
           "properties": {
             "DataSetList": {
               "title": "DataSetDefinitionType",
               "description": "The DataSetDefinition structure contains the description and other necessary metadata of the   complete set of machine settings required for production.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3021",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetDefinitionType",
               "required": [ "ID", "Description", "Definitions" ],
               "properties": {
                 "ID": {
@@ -9000,14 +9000,14 @@
                     "title": "DataDefinitionType",
                     "description": "The DataDefinitionType structure contains the metadata that describes a parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDefinitionType",
                     "required": [ "EngineeringUnits", "DisplayFormat", "Dependency", "DataType", "UserSubset", "ControlRange", "AlarmRange" ],
                     "properties": {
                       "EngineeringUnits": {
                         "title": "EUInformation",
                         "description": "Unit of measure for the parameter.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -9033,7 +9033,7 @@
                       "Dependency": {
                         "title": "ParameterDependencyEnumeration",
                         "description": "The dependency of the parameter with respect to machine and   brand.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -9050,7 +9050,7 @@
                         "title": "Range",
                         "description": "The range where the parameter actual values is considered in   control.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                        "dov:typeRef": "org.opcfoundation.UA.Range",
                         "required": [ "Low", "High" ],
                         "properties": {
                           "Low": {
@@ -9069,7 +9069,7 @@
                         "title": "Range",
                         "description": "Outside this range, the underlying system generates an alarm for the   parameter.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                        "dov:typeRef": "org.opcfoundation.UA.Range",
                         "required": [ "Low", "High" ],
                         "properties": {
                           "Low": {
@@ -9093,7 +9093,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9107,7 +9107,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9138,7 +9138,7 @@
         "description": "The GetRootCauseGroupList Method returns the complete list of root cause groups as persisted   by the server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7322",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RootCauseGroupList", "ExecutionFeedback" ],
           "properties": {
             "RootCauseGroupList": {
@@ -9148,7 +9148,7 @@
                 "title": "RootCauseGroupType",
                 "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
                 "required": [ "ID", "ParentID", "Description" ],
                 "properties": {
                   "ID": {
@@ -9170,7 +9170,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9184,7 +9184,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9215,7 +9215,7 @@
         "description": "The GetRootCauseList Method returns the complete list of root causes as persisted by the   server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6210",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RootCauseList", "ExecutionFeedback" ],
           "properties": {
             "RootCauseList": {
@@ -9225,7 +9225,7 @@
                 "title": "RootCauseMessageType",
                 "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
                 "required": [ "GroupID" ],
                 "properties": {
                   "GroupID": {
@@ -9239,7 +9239,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9253,7 +9253,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9284,7 +9284,7 @@
         "description": "The GetStopReasonList Method returns the complete list of stop reasons as persisted by the   server.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6306",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "StopReasonList", "ExecutionFeedback" ],
           "properties": {
             "StopReasonList": {
@@ -9294,7 +9294,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -9312,7 +9312,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9326,7 +9326,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9357,7 +9357,7 @@
         "description": "The SetDataSetListMESID Method sets the MES_ID of one or more items of the array Definitions contained in the DataSetList.  Each item of Definitions is identified by its ID.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9125",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IDs", "MESIDs" ],
           "properties": {
             "IDs": {
@@ -9378,14 +9378,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=19982",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9399,7 +9399,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9430,7 +9430,7 @@
         "description": "The SetRootCauseLists Method sets both the RootCauseList and RootCauseGroupList   according to the input arguments.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6326",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RootCauseList", "RootCauseGroupList" ],
           "properties": {
             "RootCauseList": {
@@ -9440,7 +9440,7 @@
                 "title": "RootCauseMessageType",
                 "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
                 "required": [ "GroupID" ],
                 "properties": {
                   "GroupID": {
@@ -9457,7 +9457,7 @@
                 "title": "RootCauseGroupType",
                 "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
                 "required": [ "ID", "ParentID", "Description" ],
                 "properties": {
                   "ID": {
@@ -9479,14 +9479,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6327",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -9500,7 +9500,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -9533,7 +9533,7 @@
         "title": "DataSetDefinitionType",
         "description": "The DataSetDefinition structure contains the description and other necessary metadata of the   complete set of machine settings required for production.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3021",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetDefinitionType",
         "required": [ "ID", "Description", "Definitions" ],
         "properties": {
           "ID": {
@@ -9551,14 +9551,14 @@
               "title": "DataDefinitionType",
               "description": "The DataDefinitionType structure contains the metadata that describes a parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDefinitionType",
               "required": [ "EngineeringUnits", "DisplayFormat", "Dependency", "DataType", "UserSubset", "ControlRange", "AlarmRange" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "description": "Unit of measure for the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -9584,7 +9584,7 @@
                 "Dependency": {
                   "title": "ParameterDependencyEnumeration",
                   "description": "The dependency of the parameter with respect to machine and   brand.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ParameterDependencyEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -9601,7 +9601,7 @@
                   "title": "Range",
                   "description": "The range where the parameter actual values is considered in   control.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -9620,7 +9620,7 @@
                   "title": "Range",
                   "description": "Outside this range, the underlying system generates an alarm for the   parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -9690,7 +9690,7 @@
           "title": "RootCauseGroupType",
           "description": "The RootCauseGroupType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3030",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseGroupType",
           "required": [ "ID", "ParentID", "Description" ],
           "properties": {
             "ID": {
@@ -9729,7 +9729,7 @@
           "title": "RootCauseMessageType",
           "description": "The RootCauseMessageType structure contains a root cause message and its group identifier.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3029",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.RootCauseMessageType",
           "required": [ "GroupID" ],
           "properties": {
             "GroupID": {
@@ -9778,7 +9778,7 @@
           "title": "MessageType",
           "description": "The MessageType provides a uniquely identified localised text.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
           "required": [ "ID", "LocalText" ],
           "properties": {
             "ID": {
@@ -9813,7 +9813,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleHistoricalRecordType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleHistoricalRecordType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9866,7 +9866,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleLiveStatusType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleLiveStatusType",
     "links": [
       {
         "rel": "tm:extends",
@@ -9895,7 +9895,7 @@
     "schemaDefinitions": {
       "ControlModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "const": {
           "OTHER": 0,
           "PRODUCTION": 1,
@@ -9949,7 +9949,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -10043,7 +10043,7 @@
       },
       "CommandEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
         "const": {
           "Abort": 0,
           "Start": 1,
@@ -10114,14 +10114,14 @@
         "description": "The AcknowledgeAlarms Method acknowledges all alarms of the machine module.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12166",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10135,7 +10135,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10166,14 +10166,14 @@
         "description": "The method resets all aggregated values calculated by each ProcessItem",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=19799",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10187,7 +10187,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10218,13 +10218,13 @@
         "description": "The Method SendCommand sends a command to change the state of the machine module state machine.  The Method SendCommand sends a command to change the state of the machine module state machine.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Command" ],
           "properties": {
             "Command": {
               "title": "CommandEnumeration",
               "description": "The command to be sent to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.CommandEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10233,14 +10233,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6385",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10254,7 +10254,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10285,13 +10285,13 @@
         "description": "The SetControlMode Method sets the control mode of the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6232",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ControlMode" ],
           "properties": {
             "ControlMode": {
               "title": "ControlModeEnumeration",
               "description": "The control mode to be set to the machine module.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -10300,14 +10300,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10321,7 +10321,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10352,7 +10352,7 @@
         "description": "The Method SetIdleEnergySavingMode activates the energy saving mode when the machine   module is idle.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "IdleEnergySavingMode" ],
           "properties": {
             "IdleEnergySavingMode": {
@@ -10363,14 +10363,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6393",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10384,7 +10384,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10416,7 +10416,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ControlModeEnumeration",
         "description": "The ControlMode property describes the current control mode of the machine.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3023",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10456,7 +10456,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The Property State describes the status of the state machine controlling the machine module. State   provides a subset of the information of the state machine, when the latter is implemented.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -10482,7 +10482,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleProductionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleProductionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -10505,7 +10505,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -10529,7 +10529,7 @@
       },
       "ProductionStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionStatusEnumeration",
         "const": {
           "Other": 0,
           "BrandChange": 1,
@@ -10575,14 +10575,14 @@
         "description": "The AbortProductionOrder method is used to abnormally terminate, or abort, a production order   that is in execution or starting or completing. Aborting cannot be reversed or undone.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22399",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAbort" ],
           "properties": {
             "POToAbort": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -10593,7 +10593,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -10612,7 +10612,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -10656,7 +10656,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -10718,14 +10718,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22400",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -10739,7 +10739,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -10770,21 +10770,21 @@
         "description": "The AssignProductionOrder Method is used to transfer the information of an upcoming   production order to the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22538",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAssign" ],
           "properties": {
             "POToAssign": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -10795,7 +10795,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -10814,7 +10814,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -10858,7 +10858,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -10920,7 +10920,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -10938,7 +10938,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -10957,7 +10957,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -10972,7 +10972,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -10991,7 +10991,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -11010,7 +11010,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -11054,7 +11054,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -11077,7 +11077,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -11099,7 +11099,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -11154,7 +11154,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -11166,7 +11166,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -11181,7 +11181,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -11200,7 +11200,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -11219,7 +11219,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -11263,7 +11263,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -11286,7 +11286,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -11308,7 +11308,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -11370,7 +11370,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -11388,7 +11388,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -11410,14 +11410,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22539",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11431,7 +11431,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11462,14 +11462,14 @@
         "description": "The ClearProductionOrder method is used to positively confirm that the machine module where   a production order is aborted has been cleared of the product or parts left by the aborted   production order.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22403",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11483,7 +11483,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11514,14 +11514,14 @@
         "description": "The CompleteProductionOrder method is used to complete a production order in execution.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22405",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11535,7 +11535,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11566,14 +11566,14 @@
         "description": "The Method ResetProductionTotals simultaneously resets the totals of the machine components   belonging to the following machine folders: DefectDetectionSensors, MaterialLoadingPoints, MaterialOutputPoints, MaterialRejectionPoints.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6089",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11587,7 +11587,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11617,14 +11617,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9654",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeaderToStart", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POHeaderToStart": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -11635,7 +11635,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -11654,7 +11654,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -11698,7 +11698,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -11774,14 +11774,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9655",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -11795,7 +11795,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -11826,21 +11826,21 @@
         "description": "The StartProductionOrder Method starts a production order at the machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22409",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToStart", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POToStart": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -11851,7 +11851,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -11870,7 +11870,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -11914,7 +11914,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -11976,7 +11976,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -11994,7 +11994,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -12013,7 +12013,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -12028,7 +12028,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -12047,7 +12047,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -12066,7 +12066,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -12110,7 +12110,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -12133,7 +12133,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -12155,7 +12155,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -12210,7 +12210,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -12222,7 +12222,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -12237,7 +12237,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -12256,7 +12256,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -12275,7 +12275,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -12319,7 +12319,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -12342,7 +12342,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -12364,7 +12364,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -12426,7 +12426,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -12444,7 +12444,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -12480,14 +12480,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22410",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -12501,7 +12501,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -12532,14 +12532,14 @@
         "description": "The UnAssignProductionOrder method is used to remove the specified production order from   AssignedProductionOrders[] of an infeed machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22412",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnassign" ],
           "properties": {
             "POToUnassign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -12550,7 +12550,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -12569,7 +12569,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -12613,7 +12613,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -12675,14 +12675,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22413",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -12696,7 +12696,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -12732,14 +12732,14 @@
           "title": "ProductionOrderType",
           "description": "The ProductionOrderType structure contains the complete production order information.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
           "required": [ "Header", "MaterialList", "DataSet" ],
           "properties": {
             "Header": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -12750,7 +12750,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -12769,7 +12769,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -12813,7 +12813,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -12875,7 +12875,7 @@
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -12893,7 +12893,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -12912,7 +12912,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -12927,7 +12927,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -12946,7 +12946,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -12965,7 +12965,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -13009,7 +13009,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -13032,7 +13032,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -13054,7 +13054,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -13109,7 +13109,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -13121,7 +13121,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -13136,7 +13136,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -13155,7 +13155,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -13174,7 +13174,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -13218,7 +13218,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -13241,7 +13241,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -13263,7 +13263,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -13325,7 +13325,7 @@
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -13343,7 +13343,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -13411,7 +13411,7 @@
         "title": "ProductionOrderHeaderType",
         "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
         "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
         "properties": {
           "Number": {
@@ -13422,7 +13422,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -13441,7 +13441,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -13485,7 +13485,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -13555,7 +13555,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "ProductionStatusEnumeration",
         "description": "The execution status of the production order.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3017",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -13581,7 +13581,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSetupType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1016",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSetupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -13604,7 +13604,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -13645,14 +13645,14 @@
         "description": "The LoadDataSet Method loads the dataset to the underlying system after having validated that (a) the dataset is complete when IsCompleteDataset is True and (b) the dataset is valid.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6437",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSet", "IsCompleteDataSet" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -13670,7 +13670,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -13694,14 +13694,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6438",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -13715,7 +13715,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -13746,14 +13746,14 @@
         "description": "The LoadMaterialList Method loads the material list to the underlying system after having validated that   (a) the material list is complete and (b) the material list is valid.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6305",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaterialList" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -13771,7 +13771,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -13790,7 +13790,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -13805,7 +13805,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -13824,7 +13824,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -13843,7 +13843,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -13887,7 +13887,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -13910,7 +13910,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -13932,7 +13932,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -13987,7 +13987,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -13999,7 +13999,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -14014,7 +14014,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -14033,7 +14033,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -14052,7 +14052,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -14096,7 +14096,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -14119,7 +14119,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -14141,7 +14141,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -14203,14 +14203,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6329",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14224,7 +14224,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14255,14 +14255,14 @@
         "description": "The ValidateDataSet Method transfers a dataset, complete when IsCompleteDataSet is True, to the underlying system and returns the result of the validation, i.e. verifying that the dataset is complete and can run in production.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6185",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DataSet", "IsCompleteDataSet" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -14280,7 +14280,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -14304,7 +14304,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6186",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FailedValidationEntries", "FailedValidationMessages", "ExecutionFeedback" ],
           "properties": {
             "FailedValidationEntries": {
@@ -14314,7 +14314,7 @@
                 "title": "DataSetEntryType",
                 "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -14335,7 +14335,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -14353,7 +14353,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -14367,7 +14367,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -14398,14 +14398,14 @@
         "description": "The ValidateMaterialList Method transfers a material list to the underlying system and returns the result   of the validation.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6331",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "MaterialList" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -14423,7 +14423,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -14442,7 +14442,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -14457,7 +14457,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -14476,7 +14476,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -14495,7 +14495,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -14539,7 +14539,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -14562,7 +14562,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -14584,7 +14584,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -14639,7 +14639,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -14651,7 +14651,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -14666,7 +14666,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -14685,7 +14685,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -14704,7 +14704,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -14748,7 +14748,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -14771,7 +14771,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -14793,7 +14793,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -14855,7 +14855,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6332",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "FailedValidationEntries", "FailedValidationMessages", "ExecutionFeedback" ],
           "properties": {
             "FailedValidationEntries": {
@@ -14865,7 +14865,7 @@
                 "title": "MaterialListItemType",
                 "description": "The MaterialListItemType structure contains a single material to be processed.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                 "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                 "properties": {
                   "AssemblyID": {
@@ -14884,7 +14884,7 @@
                     "title": "MaterialSublotType",
                     "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                     "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                     "properties": {
                       "ID": {
@@ -14899,7 +14899,7 @@
                         "title": "MaterialLotType",
                         "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                         "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                         "properties": {
                           "ID": {
@@ -14918,7 +14918,7 @@
                             "title": "MaterialDefinitionType",
                             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                             "properties": {
                               "ID": {
@@ -14937,7 +14937,7 @@
                                 "title": "EUInformation",
                                 "description": "The base unit of measure for the material definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -14981,7 +14981,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -15004,7 +15004,7 @@
                           "Status": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The stock status of the material lot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -15026,7 +15026,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -15081,7 +15081,7 @@
                   "MaterialStockStatus": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The requested stock status for the material sublot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -15093,7 +15093,7 @@
                       "title": "MaterialSublotType",
                       "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                       "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                       "properties": {
                         "ID": {
@@ -15108,7 +15108,7 @@
                           "title": "MaterialLotType",
                           "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                           "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                           "properties": {
                             "ID": {
@@ -15127,7 +15127,7 @@
                               "title": "MaterialDefinitionType",
                               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                               "properties": {
                                 "ID": {
@@ -15146,7 +15146,7 @@
                                   "title": "EUInformation",
                                   "description": "The base unit of measure for the material definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                   "properties": {
                                     "NamespaceUri": {
@@ -15190,7 +15190,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -15213,7 +15213,7 @@
                             "Status": {
                               "title": "MaterialStockStatusEnumeration",
                               "description": "The stock status of the material lot.",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                               "type": "integer",
                               "minimum": -2147483648,
                               "maximum": 2147483647
@@ -15235,7 +15235,7 @@
                                 "title": "DataDescriptionType",
                                 "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                 "required": [ "ID", "MES_ID", "Description" ],
                                 "properties": {
                                   "ID": {
@@ -15298,7 +15298,7 @@
                 "title": "MessageType",
                 "description": "The MessageType provides a uniquely identified localised text.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                 "required": [ "ID", "LocalText" ],
                 "properties": {
                   "ID": {
@@ -15316,7 +15316,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -15330,7 +15330,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -15363,7 +15363,7 @@
         "title": "DataSetType",
         "description": "The DataSetType structure contains a set of data values.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
         "required": [ "ID", "Description", "Values" ],
         "properties": {
           "ID": {
@@ -15381,7 +15381,7 @@
               "title": "DataSetEntryType",
               "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -15415,7 +15415,7 @@
         "title": "MaterialListType",
         "description": "The MaterialListType structure contains a set of material list items.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
         "required": [ "ID", "Description", "Items" ],
         "properties": {
           "ID": {
@@ -15433,7 +15433,7 @@
               "title": "MaterialListItemType",
               "description": "The MaterialListItemType structure contains a single material to be processed.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
               "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
               "properties": {
                 "AssemblyID": {
@@ -15452,7 +15452,7 @@
                   "title": "MaterialSublotType",
                   "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                   "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                   "properties": {
                     "ID": {
@@ -15467,7 +15467,7 @@
                       "title": "MaterialLotType",
                       "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                       "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                       "properties": {
                         "ID": {
@@ -15486,7 +15486,7 @@
                           "title": "MaterialDefinitionType",
                           "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                           "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                           "properties": {
                             "ID": {
@@ -15505,7 +15505,7 @@
                               "title": "EUInformation",
                               "description": "The base unit of measure for the material definition.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -15549,7 +15549,7 @@
                                 "title": "DataDescriptionType",
                                 "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                 "required": [ "ID", "MES_ID", "Description" ],
                                 "properties": {
                                   "ID": {
@@ -15572,7 +15572,7 @@
                         "Status": {
                           "title": "MaterialStockStatusEnumeration",
                           "description": "The stock status of the material lot.",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                           "type": "integer",
                           "minimum": -2147483648,
                           "maximum": 2147483647
@@ -15594,7 +15594,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -15649,7 +15649,7 @@
                 "MaterialStockStatus": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The requested stock status for the material sublot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -15661,7 +15661,7 @@
                     "title": "MaterialSublotType",
                     "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                     "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                     "properties": {
                       "ID": {
@@ -15676,7 +15676,7 @@
                         "title": "MaterialLotType",
                         "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                         "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                         "properties": {
                           "ID": {
@@ -15695,7 +15695,7 @@
                             "title": "MaterialDefinitionType",
                             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                             "properties": {
                               "ID": {
@@ -15714,7 +15714,7 @@
                                 "title": "EUInformation",
                                 "description": "The base unit of measure for the material definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -15758,7 +15758,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -15781,7 +15781,7 @@
                           "Status": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The stock status of the material lot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -15803,7 +15803,7 @@
                               "title": "DataDescriptionType",
                               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                               "required": [ "ID", "MES_ID", "Description" ],
                               "properties": {
                                 "ID": {
@@ -15882,7 +15882,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleSpecificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleSpecificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -15899,7 +15899,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -15928,7 +15928,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -15969,7 +15969,7 @@
         "description": "The DeleteSpecificationRecord Method deletes a specification record.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12169",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "SpecificationRecord" ],
           "properties": {
             "SpecificationRecord": {
@@ -15980,14 +15980,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -16001,7 +16001,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -16032,7 +16032,7 @@
         "description": "The LoadMachineModuleDocumentation Method allows to securely load any machine module   documentation to the documentation repository DocumentationRep folder where it can be reached by   applications.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9268",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DocumentToBeLoaded", "DocumentName" ],
           "properties": {
             "DocumentToBeLoaded": {
@@ -16048,14 +16048,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9269",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -16069,7 +16069,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -16100,7 +16100,7 @@
         "description": "The RemoveMachineModuleDocumentation Method allows to securely remove, i.e. permanently delete,  any machine module documentation from the documentation repository Documentation.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9271",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DocumentName" ],
           "properties": {
             "DocumentName": {
@@ -16111,14 +16111,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=9272",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -16132,7 +16132,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -16163,7 +16163,7 @@
         "description": "The Method SetNewSpecification saves its arguments as the new specification for the machine module.   Prior to that it saves the previous specification into the PastSpecification Records Object of the same   machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "NewMaterialLoadingPoints", "NewMaterialStorageBuffers", "NewMaterialOutputPoints", "NewMaterialRejectionPoints" ],
           "properties": {
             "NewMaterialLoadingPoints": {
@@ -16173,7 +16173,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -16191,7 +16191,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -16210,7 +16210,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -16254,7 +16254,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -16293,7 +16293,7 @@
                 "title": "MaterialStorageBufferDataType",
                 "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
                 "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
                 "properties": {
                   "ID": {
@@ -16304,7 +16304,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -16323,7 +16323,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -16367,7 +16367,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -16391,7 +16391,7 @@
                     "title": "EUInformation",
                     "description": "The unit of measure for the material stored in the buffer.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -16419,7 +16419,7 @@
                   "StorageLogic": {
                     "title": "StorageLogicEnumeration",
                     "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -16427,7 +16427,7 @@
                   "MixingLogic": {
                     "title": "StorageMixingLogicEnumeration",
                     "description": "How different material loaded into the material storage buffer mix.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -16442,7 +16442,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -16460,7 +16460,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -16479,7 +16479,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -16523,7 +16523,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -16562,7 +16562,7 @@
                 "title": "MaterialPointType",
                 "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
                 "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
                 "properties": {
                   "ID": {
@@ -16580,7 +16580,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -16599,7 +16599,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -16643,7 +16643,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -16679,14 +16679,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6367",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -16700,7 +16700,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -16754,7 +16754,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -16772,7 +16772,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -16791,7 +16791,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -16835,7 +16835,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -16883,7 +16883,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -16901,7 +16901,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -16920,7 +16920,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -16964,7 +16964,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -17012,7 +17012,7 @@
           "title": "MaterialPointType",
           "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
           "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
           "properties": {
             "ID": {
@@ -17030,7 +17030,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -17049,7 +17049,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -17093,7 +17093,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -17141,7 +17141,7 @@
           "title": "MaterialStorageBufferDataType",
           "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
           "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
           "properties": {
             "ID": {
@@ -17152,7 +17152,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -17171,7 +17171,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -17215,7 +17215,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -17239,7 +17239,7 @@
               "title": "EUInformation",
               "description": "The unit of measure for the material stored in the buffer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -17267,7 +17267,7 @@
             "StorageLogic": {
               "title": "StorageLogicEnumeration",
               "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -17275,7 +17275,7 @@
             "MixingLogic": {
               "title": "StorageMixingLogicEnumeration",
               "description": "How different material loaded into the material storage buffer mix.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -17296,7 +17296,7 @@
         "title": "TimeZoneDataType",
         "description": "The local time zone where the machine operates. It is required to convert UTC times into local   time.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=8912",
+        "dov:typeRef": "org.opcfoundation.UA.TimeZoneDataType",
         "required": [ "Offset", "DaylightSavingInOffset" ],
         "properties": {
           "Offset": {
@@ -17382,7 +17382,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialLocationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1077",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLocationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -17411,7 +17411,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -17435,7 +17435,7 @@
       },
       "StateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "const": {
           "Stopped": 0,
           "Resetting": 1,
@@ -17609,7 +17609,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StateEnumeration",
         "description": "The state the material location is in.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -17629,7 +17629,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -17644,7 +17644,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -17663,7 +17663,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -17682,7 +17682,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -17726,7 +17726,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -17749,7 +17749,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -17771,7 +17771,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -17842,7 +17842,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -17857,7 +17857,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -17876,7 +17876,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -17895,7 +17895,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -17939,7 +17939,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -17962,7 +17962,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -17984,7 +17984,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -18056,7 +18056,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1046",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18101,14 +18101,14 @@
         "description": "The Method ResetAggregates restarts from new the computation of aggregates performed by the   underlying system.",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=22389",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -18122,7 +18122,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -18419,7 +18419,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessControlItemType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1040",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessControlItemType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18452,7 +18452,7 @@
         "description": "The SetRemoteControl Method enables or disables the remote control mode.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -18463,14 +18463,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6042",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -18484,7 +18484,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -18605,7 +18605,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SensorFunctionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1044",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SensorFunctionType",
     "links": [
       {
         "rel": "tm:extends",
@@ -18650,7 +18650,7 @@
         "description": "The Method LoadReferenceFeatures loads binary profiles to be used as references for defect detection.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7443",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Features" ],
           "properties": {
             "Features": {
@@ -18665,14 +18665,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6233",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -18686,7 +18686,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -18717,7 +18717,7 @@
         "description": "The method SetDetectionMode enables or disables the detection function and the underneath defect reasons.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7441",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -18728,14 +18728,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7442",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -18749,7 +18749,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -18835,7 +18835,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleProductionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleProductionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19279,7 +19279,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1018",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19503,7 +19503,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1028",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCExecuteStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -19754,7 +19754,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/PackML/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6935",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Parameter" ],
           "properties": {
             "Parameter": {
@@ -19763,7 +19763,7 @@
               "items": {
                 "title": "PackMLDescriptorDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/PackML/;i=16",
+                "dov:typeRef": "org.opcfoundation.UA.PackML.PackMLDescriptorDataType",
                 "required": [ "ID", "Name", "Unit", "Value" ],
                 "properties": {
                   "ID": {
@@ -19780,7 +19780,7 @@
                     "title": "EUInformation",
                     "description": "OPC UA engineering unit information",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -20371,7 +20371,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCMachineStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1019",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCMachineStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20612,7 +20612,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderExecutionStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1072",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderExecutionStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -20953,7 +20953,7 @@
         "title": "ProductionOrderHeaderType",
         "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
         "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
         "properties": {
           "Number": {
@@ -20964,7 +20964,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -20983,7 +20983,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -21027,7 +21027,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -21460,7 +21460,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_TMCDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1090",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.TMCDeviceType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21492,7 +21492,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ControlModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1062",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ControlModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21542,7 +21542,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_AnalogInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1063",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.AnalogInputType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21644,7 +21644,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DigitalInputType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1064",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DigitalInputType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21715,7 +21715,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MotorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1065",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MotorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21753,7 +21753,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_SensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1066",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.SensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21785,7 +21785,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ValveType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1067",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ValveType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21829,7 +21829,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_DefectDetectionSensorType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1025",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DefectDetectionSensorType",
     "links": [
       {
         "rel": "tm:extends",
@@ -21874,7 +21874,7 @@
         "description": "The Method SetDetectionMode enables or disables the defect detection sensor.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7467",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Enable" ],
           "properties": {
             "Enable": {
@@ -21885,14 +21885,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=7468",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -21906,7 +21906,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -22027,7 +22027,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_EquipmentModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1071",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.EquipmentModuleType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22089,7 +22089,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MachineModuleType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MachineModuleType",
     "dov:isComposite": true,
     "links": [
       {
@@ -22232,7 +22232,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialLoadingPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLoadingPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -22243,7 +22243,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -22267,7 +22267,7 @@
       },
       "MaterialValidationStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
         "const": {
           "None": 0,
           "Waiting": 1,
@@ -22296,7 +22296,7 @@
       },
       "MaterialIntegrityAgentEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialIntegrityAgentEnumeration",
         "const": {
           "None": 0,
           "Local": 1,
@@ -22342,13 +22342,13 @@
         "description": "The SetPresentedMaterialValidationStatus Method provides a client with an affordance to perform the   validation of the PresentedMaterial against the ExpectedMaterials and set the result of the validation in   the PresentedMaterialValidationStatus variable.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13570",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ValidationResult" ],
           "properties": {
             "ValidationResult": {
               "title": "MaterialValidationStatusEnumeration",
               "description": "The result of the validation of the PresentedMaterial.",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
               "type": "integer",
               "minimum": -2147483648,
               "maximum": 2147483647
@@ -22357,14 +22357,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=13571",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -22378,7 +22378,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -22605,7 +22605,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -22620,7 +22620,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -22639,7 +22639,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -22658,7 +22658,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -22702,7 +22702,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -22725,7 +22725,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -22747,7 +22747,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -22816,7 +22816,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -22831,7 +22831,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -22850,7 +22850,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -22869,7 +22869,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -22913,7 +22913,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -22936,7 +22936,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -22958,7 +22958,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -23023,7 +23023,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MaterialIntegrityAgentEnumeration",
         "description": "MaterialIntegrityAgent defines how material validation is performed.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3020",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialIntegrityAgentEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23046,7 +23046,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -23064,7 +23064,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -23083,7 +23083,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -23127,7 +23127,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -23221,7 +23221,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -23236,7 +23236,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -23255,7 +23255,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -23274,7 +23274,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -23318,7 +23318,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -23341,7 +23341,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -23363,7 +23363,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -23432,7 +23432,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "MaterialValidationStatusEnumeration",
         "description": "The status of the validation of the presented material.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -23653,7 +23653,7 @@
             "title": "MaterialSublotType",
             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
             "properties": {
               "ID": {
@@ -23668,7 +23668,7 @@
                 "title": "MaterialLotType",
                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                 "properties": {
                   "ID": {
@@ -23687,7 +23687,7 @@
                     "title": "MaterialDefinitionType",
                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                     "properties": {
                       "ID": {
@@ -23706,7 +23706,7 @@
                         "title": "EUInformation",
                         "description": "The base unit of measure for the material definition.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -23750,7 +23750,7 @@
                           "title": "DataDescriptionType",
                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                           "required": [ "ID", "MES_ID", "Description" ],
                           "properties": {
                             "ID": {
@@ -23773,7 +23773,7 @@
                   "Status": {
                     "title": "MaterialStockStatusEnumeration",
                     "description": "The stock status of the material lot.",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                     "type": "integer",
                     "minimum": -2147483648,
                     "maximum": 2147483647
@@ -23795,7 +23795,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -23896,7 +23896,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -23911,7 +23911,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -23930,7 +23930,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -23949,7 +23949,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -23993,7 +23993,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -24016,7 +24016,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -24038,7 +24038,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -24103,7 +24103,7 @@
         "data": {
           "title": "MaterialValidationStatusEnumeration",
           "description": "The status of the validation of the presented material.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3040",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialValidationStatusEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -24127,7 +24127,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialOutputPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1037",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialOutputPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -24138,7 +24138,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -24231,7 +24231,7 @@
         "title": "MaterialDefinitionType",
         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
         "properties": {
           "ID": {
@@ -24250,7 +24250,7 @@
             "title": "EUInformation",
             "description": "The base unit of measure for the material definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -24294,7 +24294,7 @@
               "title": "DataDescriptionType",
               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
               "required": [ "ID", "MES_ID", "Description" ],
               "properties": {
                 "ID": {
@@ -24327,7 +24327,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -24345,7 +24345,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -24364,7 +24364,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -24408,7 +24408,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -24502,7 +24502,7 @@
         "title": "MaterialSublotType",
         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
         "properties": {
           "ID": {
@@ -24517,7 +24517,7 @@
             "title": "MaterialLotType",
             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
             "properties": {
               "ID": {
@@ -24536,7 +24536,7 @@
                 "title": "MaterialDefinitionType",
                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                 "properties": {
                   "ID": {
@@ -24555,7 +24555,7 @@
                     "title": "EUInformation",
                     "description": "The base unit of measure for the material definition.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -24599,7 +24599,7 @@
                       "title": "DataDescriptionType",
                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                       "required": [ "ID", "MES_ID", "Description" ],
                       "properties": {
                         "ID": {
@@ -24622,7 +24622,7 @@
               "Status": {
                 "title": "MaterialStockStatusEnumeration",
                 "description": "The stock status of the material lot.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -24644,7 +24644,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -24857,7 +24857,7 @@
           "title": "MaterialSublotType",
           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
           "properties": {
             "ID": {
@@ -24872,7 +24872,7 @@
               "title": "MaterialLotType",
               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
               "properties": {
                 "ID": {
@@ -24891,7 +24891,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -24910,7 +24910,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -24954,7 +24954,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -24977,7 +24977,7 @@
                 "Status": {
                   "title": "MaterialStockStatusEnumeration",
                   "description": "The stock status of the material lot.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -24999,7 +24999,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -25152,7 +25152,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialRejectionPointType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1023",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialRejectionPointType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25185,7 +25185,7 @@
         "description": "The Method SetRejectionMode turns the rejection on or off.  The Method SetRejectionMode turns the rejection on or off.  ",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6868",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RejectionMode" ],
           "properties": {
             "RejectionMode": {
@@ -25196,14 +25196,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=6917",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -25217,7 +25217,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -25250,7 +25250,7 @@
         "title": "MaterialDefinitionType",
         "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
         "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
         "properties": {
           "ID": {
@@ -25269,7 +25269,7 @@
             "title": "EUInformation",
             "description": "The base unit of measure for the material definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -25313,7 +25313,7 @@
               "title": "DataDescriptionType",
               "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
               "required": [ "ID", "MES_ID", "Description" ],
               "properties": {
                 "ID": {
@@ -25346,7 +25346,7 @@
         "title": "MaterialPointType",
         "description": "The MaterialPointType structure provides the description of the capability of a load or  unload point.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialPointType",
         "required": [ "ID", "Description", "MaterialCapability", "ConnectedMaterialPoint", "PropagatesProductionOrder" ],
         "properties": {
           "ID": {
@@ -25364,7 +25364,7 @@
               "title": "MaterialDefinitionType",
               "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
               "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
               "properties": {
                 "ID": {
@@ -25383,7 +25383,7 @@
                   "title": "EUInformation",
                   "description": "The base unit of measure for the material definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -25427,7 +25427,7 @@
                     "title": "DataDescriptionType",
                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                     "required": [ "ID", "MES_ID", "Description" ],
                     "properties": {
                       "ID": {
@@ -25771,7 +25771,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_MaterialStorageBufferType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1035",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferType",
     "links": [
       {
         "rel": "tm:extends",
@@ -25782,7 +25782,7 @@
     "schemaDefinitions": {
       "StorageLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "const": {
           "Other": 0,
           "FIFO": 1,
@@ -25811,7 +25811,7 @@
       },
       "StorageMixingLogicEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "const": {
           "Mixing": 0,
           "NonMixingByProduct": 1,
@@ -25936,7 +25936,7 @@
         "title": "MaterialStorageBufferDataType",
         "description": "The MaterialStorageBufferDataType structure provides the description of the capability of a   material storage buffer.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3014",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStorageBufferDataType",
         "required": [ "ID", "StoredMaterial", "EngineeringUnits", "TotalStorageCapacity", "StorageLogic", "MixingLogic" ],
         "properties": {
           "ID": {
@@ -25947,7 +25947,7 @@
             "title": "MaterialDefinitionType",
             "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
             "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
             "properties": {
               "ID": {
@@ -25966,7 +25966,7 @@
                 "title": "EUInformation",
                 "description": "The base unit of measure for the material definition.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -26010,7 +26010,7 @@
                   "title": "DataDescriptionType",
                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                   "required": [ "ID", "MES_ID", "Description" ],
                   "properties": {
                     "ID": {
@@ -26034,7 +26034,7 @@
             "title": "EUInformation",
             "description": "The unit of measure for the material stored in the buffer.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
             "properties": {
               "NamespaceUri": {
@@ -26062,7 +26062,7 @@
           "StorageLogic": {
             "title": "StorageLogicEnumeration",
             "description": "The logic by which product is loaded and unloaded from the material storage buffer.",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -26070,7 +26070,7 @@
           "MixingLogic": {
             "title": "StorageMixingLogicEnumeration",
             "description": "How different material loaded into the material storage buffer mix.",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
             "type": "integer",
             "minimum": -2147483648,
             "maximum": 2147483647
@@ -26107,7 +26107,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StorageMixingLogicEnumeration",
         "description": "MixingLogic identifies if and how materials can be mixed in the MaterialStorageBuffer.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3035",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageMixingLogicEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -26191,7 +26191,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TMC/v2/",
         "title": "StorageLogicEnumeration",
         "description": "The logic used at the buffer storage to store and retrieve material.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3015",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.StorageLogicEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -26478,7 +26478,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProcessControlLoopType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1049",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProcessControlLoopType",
     "links": [
       {
         "rel": "tm:extends",
@@ -26577,7 +26577,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_ProductionOrderOrchestrationLayerType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1073",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderOrchestrationLayerType",
     "dov:isComposite": true,
     "links": [
       {
@@ -26595,7 +26595,7 @@
     "schemaDefinitions": {
       "MaterialStockStatusEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
         "const": {
           "Unrestricted": 0,
           "QualityInspection": 1,
@@ -26636,14 +26636,14 @@
         "description": "The AbortProductionOrder Method is used to abort a production order that is in execution or starting or   completing in the production line.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11950",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAbort" ],
           "properties": {
             "POToAbort": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -26654,7 +26654,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -26673,7 +26673,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -26717,7 +26717,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -26779,14 +26779,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11951",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -26800,7 +26800,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -26831,14 +26831,14 @@
         "description": "The AssignProductionOrder Method is used to assign a production order to one infeed machine module   where it shall be executed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11953",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToAssign", "MachineModuleUserName" ],
           "properties": {
             "POToAssign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -26849,7 +26849,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -26868,7 +26868,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -26912,7 +26912,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -26981,14 +26981,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11954",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27002,7 +27002,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27033,14 +27033,14 @@
         "description": "The CompleteProductionOrder Method is used to complete a production order in execution.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11956",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToComplete", "MachineModuleUserName" ],
           "properties": {
             "POToComplete": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27051,7 +27051,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27070,7 +27070,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27114,7 +27114,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27180,14 +27180,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11957",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27201,7 +27201,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27232,14 +27232,14 @@
         "description": "The GetDataset Method is used to retrieve the data set from a production order header.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11959",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27250,7 +27250,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27269,7 +27269,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27313,7 +27313,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27379,14 +27379,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11960",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DataSet", "ExecutionFeedback" ],
           "properties": {
             "DataSet": {
               "title": "DataSetType",
               "description": "The DataSetType structure contains a set of data values.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
               "required": [ "ID", "Description", "Values" ],
               "properties": {
                 "ID": {
@@ -27404,7 +27404,7 @@
                     "title": "DataSetEntryType",
                     "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -27424,7 +27424,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -27438,7 +27438,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -27469,14 +27469,14 @@
         "description": "The GetMaterialList Method is used to retrieve the material list information from a production order   header.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11962",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -27487,7 +27487,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -27506,7 +27506,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -27550,7 +27550,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -27616,14 +27616,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11963",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "MaterialList", "ExecutionFeedback" ],
           "properties": {
             "MaterialList": {
               "title": "MaterialListType",
               "description": "The MaterialListType structure contains a set of material list items.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
               "required": [ "ID", "Description", "Items" ],
               "properties": {
                 "ID": {
@@ -27641,7 +27641,7 @@
                     "title": "MaterialListItemType",
                     "description": "The MaterialListItemType structure contains a single material to be processed.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                     "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                     "properties": {
                       "AssemblyID": {
@@ -27660,7 +27660,7 @@
                         "title": "MaterialSublotType",
                         "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                         "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                         "properties": {
                           "ID": {
@@ -27675,7 +27675,7 @@
                             "title": "MaterialLotType",
                             "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                             "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                             "properties": {
                               "ID": {
@@ -27694,7 +27694,7 @@
                                 "title": "MaterialDefinitionType",
                                 "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                 "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                 "properties": {
                                   "ID": {
@@ -27713,7 +27713,7 @@
                                     "title": "EUInformation",
                                     "description": "The base unit of measure for the material definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                     "properties": {
                                       "NamespaceUri": {
@@ -27757,7 +27757,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -27780,7 +27780,7 @@
                               "Status": {
                                 "title": "MaterialStockStatusEnumeration",
                                 "description": "The stock status of the material lot.",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                 "type": "integer",
                                 "minimum": -2147483648,
                                 "maximum": 2147483647
@@ -27802,7 +27802,7 @@
                                   "title": "DataDescriptionType",
                                   "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                   "required": [ "ID", "MES_ID", "Description" ],
                                   "properties": {
                                     "ID": {
@@ -27857,7 +27857,7 @@
                       "MaterialStockStatus": {
                         "title": "MaterialStockStatusEnumeration",
                         "description": "The requested stock status for the material sublot.",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                         "type": "integer",
                         "minimum": -2147483648,
                         "maximum": 2147483647
@@ -27869,7 +27869,7 @@
                           "title": "MaterialSublotType",
                           "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                           "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                           "properties": {
                             "ID": {
@@ -27884,7 +27884,7 @@
                               "title": "MaterialLotType",
                               "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                               "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                               "properties": {
                                 "ID": {
@@ -27903,7 +27903,7 @@
                                   "title": "MaterialDefinitionType",
                                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                   "properties": {
                                     "ID": {
@@ -27922,7 +27922,7 @@
                                       "title": "EUInformation",
                                       "description": "The base unit of measure for the material definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                       "properties": {
                                         "NamespaceUri": {
@@ -27966,7 +27966,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -27989,7 +27989,7 @@
                                 "Status": {
                                   "title": "MaterialStockStatusEnumeration",
                                   "description": "The stock status of the material lot.",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                   "type": "integer",
                                   "minimum": -2147483648,
                                   "maximum": 2147483647
@@ -28011,7 +28011,7 @@
                                     "title": "DataDescriptionType",
                                     "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                     "required": [ "ID", "MES_ID", "Description" ],
                                     "properties": {
                                       "ID": {
@@ -28073,7 +28073,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -28087,7 +28087,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -28118,14 +28118,14 @@
         "description": "The GetProductionOrder Method is used to retrieve the complete production order information starting   with a production order header as an input argument.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11965",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POHeader", "MachineModuleUserName" ],
           "properties": {
             "POHeader": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -28136,7 +28136,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -28155,7 +28155,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -28199,7 +28199,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -28265,21 +28265,21 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=11966",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ProductionOrder", "ExecutionFeedback" ],
           "properties": {
             "ProductionOrder": {
               "title": "ProductionOrderType",
               "description": "The ProductionOrderType structure contains the complete production order information.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3038",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderType",
               "required": [ "Header", "MaterialList", "DataSet" ],
               "properties": {
                 "Header": {
                   "title": "ProductionOrderHeaderType",
                   "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
                   "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
                   "properties": {
                     "Number": {
@@ -28290,7 +28290,7 @@
                       "title": "MaterialDefinitionType",
                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                       "properties": {
                         "ID": {
@@ -28309,7 +28309,7 @@
                           "title": "EUInformation",
                           "description": "The base unit of measure for the material definition.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -28353,7 +28353,7 @@
                             "title": "DataDescriptionType",
                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                             "required": [ "ID", "MES_ID", "Description" ],
                             "properties": {
                               "ID": {
@@ -28415,7 +28415,7 @@
                   "title": "MaterialListType",
                   "description": "The MaterialListType structure contains a set of material list items.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3037",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListType",
                   "required": [ "ID", "Description", "Items" ],
                   "properties": {
                     "ID": {
@@ -28433,7 +28433,7 @@
                         "title": "MaterialListItemType",
                         "description": "The MaterialListItemType structure contains a single material to be processed.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3036",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialListItemType",
                         "required": [ "AssemblyID", "MaterialPointID", "MaterialPointMES_ID", "MaterialSublot", "MaterialStockStatus", "FollowUpMaterials" ],
                         "properties": {
                           "AssemblyID": {
@@ -28452,7 +28452,7 @@
                             "title": "MaterialSublotType",
                             "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                             "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                             "properties": {
                               "ID": {
@@ -28467,7 +28467,7 @@
                                 "title": "MaterialLotType",
                                 "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                 "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                 "properties": {
                                   "ID": {
@@ -28486,7 +28486,7 @@
                                     "title": "MaterialDefinitionType",
                                     "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                     "type": "object",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                     "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                     "properties": {
                                       "ID": {
@@ -28505,7 +28505,7 @@
                                         "title": "EUInformation",
                                         "description": "The base unit of measure for the material definition.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                         "properties": {
                                           "NamespaceUri": {
@@ -28549,7 +28549,7 @@
                                           "title": "DataDescriptionType",
                                           "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                          "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                           "required": [ "ID", "MES_ID", "Description" ],
                                           "properties": {
                                             "ID": {
@@ -28572,7 +28572,7 @@
                                   "Status": {
                                     "title": "MaterialStockStatusEnumeration",
                                     "description": "The stock status of the material lot.",
-                                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                     "type": "integer",
                                     "minimum": -2147483648,
                                     "maximum": 2147483647
@@ -28594,7 +28594,7 @@
                                       "title": "DataDescriptionType",
                                       "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                       "required": [ "ID", "MES_ID", "Description" ],
                                       "properties": {
                                         "ID": {
@@ -28649,7 +28649,7 @@
                           "MaterialStockStatus": {
                             "title": "MaterialStockStatusEnumeration",
                             "description": "The requested stock status for the material sublot.",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                             "type": "integer",
                             "minimum": -2147483648,
                             "maximum": 2147483647
@@ -28661,7 +28661,7 @@
                               "title": "MaterialSublotType",
                               "description": "The MaterialSublotType structure contains the material sublot information. It is harmonised with   ISA 95 Material Sublot.",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3025",
+                              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialSublotType",
                               "required": [ "ID", "MES_ID", "MaterialLot", "MaterialStorageLocationID", "Quantity" ],
                               "properties": {
                                 "ID": {
@@ -28676,7 +28676,7 @@
                                   "title": "MaterialLotType",
                                   "description": "The MaterialLotType structure contains the material lot information. It is harmonised with ISA   95 Material Lot.",
                                   "type": "object",
-                                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3012",
+                                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialLotType",
                                   "required": [ "ID", "MES_ID", "Description", "MaterialDefinition", "Status", "ProductionDate" ],
                                   "properties": {
                                     "ID": {
@@ -28695,7 +28695,7 @@
                                       "title": "MaterialDefinitionType",
                                       "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                                       "type": "object",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                                       "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                                       "properties": {
                                         "ID": {
@@ -28714,7 +28714,7 @@
                                           "title": "EUInformation",
                                           "description": "The base unit of measure for the material definition.",
                                           "type": "object",
-                                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                           "properties": {
                                             "NamespaceUri": {
@@ -28758,7 +28758,7 @@
                                             "title": "DataDescriptionType",
                                             "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                             "type": "object",
-                                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                            "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                             "required": [ "ID", "MES_ID", "Description" ],
                                             "properties": {
                                               "ID": {
@@ -28781,7 +28781,7 @@
                                     "Status": {
                                       "title": "MaterialStockStatusEnumeration",
                                       "description": "The stock status of the material lot.",
-                                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3039",
+                                      "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialStockStatusEnumeration",
                                       "type": "integer",
                                       "minimum": -2147483648,
                                       "maximum": 2147483647
@@ -28803,7 +28803,7 @@
                                         "title": "DataDescriptionType",
                                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                                         "type": "object",
-                                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                                         "required": [ "ID", "MES_ID", "Description" ],
                                         "properties": {
                                           "ID": {
@@ -28865,7 +28865,7 @@
                   "title": "DataSetType",
                   "description": "The DataSetType structure contains a set of data values.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3018",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetType",
                   "required": [ "ID", "Description", "Values" ],
                   "properties": {
                     "ID": {
@@ -28883,7 +28883,7 @@
                         "title": "DataSetEntryType",
                         "description": "The DataSetEntryType structure contains the value of a single parameter, or data value.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3004",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataSetEntryType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -28905,7 +28905,7 @@
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -28919,7 +28919,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -28950,14 +28950,14 @@
         "description": "The ReleaseProductionOrder Method is used to make a production order available to a machine module   for orchestrated execution in a production line (Process Cell according to ANSI/ISA-88.00.01-2010   Physical Model).",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12008",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToRelease", "MachineModuleUserName" ],
           "properties": {
             "POToRelease": {
               "title": "OrchestrationProductionOrderType",
               "description": "The OrchestrationProductionOrderType structure contains the complete production order   information used by the Production Order Orchestration Layer.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.OrchestrationProductionOrderType",
               "required": [ "ActiveMachineModules" ],
               "properties": {
                 "ActiveMachineModules": {
@@ -28977,14 +28977,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12009",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -28998,7 +28998,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29029,14 +29029,14 @@
         "description": "The StartProductionOrder Method is used to start the execution of a production order at a machine   module specifying the loading points that input materials will be fed to and the output points where output   will be directed.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12011",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToStart", "MachineModuleUserName", "SourceMaterialLoadingPointIDs", "DestinationMaterialOutputPointIDs" ],
           "properties": {
             "POToStart": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29047,7 +29047,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29066,7 +29066,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29110,7 +29110,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29190,14 +29190,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12012",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29211,7 +29211,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29242,14 +29242,14 @@
         "description": "The UnAssignProductionOrder Method is used to unassign a production order previously assigned to   an infeed machine module.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12014",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnassign" ],
           "properties": {
             "POToUnassign": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29260,7 +29260,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29279,7 +29279,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29323,7 +29323,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29385,14 +29385,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12015",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29406,7 +29406,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29437,14 +29437,14 @@
         "description": "The UnreleaseProductionOrder Method is used to reverse the effect of the ReleaseProductionOrder  method and make a previously released production order unavailable for assignment and production.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12017",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "POToUnrelease" ],
           "properties": {
             "POToUnrelease": {
               "title": "ProductionOrderHeaderType",
               "description": "The ProductionOrderHeaderType structure contains the header information for a production   order.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3016",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.ProductionOrderHeaderType",
               "required": [ "Number", "ProducedMaterial", "TargetQuantity", "ContinueAtJobEnd", "TargetStartTime", "TargetEndTime", "DataSetID", "DataSetDescription", "MaterialListID", "MaterialListDescription" ],
               "properties": {
                 "Number": {
@@ -29455,7 +29455,7 @@
                   "title": "MaterialDefinitionType",
                   "description": "The MaterialDefinitionType structure contains the definition of a material. It is harmonised with   ISA 95 Material Definition.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MaterialDefinitionType",
                   "required": [ "ID", "MES_ID", "Description", "BaseUnitOfMeasure", "BatchManaged" ],
                   "properties": {
                     "ID": {
@@ -29474,7 +29474,7 @@
                       "title": "EUInformation",
                       "description": "The base unit of measure for the material definition.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -29518,7 +29518,7 @@
                         "title": "DataDescriptionType",
                         "description": "The DataDescriptionType structure contains a metadata, i.e. a description.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3019",
+                        "dov:typeRef": "org.opcfoundation.UA.TMC.v2.DataDescriptionType",
                         "required": [ "ID", "MES_ID", "Description" ],
                         "properties": {
                           "ID": {
@@ -29580,14 +29580,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=12018",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29601,7 +29601,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29662,7 +29662,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_UIInformationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1020",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.UIInformationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -29696,7 +29696,7 @@
         "description": "The Method DeleteUIResource permanently removes a UI resource from the underlying system   memory.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16748",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResourceName" ],
           "properties": {
             "ResourceName": {
@@ -29707,14 +29707,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16749",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29728,7 +29728,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29759,7 +29759,7 @@
         "description": "The Method LoadUIResource loads a UI resource in the underlying system for visualization. It will   override the existing UI resource by the same name.",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16539",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResourceName", "ResourceValue" ],
           "properties": {
             "ResourceName": {
@@ -29774,14 +29774,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=16540",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ExecutionFeedback" ],
           "properties": {
             "ExecutionFeedback": {
               "title": "MethodExecutionFeedbackType",
               "description": "The MethodExecutionFeedbackType provides suitable feedback, both positive and negative, to an OPC UA client invoking a method.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3009",
+              "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MethodExecutionFeedbackType",
               "required": [ "Success", "Message" ],
               "properties": {
                 "Success": {
@@ -29795,7 +29795,7 @@
                     "title": "MessageType",
                     "description": "The MessageType provides a uniquely identified localised text.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.MessageType",
                     "required": [ "ID", "LocalText" ],
                     "properties": {
                       "ID": {
@@ -29934,7 +29934,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TMC_v2_UserInterfaceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TMC/v2/;i=1043",
+    "dov:typeRef": "org.opcfoundation.UA.TMC.v2.UserInterfaceType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/TTD.TM.json
+++ b/wot-codegen/opc-output-simple/TTD.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TTDResultReadyEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TTDResultReadyEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -73,14 +73,14 @@
         "title": "ResultDataType",
         "description": "Contains fields that were created during the execution of a recipe.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
         "required": [ "ResultMetaData", "ResultContent" ],
         "properties": {
           "ResultMetaData": {
             "title": "ResultMetaDataType",
             "description": "Meta data of a result, describing the result.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
             "required": [ "ResultId" ],
             "properties": {
               "ResultId": {
@@ -146,7 +146,7 @@
                 "title": "ProcessingTimesDataType",
                 "description": "Contains measured times that were generated during the execution of a recipe.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                 "required": [ "StartTime", "EndTime" ],
                 "properties": {
                   "StartTime": {
@@ -181,7 +181,7 @@
               "ResultEvaluation": {
                 "title": "ResultEvaluationEnum",
                 "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                 "type": "integer",
                 "minimum": -2147483648,
                 "maximum": 2147483647
@@ -236,14 +236,14 @@
           "title": "ResultDataType",
           "description": "Contains fields that were created during the execution of a recipe.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+          "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
           "required": [ "ResultMetaData", "ResultContent" ],
           "properties": {
             "ResultMetaData": {
               "title": "ResultMetaDataType",
               "description": "Meta data of a result, describing the result.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
               "required": [ "ResultId" ],
               "properties": {
                 "ResultId": {
@@ -309,7 +309,7 @@
                   "title": "ProcessingTimesDataType",
                   "description": "Contains measured times that were generated during the execution of a recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                   "required": [ "StartTime", "EndTime" ],
                   "properties": {
                     "StartTime": {
@@ -344,7 +344,7 @@
                 "ResultEvaluation": {
                   "title": "ResultEvaluationEnum",
                   "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                   "type": "integer",
                   "minimum": -2147483648,
                   "maximum": 2147483647
@@ -397,7 +397,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_JobStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1009",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.JobStatisticsType",
     "dov:isComposite": true,
     "links": [
       {
@@ -496,7 +496,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_MachineStatisticsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1012",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.MachineStatisticsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -562,7 +562,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_RecurrentPrognosisType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.RecurrentPrognosisType",
     "dov:isComposite": true,
     "links": [
       {
@@ -672,7 +672,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_RecipeManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -699,7 +699,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -719,7 +719,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6050",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "RecipeId" ],
           "properties": {
             "RecipeId": {
@@ -729,20 +729,20 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Recipe" ],
           "properties": {
             "Recipe": {
               "title": "RecipeDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
               "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
               "properties": {
                 "RecipeId": {
                   "title": "RecipeIdDataType",
                   "description": "RecipeId meta data describing this recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Name": {
@@ -805,7 +805,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6049",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "RecipeIds" ],
           "properties": {
             "RecipeIds": {
@@ -813,7 +813,7 @@
               "items": {
                 "title": "RecipeIdDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                 "required": [ "Id" ],
                 "properties": {
                   "Name": {
@@ -866,7 +866,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Recipes" ],
           "properties": {
             "Recipes": {
@@ -874,14 +874,14 @@
               "items": {
                 "title": "RecipeDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
                 "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
                 "properties": {
                   "RecipeId": {
                     "title": "RecipeIdDataType",
                     "description": "RecipeId meta data describing this recipe.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Name": {
@@ -945,20 +945,20 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Recipe", "Overwrite" ],
           "properties": {
             "Recipe": {
               "title": "RecipeDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+              "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
               "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
               "properties": {
                 "RecipeId": {
                   "title": "RecipeIdDataType",
                   "description": "RecipeId meta data describing this recipe.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                   "required": [ "Id" ],
                   "properties": {
                     "Name": {
@@ -1024,7 +1024,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/TTD/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Recipes", "Overwrite" ],
           "properties": {
             "Recipes": {
@@ -1032,14 +1032,14 @@
               "items": {
                 "title": "RecipeDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3018",
+                "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeDataType",
                 "required": [ "RecipeId", "RecipeContent", "ContentEncoding" ],
                 "properties": {
                   "RecipeId": {
                     "title": "RecipeIdDataType",
                     "description": "RecipeId meta data describing this recipe.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
                     "required": [ "Id" ],
                     "properties": {
                       "Name": {
@@ -1110,7 +1110,7 @@
         "items": {
           "title": "RecipeIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.RecipeIdDataType",
           "required": [ "Id" ],
           "properties": {
             "Name": {
@@ -1175,7 +1175,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TTDResultManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TTDResultManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1198,7 +1198,7 @@
     "schemaDefinitions": {
       "ResultEvaluationEnum": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
         "const": {
           "Undefined": 0,
           "OK": 1,
@@ -1231,7 +1231,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Machinery/Result/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6111",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ResultId", "Timeout" ],
           "properties": {
             "ResultId": {
@@ -1248,7 +1248,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=6112",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ResultHandle", "Result", "Error" ],
           "properties": {
             "ResultHandle": {
@@ -1261,14 +1261,14 @@
               "title": "ResultDataType",
               "description": "Contains fields that were created during the execution of a recipe.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultDataType",
               "required": [ "ResultMetaData", "ResultContent" ],
               "properties": {
                 "ResultMetaData": {
                   "title": "ResultMetaDataType",
                   "description": "Meta data of a result, describing the result.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3007",
+                  "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultMetaDataType",
                   "required": [ "ResultId" ],
                   "properties": {
                     "ResultId": {
@@ -1334,7 +1334,7 @@
                       "title": "ProcessingTimesDataType",
                       "description": "Contains measured times that were generated during the execution of a recipe.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ProcessingTimesDataType",
                       "required": [ "StartTime", "EndTime" ],
                       "properties": {
                         "StartTime": {
@@ -1369,7 +1369,7 @@
                     "ResultEvaluation": {
                       "title": "ResultEvaluationEnum",
                       "description": "The ResultEvaluation indicates whether the result was in tolerance.",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Result/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.Machinery.Result.ResultEvaluationEnum",
                       "type": "integer",
                       "minimum": -2147483648,
                       "maximum": 2147483647
@@ -1434,7 +1434,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "TTD_TextileTestingDeviceType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=1010",
+    "dov:typeRef": "org.opcfoundation.UA.TTD.TextileTestingDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1484,7 +1484,7 @@
         "items": {
           "title": "ExchangeablePartDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.ExchangeablePartDataType",
           "required": [ "PartType", "Mounted" ],
           "properties": {
             "PartType": {
@@ -1534,7 +1534,7 @@
         "items": {
           "title": "OptionalModuleDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3009",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.OptionalModuleDataType",
           "required": [ "ModuleName", "ModuleType", "IsInstalled" ],
           "properties": {
             "ModuleName": {
@@ -1575,7 +1575,7 @@
         "items": {
           "title": "TestProcedureIdDataType",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/TTD/;i=3034",
+          "dov:typeRef": "org.opcfoundation.UA.TTD.TestProcedureIdDataType",
           "required": [ "TestProcedureId" ],
           "properties": {
             "TestProcedureId": {

--- a/wot-codegen/opc-output-simple/WMTP.TM.json
+++ b/wot-codegen/opc-output-simple/WMTP.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPMeasurementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPMeasurementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -46,7 +46,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6200",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "DeltaValue" ],
           "properties": {
             "DeltaValue": {
@@ -66,7 +66,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6182",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TriggerDuration" ],
           "properties": {
             "TriggerDuration": {
@@ -411,7 +411,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WirelessMachineToolPeripheralType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WirelessMachineToolPeripheralType",
     "dov:isComposite": true,
     "links": [
       {
@@ -474,7 +474,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPServiceCycleDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPServiceCycleDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -499,7 +499,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6241",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -507,13 +507,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -550,7 +550,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -568,7 +568,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -638,19 +638,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6246",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -687,7 +687,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -705,7 +705,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -774,7 +774,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6243",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -791,7 +791,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6244",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -799,13 +799,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -842,7 +842,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -860,7 +860,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -930,19 +930,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6245",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -979,7 +979,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -997,7 +997,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1066,7 +1066,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6247",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1081,7 +1081,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6248",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
@@ -1089,13 +1089,13 @@
               "items": {
                 "title": "WMTPOutputDataType",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
                 "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
                 "properties": {
                   "EngineeringUnits": {
                     "title": "EUInformation",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1132,7 +1132,7 @@
                   "InstrumentRange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -1150,7 +1150,7 @@
                   "EURange": {
                     "title": "Range",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                    "dov:typeRef": "org.opcfoundation.UA.Range",
                     "required": [ "Low", "High" ],
                     "properties": {
                       "Low": {
@@ -1220,7 +1220,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6164",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeleteAllStoredRecordsSuccessfull" ],
           "properties": {
             "DeleteAllStoredRecordsSuccessfull": {
@@ -1240,7 +1240,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6170",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -1267,7 +1267,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6166",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1292,7 +1292,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6174",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -1314,7 +1314,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6178",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1329,7 +1329,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6179",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -1362,7 +1362,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WMTP_WMTPWorkCycleDataType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPWorkCycleDataType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1387,19 +1387,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6233",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1436,7 +1436,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1454,7 +1454,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1523,19 +1523,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6240",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1572,7 +1572,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1590,7 +1590,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1659,7 +1659,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6235",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -1676,19 +1676,19 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6236",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1725,7 +1725,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1743,7 +1743,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1812,19 +1812,19 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6239",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1861,7 +1861,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1879,7 +1879,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -1948,7 +1948,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6237",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -1963,19 +1963,19 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6238",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "CombinedReport" ],
           "properties": {
             "CombinedReport": {
               "title": "WMTPOutputDataType",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.WMTP.WMTPOutputDataType",
               "required": [ "EngineeringUnits", "ActualValue", "TypeOfMeasurement", "TypeOfSample", "InstrumentRange", "EURange", "ValuePrecision", "Definition", "SignalTag", "RelativeUncertainty", "AbsoluteUncertainty", "Timestamp", "Index", "MeasurementPeriod", "InternalUpdateInterval" ],
               "properties": {
                 "EngineeringUnits": {
                   "title": "EUInformation",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -2012,7 +2012,7 @@
                 "InstrumentRange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -2030,7 +2030,7 @@
                 "EURange": {
                   "title": "Range",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=884",
+                  "dov:typeRef": "org.opcfoundation.UA.Range",
                   "required": [ "Low", "High" ],
                   "properties": {
                     "Low": {
@@ -2099,7 +2099,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6165",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "DeleteAllStoredRecordsSuccessfull" ],
           "properties": {
             "DeleteAllStoredRecordsSuccessfull": {
@@ -2119,7 +2119,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6172",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromIndex", "ToIndex" ],
           "properties": {
             "FromIndex": {
@@ -2146,7 +2146,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6168",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -2171,7 +2171,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6176",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {
@@ -2193,7 +2193,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WMTP/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6180",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FromTimestamp", "ToTimestamp" ],
           "properties": {
             "FromTimestamp": {
@@ -2208,7 +2208,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WMTP/;i=6181",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "NumberOfStoredRecords" ],
           "properties": {
             "NumberOfStoredRecords": {

--- a/wot-codegen/opc-output-simple/Weihenstephan.TM.json
+++ b/wot-codegen/opc-output-simple/Weihenstephan.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -35,7 +35,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSBaseObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSBaseObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -62,7 +62,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSAlarmType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSAlarmType",
     "dov:isComposite": true,
     "links": [
       {
@@ -89,7 +89,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSWarningType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSWarningType",
     "dov:isComposite": true,
     "links": [
       {
@@ -116,7 +116,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSBaseStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSBaseStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -143,7 +143,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSExecuteStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSExecuteStateMachineType",
     "dov:isComposite": true,
     "links": [
       {
@@ -170,7 +170,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSHeldStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSHeldStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Weihenstephan_WSSuspendedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Weihenstephan/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Weihenstephan.WSSuspendedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/WireHarness.TM.json
+++ b/wot-codegen/opc-output-simple/WireHarness.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_ArticleSpecManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.ArticleSpecManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -40,14 +40,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArticleSpec" ],
           "properties": {
             "ArticleSpec": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -85,7 +85,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -111,7 +111,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -133,7 +133,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -178,14 +178,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "ArticleSpec" ],
           "properties": {
             "ArticleSpec": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -223,7 +223,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -249,7 +249,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -271,7 +271,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -321,7 +321,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -359,7 +359,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -385,7 +385,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -407,7 +407,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -462,7 +462,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -500,7 +500,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -526,7 +526,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -548,7 +548,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -599,7 +599,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_ProductFinishedEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.ProductFinishedEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -611,7 +611,7 @@
     "schemaDefinitions": {
       "JobResult": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobResult",
         "const": {
           "Unknown": 0,
           "Successful": 1,
@@ -777,7 +777,7 @@
       "State": {
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "title": "JobResult",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Machinery/Jobs/;i=3006",
+        "dov:typeRef": "org.opcfoundation.UA.Machinery.Jobs.JobResult",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -808,7 +808,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_RunCompleteEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.RunCompleteEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -977,7 +977,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessMachineIdentificationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessMachineIdentificationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1033,7 +1033,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_PartManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.PartManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1065,14 +1065,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Part" ],
           "properties": {
             "Part": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1110,7 +1110,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1136,7 +1136,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1158,7 +1158,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1203,7 +1203,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6028",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "TypeNodeId" ],
           "properties": {
             "TypeNodeId": {
@@ -1213,7 +1213,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6034",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Parts" ],
           "properties": {
             "Parts": {
@@ -1222,7 +1222,7 @@
                 "title": "ISA95MaterialDataType",
                 "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                 "properties": {
                   "MaterialClassID": {
                     "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1260,7 +1260,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1286,7 +1286,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -1308,7 +1308,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -1354,14 +1354,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/WireHarness/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "Part" ],
           "properties": {
             "Part": {
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1399,7 +1399,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1425,7 +1425,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1447,7 +1447,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1497,7 +1497,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1535,7 +1535,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1561,7 +1561,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1583,7 +1583,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1635,7 +1635,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1673,7 +1673,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1699,7 +1699,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1721,7 +1721,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1773,7 +1773,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1811,7 +1811,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1837,7 +1837,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1859,7 +1859,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -1911,7 +1911,7 @@
           "title": "ISA95MaterialDataType",
           "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
           "properties": {
             "MaterialClassID": {
               "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1949,7 +1949,7 @@
               "title": "EUInformation",
               "description": "The Unit Of Measure of the quantity",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
               "properties": {
                 "NamespaceUri": {
@@ -1975,7 +1975,7 @@
                 "title": "ISA95PropertyDataType",
                 "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -1997,7 +1997,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2052,7 +2052,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2090,7 +2090,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2116,7 +2116,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2138,7 +2138,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2186,7 +2186,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2224,7 +2224,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2250,7 +2250,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2272,7 +2272,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2320,7 +2320,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2358,7 +2358,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2384,7 +2384,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2406,7 +2406,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2454,7 +2454,7 @@
             "title": "ISA95MaterialDataType",
             "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
             "properties": {
               "MaterialClassID": {
                 "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2492,7 +2492,7 @@
                 "title": "EUInformation",
                 "description": "The Unit Of Measure of the quantity",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                 "properties": {
                   "NamespaceUri": {
@@ -2518,7 +2518,7 @@
                   "title": "ISA95PropertyDataType",
                   "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -2540,7 +2540,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -2591,7 +2591,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessJobOrderReceiverSubStatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessJobOrderReceiverSubStatesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -2607,7 +2607,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6021",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2625,7 +2625,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6024",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2648,7 +2648,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6018",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2666,7 +2666,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6020",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2689,7 +2689,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6101",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2707,7 +2707,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6102",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2730,7 +2730,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6103",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2748,7 +2748,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6104",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2771,7 +2771,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6025",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2789,7 +2789,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6100",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2812,7 +2812,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6105",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -2830,7 +2830,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6106",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -2853,14 +2853,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6107",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -2881,7 +2881,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -2899,7 +2899,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2921,7 +2921,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2976,7 +2976,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -2998,7 +2998,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3034,7 +3034,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3061,7 +3061,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3087,7 +3087,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3109,7 +3109,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3148,7 +3148,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3175,7 +3175,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3201,7 +3201,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3223,7 +3223,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3262,7 +3262,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -3289,7 +3289,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3315,7 +3315,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3337,7 +3337,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3376,7 +3376,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3414,7 +3414,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -3440,7 +3440,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -3462,7 +3462,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -3507,7 +3507,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=6108",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -3541,7 +3541,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WireHarness_WireHarnessMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WireHarness/;i=1000",
+    "dov:typeRef": "org.opcfoundation.UA.WireHarness.WireHarnessMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/WoT-Con.TM.json
+++ b/wot-codegen/opc-output-simple/WoT-Con.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetConnectionManagementType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=1",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetConnectionManagementType",
     "links": [
       {
         "rel": "tm:extends",
@@ -36,7 +36,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=76",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetEndpoint" ],
           "properties": {
             "AssetEndpoint": {
@@ -46,7 +46,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=77",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "Success", "Status" ],
           "properties": {
             "Success": {
@@ -69,7 +69,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=27",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetName" ],
           "properties": {
             "AssetName": {
@@ -79,7 +79,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=28",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -99,7 +99,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=50",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetName", "AssetEndpoint" ],
           "properties": {
             "AssetName": {
@@ -112,7 +112,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=170",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -132,7 +132,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=30",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "AssetId" ],
           "properties": {
             "AssetId": {
@@ -152,7 +152,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=48",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "AssetEndpoints" ],
           "properties": {
             "AssetEndpoints": {
@@ -201,7 +201,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetConfigurationType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=105",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetConfigurationType",
     "links": [
       {
         "rel": "tm:extends",
@@ -260,7 +260,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_IWoTAssetType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=42",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.IWoTAssetType",
     "links": [
       {
         "rel": "tm:extends",
@@ -311,7 +311,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "WoT_Con_WoTAssetFileType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=110",
+    "dov:typeRef": "org.opcfoundation.UA.WoT-Con.WoTAssetFileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -326,7 +326,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/WoT-Con/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/WoT-Con/;i=112",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "FileHandle" ],
           "properties": {
             "FileHandle": {

--- a/wot-codegen/opc-output-simple/Woodworking.TM.json
+++ b/wot-codegen/opc-output-simple/Woodworking.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwAlarmConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwAlarmConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -20,7 +20,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -76,14 +76,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -196,7 +196,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -293,7 +293,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwAcknowledgeableConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwAcknowledgeableConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -305,7 +305,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -361,14 +361,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -481,7 +481,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -578,7 +578,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwConditionType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwConditionType",
     "dov:isEvent": true,
     "links": [
       {
@@ -590,7 +590,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -646,14 +646,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -766,7 +766,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -863,7 +863,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwBaseEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=13",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwBaseEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -875,7 +875,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -931,14 +931,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -1051,7 +1051,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1148,7 +1148,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwBaseStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=6",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwBaseStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1192,7 +1192,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwEventMessageType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwEventMessageType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1203,7 +1203,7 @@
     "schemaDefinitions": {
       "WwEventCategoryEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "const": {
           "OTHER": 0,
           "DIAGNOSTIC": 1,
@@ -1259,14 +1259,14 @@
           "title": "WwMessageArgumentDataType",
           "description": "The WwArgumentDataType definition extends the argument structure with an argument value.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3003",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentDataType",
           "required": [ "Value" ],
           "properties": {
             "Value": {
               "title": "WwMessageArgumentValueDataType",
               "description": "The WwArgumentValueDataType definition defines the possible types of an argument value.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3002",
+              "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMessageArgumentValueDataType",
               "properties": {
                 "Array": {
                   "description": "The content of the value as an array of the own type",
@@ -1379,7 +1379,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwEventCategoryEnumeration",
         "description": "The EventCategory Variable provides the category of the event.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=3004",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventCategoryEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -1476,7 +1476,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwStateType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=8",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwStateType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1514,7 +1514,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwSubUnitsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=7",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwSubUnitsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -1546,7 +1546,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitFlagsType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=4",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitFlagsType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2284,7 +2284,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitOverviewType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=5",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitOverviewType",
     "links": [
       {
         "rel": "tm:extends",
@@ -2295,7 +2295,7 @@
     "schemaDefinitions": {
       "WwUnitModeEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
         "const": {
           "OTHER": 0,
           "AUTOMATIC": 1,
@@ -2334,7 +2334,7 @@
       },
       "WwUnitStateEnumeration": {
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
         "const": {
           "OFFLINE": 0,
           "STANDBY": 1,
@@ -2386,7 +2386,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwUnitModeEnumeration",
         "description": "The CurrentMode Variable provides the generalized mode of the component.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2403,7 +2403,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/Woodworking/",
         "title": "WwUnitStateEnumeration",
         "description": "The CurrentState Variable provides the generalized state of the component.",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+        "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
         "type": "integer",
         "minimum": -2147483648,
         "maximum": 2147483647,
@@ -2423,7 +2423,7 @@
         "data": {
           "title": "WwUnitModeEnumeration",
           "description": "The CurrentMode Variable provides the generalized mode of the component.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=20",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitModeEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2441,7 +2441,7 @@
         "data": {
           "title": "WwUnitStateEnumeration",
           "description": "The CurrentState Variable provides the generalized state of the component.",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=21",
+          "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwUnitStateEnumeration",
           "type": "integer",
           "minimum": -2147483648,
           "maximum": 2147483647
@@ -2465,7 +2465,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_IWwUnitValuesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.IWwUnitValuesType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3588,7 +3588,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwEventsDispatcherType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=15",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwEventsDispatcherType",
     "links": [
       {
         "rel": "tm:extends",
@@ -3614,7 +3614,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Woodworking_WwMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/Woodworking/;i=2",
+    "dov:typeRef": "org.opcfoundation.UA.Woodworking.WwMachineType",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/opc-output-simple/isa95-jobcontrol.TM.json
+++ b/wot-codegen/opc-output-simple/isa95-jobcontrol.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderStatusEventType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1006",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderStatusEventType",
     "dov:isEvent": true,
     "links": [
       {
@@ -39,7 +39,7 @@
         "title": "ISA95JobOrderDataType",
         "description": "Defines the information needed to schedule and execute a job.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
         "required": [ "JobOrderID" ],
         "properties": {
           "JobOrderID": {
@@ -60,7 +60,7 @@
               "title": "ISA95WorkMasterDataType",
               "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -78,7 +78,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -100,7 +100,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -155,7 +155,7 @@
               "title": "ISA95ParameterDataType",
               "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -177,7 +177,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the value",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -213,7 +213,7 @@
               "title": "ISA95PersonnelDataType",
               "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -240,7 +240,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -266,7 +266,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -288,7 +288,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -327,7 +327,7 @@
               "title": "ISA95EquipmentDataType",
               "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -354,7 +354,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -380,7 +380,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -402,7 +402,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -441,7 +441,7 @@
               "title": "ISA95PhysicalAssetDataType",
               "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -468,7 +468,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -494,7 +494,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -516,7 +516,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -555,7 +555,7 @@
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -593,7 +593,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -619,7 +619,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -641,7 +641,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -693,7 +693,7 @@
         "title": "ISA95JobResponseDataType",
         "description": "Defines the information needed to schedule and execute a job.",
         "type": "object",
-        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
         "required": [ "JobResponseID", "JobOrderID", "JobState" ],
         "properties": {
           "JobResponseID": {
@@ -725,14 +725,14 @@
               "title": "ISA95StateDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
               "required": [ "BrowsePath", "StateText", "StateNumber" ],
               "properties": {
                 "BrowsePath": {
                   "title": "RelativePath",
                   "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                  "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                   "required": [ "Elements" ],
                   "properties": {
                     "Elements": {
@@ -740,7 +740,7 @@
                       "items": {
                         "title": "RelativePathElement",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                         "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                         "properties": {
                           "ReferenceTypeId": {
@@ -780,7 +780,7 @@
               "title": "ISA95ParameterDataType",
               "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
               "required": [ "ID", "Value" ],
               "properties": {
                 "ID": {
@@ -802,7 +802,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the value",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -838,7 +838,7 @@
               "title": "ISA95PersonnelDataType",
               "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -865,7 +865,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -891,7 +891,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -913,7 +913,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -952,7 +952,7 @@
               "title": "ISA95EquipmentDataType",
               "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -979,7 +979,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1005,7 +1005,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1027,7 +1027,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1066,7 +1066,7 @@
               "title": "ISA95PhysicalAssetDataType",
               "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
               "required": [ "ID" ],
               "properties": {
                 "ID": {
@@ -1093,7 +1093,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1119,7 +1119,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1141,7 +1141,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1180,7 +1180,7 @@
               "title": "ISA95MaterialDataType",
               "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
               "properties": {
                 "MaterialClassID": {
                   "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1218,7 +1218,7 @@
                   "title": "EUInformation",
                   "description": "The Unit Of Measure of the quantity",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                  "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                   "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                   "properties": {
                     "NamespaceUri": {
@@ -1244,7 +1244,7 @@
                     "title": "ISA95PropertyDataType",
                     "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1266,7 +1266,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1320,14 +1320,14 @@
           "title": "ISA95StateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
           "required": [ "BrowsePath", "StateText", "StateNumber" ],
           "properties": {
             "BrowsePath": {
               "title": "RelativePath",
               "description": "The browse path of substates. Shall be null when the top-level state is represented.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+              "dov:typeRef": "org.opcfoundation.UA.RelativePath",
               "required": [ "Elements" ],
               "properties": {
                 "Elements": {
@@ -1335,7 +1335,7 @@
                   "items": {
                     "title": "RelativePathElement",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                     "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                     "properties": {
                       "ReferenceTypeId": {
@@ -1394,7 +1394,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobResponseProviderObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1003",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseProviderObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -1427,7 +1427,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6042",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID" ],
           "properties": {
             "JobOrderID": {
@@ -1438,14 +1438,14 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6043",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponse", "ReturnStatus" ],
           "properties": {
             "JobResponse": {
               "title": "ISA95JobResponseDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
               "required": [ "JobResponseID", "JobOrderID", "JobState" ],
               "properties": {
                 "JobResponseID": {
@@ -1477,14 +1477,14 @@
                     "title": "ISA95StateDataType",
                     "description": "Defines the information needed to schedule and execute a job.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                     "required": [ "BrowsePath", "StateText", "StateNumber" ],
                     "properties": {
                       "BrowsePath": {
                         "title": "RelativePath",
                         "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                         "required": [ "Elements" ],
                         "properties": {
                           "Elements": {
@@ -1492,7 +1492,7 @@
                             "items": {
                               "title": "RelativePathElement",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                              "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                               "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                               "properties": {
                                 "ReferenceTypeId": {
@@ -1532,7 +1532,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -1554,7 +1554,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1590,7 +1590,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1617,7 +1617,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1643,7 +1643,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1665,7 +1665,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1704,7 +1704,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1731,7 +1731,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1757,7 +1757,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1779,7 +1779,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1818,7 +1818,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -1845,7 +1845,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1871,7 +1871,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -1893,7 +1893,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -1932,7 +1932,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -1970,7 +1970,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -1996,7 +1996,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -2018,7 +2018,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -2072,7 +2072,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6016",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderState" ],
           "properties": {
             "JobOrderState": {
@@ -2082,14 +2082,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -2097,7 +2097,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -2134,7 +2134,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6017",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "JobResponses", "ReturnStatus" ],
           "properties": {
             "JobResponses": {
@@ -2144,7 +2144,7 @@
                 "title": "ISA95JobResponseDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
                 "required": [ "JobResponseID", "JobOrderID", "JobState" ],
                 "properties": {
                   "JobResponseID": {
@@ -2176,14 +2176,14 @@
                       "title": "ISA95StateDataType",
                       "description": "Defines the information needed to schedule and execute a job.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                       "required": [ "BrowsePath", "StateText", "StateNumber" ],
                       "properties": {
                         "BrowsePath": {
                           "title": "RelativePath",
                           "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                           "required": [ "Elements" ],
                           "properties": {
                             "Elements": {
@@ -2191,7 +2191,7 @@
                               "items": {
                                 "title": "RelativePathElement",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                                "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                                 "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                                 "properties": {
                                   "ReferenceTypeId": {
@@ -2231,7 +2231,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -2253,7 +2253,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2289,7 +2289,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2316,7 +2316,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2342,7 +2342,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2364,7 +2364,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2403,7 +2403,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2430,7 +2430,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2456,7 +2456,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2478,7 +2478,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2517,7 +2517,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -2544,7 +2544,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2570,7 +2570,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2592,7 +2592,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2631,7 +2631,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -2669,7 +2669,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -2695,7 +2695,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -2717,7 +2717,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -2777,7 +2777,7 @@
           "title": "ISA95JobResponseDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
           "required": [ "JobResponseID", "JobOrderID", "JobState" ],
           "properties": {
             "JobResponseID": {
@@ -2809,14 +2809,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -2824,7 +2824,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -2864,7 +2864,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -2886,7 +2886,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2922,7 +2922,7 @@
                 "title": "ISA95PersonnelDataType",
                 "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -2949,7 +2949,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -2975,7 +2975,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -2997,7 +2997,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3036,7 +3036,7 @@
                 "title": "ISA95EquipmentDataType",
                 "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -3063,7 +3063,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3089,7 +3089,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3111,7 +3111,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3150,7 +3150,7 @@
                 "title": "ISA95PhysicalAssetDataType",
                 "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                 "required": [ "ID" ],
                 "properties": {
                   "ID": {
@@ -3177,7 +3177,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3203,7 +3203,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3225,7 +3225,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3264,7 +3264,7 @@
                 "title": "ISA95MaterialDataType",
                 "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                 "properties": {
                   "MaterialClassID": {
                     "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3302,7 +3302,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the quantity",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -3328,7 +3328,7 @@
                       "title": "ISA95PropertyDataType",
                       "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -3350,7 +3350,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -3408,7 +3408,7 @@
             "title": "ISA95JobResponseDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
             "required": [ "JobResponseID", "JobOrderID", "JobState" ],
             "properties": {
               "JobResponseID": {
@@ -3440,14 +3440,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -3455,7 +3455,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -3495,7 +3495,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -3517,7 +3517,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3553,7 +3553,7 @@
                   "title": "ISA95PersonnelDataType",
                   "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3580,7 +3580,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3606,7 +3606,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3628,7 +3628,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3667,7 +3667,7 @@
                   "title": "ISA95EquipmentDataType",
                   "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3694,7 +3694,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3720,7 +3720,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3742,7 +3742,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3781,7 +3781,7 @@
                   "title": "ISA95PhysicalAssetDataType",
                   "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                   "required": [ "ID" ],
                   "properties": {
                     "ID": {
@@ -3808,7 +3808,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3834,7 +3834,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3856,7 +3856,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -3895,7 +3895,7 @@
                   "title": "ISA95MaterialDataType",
                   "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                   "properties": {
                     "MaterialClassID": {
                       "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -3933,7 +3933,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the quantity",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -3959,7 +3959,7 @@
                         "title": "ISA95PropertyDataType",
                         "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                        "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                         "required": [ "ID", "Value" ],
                         "properties": {
                           "ID": {
@@ -3981,7 +3981,7 @@
                             "title": "EUInformation",
                             "description": "The Unit Of Measure of the value",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                            "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                             "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                             "properties": {
                               "NamespaceUri": {
@@ -4035,7 +4035,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobResponseReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1004",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4051,14 +4051,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6044",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobResponse" ],
           "properties": {
             "JobResponse": {
               "title": "ISA95JobResponseDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3013",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobResponseDataType",
               "required": [ "JobResponseID", "JobOrderID", "JobState" ],
               "properties": {
                 "JobResponseID": {
@@ -4090,14 +4090,14 @@
                     "title": "ISA95StateDataType",
                     "description": "Defines the information needed to schedule and execute a job.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                     "required": [ "BrowsePath", "StateText", "StateNumber" ],
                     "properties": {
                       "BrowsePath": {
                         "title": "RelativePath",
                         "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                        "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                         "required": [ "Elements" ],
                         "properties": {
                           "Elements": {
@@ -4105,7 +4105,7 @@
                             "items": {
                               "title": "RelativePathElement",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                              "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                               "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                               "properties": {
                                 "ReferenceTypeId": {
@@ -4145,7 +4145,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -4167,7 +4167,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4203,7 +4203,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4230,7 +4230,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4256,7 +4256,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4278,7 +4278,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4317,7 +4317,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4344,7 +4344,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4370,7 +4370,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4392,7 +4392,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4431,7 +4431,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -4458,7 +4458,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4484,7 +4484,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4506,7 +4506,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4545,7 +4545,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -4583,7 +4583,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -4609,7 +4609,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -4631,7 +4631,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -4669,7 +4669,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6045",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4703,7 +4703,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95EndedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1005",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EndedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4747,7 +4747,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95InterruptedStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1007",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95InterruptedStateMachineType",
     "links": [
       {
         "rel": "tm:extends",
@@ -4797,7 +4797,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverObjectType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1002",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverObjectType",
     "dov:isComposite": true,
     "links": [
       {
@@ -4939,7 +4939,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6063",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4957,7 +4957,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6064",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -4980,7 +4980,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6065",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -4998,7 +4998,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6066",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5021,7 +5021,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6067",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5039,7 +5039,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6068",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5062,7 +5062,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6057",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5080,7 +5080,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6058",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5103,7 +5103,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6059",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5121,7 +5121,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6060",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5144,7 +5144,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6069",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5162,7 +5162,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6070",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5185,7 +5185,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6053",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5203,7 +5203,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6054",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5226,7 +5226,7 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6055",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrderID", "Comment" ],
           "properties": {
             "JobOrderID": {
@@ -5244,7 +5244,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6056",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5267,14 +5267,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6040",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5295,7 +5295,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5313,7 +5313,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5335,7 +5335,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5390,7 +5390,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -5412,7 +5412,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5448,7 +5448,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5475,7 +5475,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5501,7 +5501,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5523,7 +5523,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5562,7 +5562,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5589,7 +5589,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5615,7 +5615,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5637,7 +5637,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5676,7 +5676,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5703,7 +5703,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5729,7 +5729,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5751,7 +5751,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5790,7 +5790,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -5828,7 +5828,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -5854,7 +5854,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -5876,7 +5876,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -5921,7 +5921,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6041",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -5944,14 +5944,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6051",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -5972,7 +5972,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -5990,7 +5990,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6012,7 +6012,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6067,7 +6067,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6089,7 +6089,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6125,7 +6125,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6152,7 +6152,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6178,7 +6178,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6200,7 +6200,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6239,7 +6239,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6266,7 +6266,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6292,7 +6292,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6314,7 +6314,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6353,7 +6353,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6380,7 +6380,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6406,7 +6406,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6428,7 +6428,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6467,7 +6467,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -6505,7 +6505,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6531,7 +6531,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6553,7 +6553,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6598,7 +6598,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6052",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -6621,14 +6621,14 @@
         "dov:namespace": "http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/",
         "input": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6061",
+          "dov:typeRef": "org.opcfoundation.UA.InputArguments",
           "required": [ "JobOrder", "Comment" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -6649,7 +6649,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6667,7 +6667,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6689,7 +6689,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6744,7 +6744,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -6766,7 +6766,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6802,7 +6802,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6829,7 +6829,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6855,7 +6855,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6877,7 +6877,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -6916,7 +6916,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -6943,7 +6943,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -6969,7 +6969,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -6991,7 +6991,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7030,7 +7030,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7057,7 +7057,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7083,7 +7083,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7105,7 +7105,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7144,7 +7144,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7182,7 +7182,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7208,7 +7208,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7230,7 +7230,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7275,7 +7275,7 @@
         },
         "output": {
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=6062",
+          "dov:typeRef": "org.opcfoundation.UA.OutputArguments",
           "required": [ "ReturnStatus" ],
           "properties": {
             "ReturnStatus": {
@@ -7320,14 +7320,14 @@
           "title": "ISA95JobOrderAndStateDataType",
           "description": "Defines the information needed to schedule and execute a job.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
           "required": [ "JobOrder", "State" ],
           "properties": {
             "JobOrder": {
               "title": "ISA95JobOrderDataType",
               "description": "Defines the information needed to schedule and execute a job.",
               "type": "object",
-              "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+              "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
               "required": [ "JobOrderID" ],
               "properties": {
                 "JobOrderID": {
@@ -7348,7 +7348,7 @@
                     "title": "ISA95WorkMasterDataType",
                     "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7366,7 +7366,7 @@
                           "title": "ISA95ParameterDataType",
                           "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7388,7 +7388,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7443,7 +7443,7 @@
                     "title": "ISA95ParameterDataType",
                     "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                     "required": [ "ID", "Value" ],
                     "properties": {
                       "ID": {
@@ -7465,7 +7465,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the value",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7501,7 +7501,7 @@
                     "title": "ISA95PersonnelDataType",
                     "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7528,7 +7528,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7554,7 +7554,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7576,7 +7576,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7615,7 +7615,7 @@
                     "title": "ISA95EquipmentDataType",
                     "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7642,7 +7642,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7668,7 +7668,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7690,7 +7690,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7729,7 +7729,7 @@
                     "title": "ISA95PhysicalAssetDataType",
                     "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                     "required": [ "ID" ],
                     "properties": {
                       "ID": {
@@ -7756,7 +7756,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7782,7 +7782,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7804,7 +7804,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7843,7 +7843,7 @@
                     "title": "ISA95MaterialDataType",
                     "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                     "properties": {
                       "MaterialClassID": {
                         "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -7881,7 +7881,7 @@
                         "title": "EUInformation",
                         "description": "The Unit Of Measure of the quantity",
                         "type": "object",
-                        "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                        "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                         "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                         "properties": {
                           "NamespaceUri": {
@@ -7907,7 +7907,7 @@
                           "title": "ISA95PropertyDataType",
                           "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                           "required": [ "ID", "Value" ],
                           "properties": {
                             "ID": {
@@ -7929,7 +7929,7 @@
                               "title": "EUInformation",
                               "description": "The Unit Of Measure of the value",
                               "type": "object",
-                              "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                              "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                               "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                               "properties": {
                                 "NamespaceUri": {
@@ -7970,14 +7970,14 @@
                 "title": "ISA95StateDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                 "required": [ "BrowsePath", "StateText", "StateNumber" ],
                 "properties": {
                   "BrowsePath": {
                     "title": "RelativePath",
                     "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                    "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                     "required": [ "Elements" ],
                     "properties": {
                       "Elements": {
@@ -7985,7 +7985,7 @@
                         "items": {
                           "title": "RelativePathElement",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                          "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                           "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                           "properties": {
                             "ReferenceTypeId": {
@@ -8115,7 +8115,7 @@
           "title": "ISA95WorkMasterDataType",
           "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
           "type": "object",
-          "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+          "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
           "required": [ "ID" ],
           "properties": {
             "ID": {
@@ -8133,7 +8133,7 @@
                 "title": "ISA95ParameterDataType",
                 "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                 "required": [ "ID", "Value" ],
                 "properties": {
                   "ID": {
@@ -8155,7 +8155,7 @@
                     "title": "EUInformation",
                     "description": "The Unit Of Measure of the value",
                     "type": "object",
-                    "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                    "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                     "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                     "properties": {
                       "NamespaceUri": {
@@ -8223,14 +8223,14 @@
             "title": "ISA95JobOrderAndStateDataType",
             "description": "Defines the information needed to schedule and execute a job.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3015",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderAndStateDataType",
             "required": [ "JobOrder", "State" ],
             "properties": {
               "JobOrder": {
                 "title": "ISA95JobOrderDataType",
                 "description": "Defines the information needed to schedule and execute a job.",
                 "type": "object",
-                "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3008",
+                "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderDataType",
                 "required": [ "JobOrderID" ],
                 "properties": {
                   "JobOrderID": {
@@ -8251,7 +8251,7 @@
                       "title": "ISA95WorkMasterDataType",
                       "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8269,7 +8269,7 @@
                             "title": "ISA95ParameterDataType",
                             "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8291,7 +8291,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8346,7 +8346,7 @@
                       "title": "ISA95ParameterDataType",
                       "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                       "required": [ "ID", "Value" ],
                       "properties": {
                         "ID": {
@@ -8368,7 +8368,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the value",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8404,7 +8404,7 @@
                       "title": "ISA95PersonnelDataType",
                       "description": "Defines a personnel resource or a person, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3011",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PersonnelDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8431,7 +8431,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8457,7 +8457,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8479,7 +8479,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8518,7 +8518,7 @@
                       "title": "ISA95EquipmentDataType",
                       "description": "Defines an equipment resource or a piece of equipment, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3005",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95EquipmentDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8545,7 +8545,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8571,7 +8571,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8593,7 +8593,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8632,7 +8632,7 @@
                       "title": "ISA95PhysicalAssetDataType",
                       "description": "Defines a physical asset, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3012",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PhysicalAssetDataType",
                       "required": [ "ID" ],
                       "properties": {
                         "ID": {
@@ -8659,7 +8659,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8685,7 +8685,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8707,7 +8707,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8746,7 +8746,7 @@
                       "title": "ISA95MaterialDataType",
                       "description": "Defines a material resource, a quantity, an optional description, and an optional collection of properties.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3010",
+                      "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95MaterialDataType",
                       "properties": {
                         "MaterialClassID": {
                           "description": "An identification of the resource, or null if the Material Class is not used to identify the material.",
@@ -8784,7 +8784,7 @@
                           "title": "EUInformation",
                           "description": "The Unit Of Measure of the quantity",
                           "type": "object",
-                          "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                          "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                           "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                           "properties": {
                             "NamespaceUri": {
@@ -8810,7 +8810,7 @@
                             "title": "ISA95PropertyDataType",
                             "description": "A subtype of OPC UA Structure that defines two linked data items: an ID, which is a unique identifier for a property within the scope of the associated resource, and the value, which is the data for the property.",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3002",
+                            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PropertyDataType",
                             "required": [ "ID", "Value" ],
                             "properties": {
                               "ID": {
@@ -8832,7 +8832,7 @@
                                 "title": "EUInformation",
                                 "description": "The Unit Of Measure of the value",
                                 "type": "object",
-                                "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                                "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                                 "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                                 "properties": {
                                   "NamespaceUri": {
@@ -8873,14 +8873,14 @@
                   "title": "ISA95StateDataType",
                   "description": "Defines the information needed to schedule and execute a job.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3006",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95StateDataType",
                   "required": [ "BrowsePath", "StateText", "StateNumber" ],
                   "properties": {
                     "BrowsePath": {
                       "title": "RelativePath",
                       "description": "The browse path of substates. Shall be null when the top-level state is represented.",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=540",
+                      "dov:typeRef": "org.opcfoundation.UA.RelativePath",
                       "required": [ "Elements" ],
                       "properties": {
                         "Elements": {
@@ -8888,7 +8888,7 @@
                           "items": {
                             "title": "RelativePathElement",
                             "type": "object",
-                            "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=537",
+                            "dov:typeRef": "org.opcfoundation.UA.RelativePathElement",
                             "required": [ "ReferenceTypeId", "IsInverse", "IncludeSubtypes", "TargetName" ],
                             "properties": {
                               "ReferenceTypeId": {
@@ -9009,7 +9009,7 @@
             "title": "ISA95WorkMasterDataType",
             "description": "Defines a Work Master ID and the defined parameters for the Work Master.",
             "type": "object",
-            "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3007",
+            "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95WorkMasterDataType",
             "required": [ "ID" ],
             "properties": {
               "ID": {
@@ -9027,7 +9027,7 @@
                   "title": "ISA95ParameterDataType",
                   "description": "A subtype of OPC UA Structure that defines three linked data items: the ID, which is a unique identifier for a property, the value, which is the data that is identified, and an optional description of the parameter.",
                   "type": "object",
-                  "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=3003",
+                  "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95ParameterDataType",
                   "required": [ "ID", "Value" ],
                   "properties": {
                     "ID": {
@@ -9049,7 +9049,7 @@
                       "title": "EUInformation",
                       "description": "The Unit Of Measure of the value",
                       "type": "object",
-                      "dov:typeRef": "nsu=http://opcfoundation.org/UA/;i=887",
+                      "dov:typeRef": "org.opcfoundation.UA.EUInformation",
                       "required": [ "NamespaceUri", "UnitId", "DisplayName", "Description" ],
                       "properties": {
                         "NamespaceUri": {
@@ -9100,7 +9100,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95JobOrderReceiverSubStatesType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1008",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95JobOrderReceiverSubStatesType",
     "dov:isComposite": true,
     "links": [
       {
@@ -9265,7 +9265,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Isa95_jobcontrol_ISA95PrepareStateMachineType",
-    "dov:typeRef": "nsu=http://opcfoundation.org/UA/ISA95-JOBCONTROL_V2/;i=1001",
+    "dov:typeRef": "org.opcfoundation.UA.ISA95-JOBCONTROL_V2.ISA95PrepareStateMachineType",
     "links": [
       {
         "rel": "tm:extends",

--- a/wot-codegen/opc-output-simple/sercos.TM.json
+++ b/wot-codegen/opc-output-simple/sercos.TM.json
@@ -8,7 +8,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_FunctionalGroupType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6012",
+    "dov:typeRef": "org.sercos.UA.FunctionalGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -34,7 +34,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosProfileType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1002",
+    "dov:typeRef": "org.sercos.UA.SercosProfileType",
     "links": [
       {
         "rel": "tm:extends",
@@ -60,7 +60,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosClassType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1003",
+    "dov:typeRef": "org.sercos.UA.SercosClassType",
     "links": [
       {
         "rel": "tm:extends",
@@ -86,7 +86,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosFunctionGroupType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1004",
+    "dov:typeRef": "org.sercos.UA.SercosFunctionGroupType",
     "links": [
       {
         "rel": "tm:extends",
@@ -112,7 +112,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_SercosDeviceType",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=1001",
+    "dov:typeRef": "org.sercos.UA.SercosDeviceType",
     "dov:isComposite": true,
     "links": [
       {
@@ -163,7 +163,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_ProfileSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6075",
+    "dov:typeRef": "org.sercos.UA.ProfileSet",
     "dov:isComposite": true,
     "links": [
       {
@@ -196,7 +196,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_ClassSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6077",
+    "dov:typeRef": "org.sercos.UA.ClassSet",
     "dov:isComposite": true,
     "links": [
       {
@@ -229,7 +229,7 @@
     ],
     "@type": "tm:ThingModel",
     "title": "Sercos_FunctionGroupSet",
-    "dov:typeRef": "nsu=http://sercos.org/UA/;i=6079",
+    "dov:typeRef": "org.sercos.UA.FunctionGroupSet",
     "dov:isComposite": true,
     "links": [
       {

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaNode.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaNode.cs
@@ -67,6 +67,20 @@ namespace Azure.Iot.Operations.Opc2WotLib
         public OpcUaNode GetReferencedOpcUaNode(OpcUaNodeId nodeId) =>
             NsUriToNsInfoMap[this.DefiningModel.NamespaceUris[nodeId.NsIndex]].NodeIndexToNodeMap[nodeId.NodeIndex];
 
+        public string GetTypeRef()
+        {
+            if (this.BrowseNamespace == null)
+            {
+                return $"org.opcfoundation.UA.{this.EffectiveName}";
+            }
+
+            Uri uri = new Uri(this.BrowseNamespace);
+            string reversedHost = string.Join('.', uri.Host.Split('.').Reverse());
+            string path = uri.AbsolutePath.Trim('/').Replace('/', '.');
+            string prefix = string.IsNullOrEmpty(path) ? reversedHost : $"{reversedHost}.{path}";
+            return $"{prefix}.{this.EffectiveName}";
+        }
+
         protected Dictionary<string, OpcUaNamespaceInfo> NsUriToNsInfoMap { get; }
     }
 }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataSchemaObject.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataSchemaObject.cs
@@ -19,7 +19,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.description = description;
             this.schemaName = schemaName;
-            this.typeRef = $"nsu={containingNode.NodeIdNamespace};i={containingNode.NodeId.NodeIndex}";
+            this.typeRef = containingNode.GetTypeRef();
 
             fieldDataSchemas =  fields.ToDictionary(
                 field => field.Key,

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataSchemaPrimitive.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataSchemaPrimitive.cs
@@ -47,7 +47,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.description = description;
             this.schemaName = schemaName;
-            this.typeRef = dataTypeNode != null ? $"nsu={dataTypeNode.NodeIdNamespace};i={dataTypeNode.NodeId.NodeIndex}" : null;
+            this.typeRef = dataTypeNode != null ? dataTypeNode.GetTypeRef() : null;
             this.kvpList = NodeIndexToKvpListMap[dataTypeNodeId.NodeIndex];
         }
     }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
@@ -30,7 +30,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName(uaObjectType.DiscriminatedEffectiveName, specName);
-            this.typeRef = $"nsu={uaObjectType.NodeIdNamespace};i={uaObjectType.NodeId.NodeIndex}";
+            this.typeRef = uaObjectType.GetTypeRef();
             this.isIntegrated = isIntegrated;
             this.inheritVars = inheritVars;
 

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.cs
@@ -71,10 +71,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
  ix1 = 1; foreach (OpcUaDataTypeEnum dataTypeEnum in this.dataTypeEnums) { 
             this.Write("    \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(dataTypeEnum.EffectiveName));
-            this.Write("\": {\r\n      \"type\": \"object\",\r\n      \"dov:typeRef\": \"nsu=");
-            this.Write(this.ToStringHelper.ToStringWithCulture(dataTypeEnum.NodeIdNamespace));
-            this.Write(";i=");
-            this.Write(this.ToStringHelper.ToStringWithCulture(dataTypeEnum.NodeId.NodeIndex));
+            this.Write("\": {\r\n      \"type\": \"object\",\r\n      \"dov:typeRef\": \"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(dataTypeEnum.GetTypeRef()));
             this.Write("\",\r\n      \"const\": {\r\n");
  int ix2 = 1; foreach (KeyValuePair<string, OpcUaEnumValue> enumValue in dataTypeEnum.EnumValues) { 
             this.Write("        \"");

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.tt
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.tt
@@ -46,7 +46,7 @@
 <# ix1 = 1; foreach (OpcUaDataTypeEnum dataTypeEnum in this.dataTypeEnums) { #>
     "<#=dataTypeEnum.EffectiveName#>": {
       "type": "object",
-      "dov:typeRef": "nsu=<#=dataTypeEnum.NodeIdNamespace#>;i=<#=dataTypeEnum.NodeId.NodeIndex#>",
+      "dov:typeRef": "<#=dataTypeEnum.GetTypeRef()#>",
       "const": {
 <# int ix2 = 1; foreach (KeyValuePair<string, OpcUaEnumValue> enumValue in dataTypeEnum.EnumValues) { #>
         "<#=enumValue.Value.SymbolicName ?? enumValue.Key#>": <#=enumValue.Value.Value#><#=ix2 < dataTypeEnum.EnumValues.Count ? "," : ""#>


### PR DESCRIPTION
This change is quite narrow.  In Thing Models converted from OPC UA models, this is a change from typeRef values such as:

```json
    "dov:typeRef": "nsu=http://opcfoundation.org/UA/AMB/;i=1005",
```

To:

```json
    "dov:typeRef": "org.opcfoundation.UA.AMB.CalibrationDueConditionClassType",
```
