### PR TITLE
feat(mqtt): disable Nagle's algorithm (TCP_NODELAY) on all TCP connections

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/aio/connection_settings.rs
+++ b/rust/azure_iot_operations_mqtt/src/aio/connection_settings.rs
@@ -69,6 +69,11 @@ pub struct MqttConnectionSettings {
     /// Path to a SAT file to be used for SAT auth
     #[builder(default = "None")]
     pub(crate) sat_file: Option<String>,
+    /// If true, disables Nagle's algorithm (sets TCP_NODELAY) on the socket.
+    /// This reduces latency for request/response protocols at the cost of
+    /// potentially lower throughput for bulk transfers. Defaults to `true`.
+    #[builder(default = "true")]
+    pub(crate) tcp_nodelay: bool,
 }
 
 impl MqttConnectionSettingsBuilder {

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
@@ -137,6 +137,11 @@ impl Default for ClientOptions {
 pub struct ConnectionTransportConfig {
     pub transport_type: ConnectionTransportType,
     pub timeout: Option<Duration>,
+    /// If true, disables Nagle's algorithm (sets TCP_NODELAY) on the socket.
+    /// This reduces latency for request/response protocols like MQTT at the
+    /// cost of potentially lower throughput for bulk transfers.
+    /// Defaults to `true`.
+    pub tcp_nodelay: bool,
 }
 
 /// The type of transport to use for the new connection.
@@ -642,6 +647,7 @@ impl ConnectHandle {
         let ConnectionTransportConfig {
             transport_type,
             timeout,
+            tcp_nodelay,
         } = transport_config;
         Ok(match transport_type {
             ConnectionTransportType::Tcp { hostname, port } => {
@@ -649,6 +655,7 @@ impl ConnectHandle {
                     timeout,
                     crate::azure_mqtt::io::tokio_tcp::connect(
                         (hostname, port),
+                        tcp_nodelay,
                         &self.reader_pool,
                         &self.writer_pool,
                     ),
@@ -666,6 +673,7 @@ impl ConnectHandle {
                     crate::azure_mqtt::io::tokio_tls::connect(
                         &hostname,
                         port,
+                        tcp_nodelay,
                         config,
                         &self.reader_pool,
                         &self.writer_pool,

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
@@ -20,14 +20,25 @@ use crate::azure_mqtt::io::{ReadableStream, Reader, WritableStream, Writer};
 // TODO: Also take max packet size and forward it to `Reader`.
 pub async fn connect<BP>(
     addr: impl ToSocketAddrs,
+    tcp_nodelay: bool,
     reader_pool: &BP,
     writer_pool: &BP,
 ) -> io::Result<(Reader<BP>, Writer<BP>)>
 where
     BP: BufferPool,
 {
-    let stream = TcpStream::connect(addr).await?;
+    let stream = connect_tcp(addr, tcp_nodelay).await?;
     Ok(connect_inner(stream, reader_pool, writer_pool))
+}
+
+/// Establish a TCP connection and apply socket options.
+pub(crate) async fn connect_tcp(
+    addr: impl ToSocketAddrs,
+    tcp_nodelay: bool,
+) -> io::Result<TcpStream> {
+    let stream = TcpStream::connect(addr).await?;
+    stream.set_nodelay(tcp_nodelay)?;
+    Ok(stream)
 }
 
 pub(crate) fn connect_inner<BP>(

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
@@ -43,6 +43,7 @@ use crate::azure_mqtt::opensslext::ssl::{ConnectionTrafficSecrets, ExtractedSecr
 pub async fn connect<BP>(
     hostname: &str,
     port: u16,
+    tcp_nodelay: bool,
     config: ConnectionTransportTlsConfig,
     reader_pool: &BP,
     writer_pool: &BP,
@@ -50,7 +51,7 @@ pub async fn connect<BP>(
 where
     BP: BufferPool,
 {
-    Ok(match connect_inner(hostname, port, config).await? {
+    Ok(match connect_inner(hostname, port, tcp_nodelay, config).await? {
         Either::Left(tcp_stream) => tokio_tcp::connect_inner(tcp_stream, reader_pool, writer_pool),
 
         Either::Right(ssl_stream) => {
@@ -69,6 +70,7 @@ where
 pub(crate) async fn connect_inner(
     hostname: &str,
     port: u16,
+    tcp_nodelay: bool,
     config: ConnectionTransportTlsConfig,
 ) -> io::Result<Either<TcpStream, SslStream<TcpStream>>> {
     /// We haven't attempted to create a TLS connection yet, so whether the kernel supports TLS or not
@@ -91,7 +93,7 @@ pub(crate) async fn connect_inner(
 
         let connector = connector.build();
 
-        let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        let tcp_stream = tokio_tcp::connect_tcp((hostname, port), tcp_nodelay).await?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -128,7 +130,7 @@ pub(crate) async fn connect_inner(
 
         let connector = connector.build();
 
-        let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        let tcp_stream = tokio_tcp::connect_tcp((hostname, port), tcp_nodelay).await?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -147,7 +149,7 @@ pub(crate) async fn connect_inner(
     } else {
         debug_assert_eq!(method, TLS_METHOD_USERSPACE);
 
-        let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        let tcp_stream = tokio_tcp::connect_tcp((hostname, port), tcp_nodelay).await?;
 
         let connector = connector.build().configure()?;
 

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
@@ -135,6 +135,7 @@ fn create_connection_transport_config(
     hostname: String,
     tcp_port: u16,
     timeout: Duration,
+    tcp_nodelay: bool,
 ) -> Result<ConnectionTransportConfig, ConnectionSettingsAdapterError> {
     let transport_type = if use_tls {
         let (client_cert, ca_trust_bundle) =
@@ -176,6 +177,7 @@ fn create_connection_transport_config(
     Ok(ConnectionTransportConfig {
         transport_type,
         timeout: Some(timeout),
+        tcp_nodelay,
     })
 }
 
@@ -195,6 +197,8 @@ pub struct AzureMqttConnectParameters {
     pub connect_properties: ConnectProperties,
     /// Connection timeout duration
     pub connection_timeout: Duration,
+    /// If true, disables Nagle's algorithm (sets TCP_NODELAY) on the socket.
+    pub tcp_nodelay: bool,
 
     /// properties used to create the `ConnectionTransportConfig` on demand
     ca_file: Option<String>,
@@ -235,6 +239,7 @@ impl AzureMqttConnectParameters {
                     outgoing_packets: outgoing_packets_tx,
                 },
                 timeout: Some(self.connection_timeout),
+                tcp_nodelay: self.tcp_nodelay,
             });
         }
 
@@ -247,6 +252,7 @@ impl AzureMqttConnectParameters {
             self.hostname.clone(),
             self.tcp_port,
             self.connection_timeout,
+            self.tcp_nodelay,
         )
     }
 }
@@ -327,6 +333,7 @@ impl MqttConnectionSettings {
             self.hostname.clone(),
             self.tcp_port,
             self.connection_timeout,
+            self.tcp_nodelay,
         )?;
 
         Ok((
@@ -346,6 +353,7 @@ impl MqttConnectionSettings {
                 tcp_port: self.tcp_port,
                 connect_properties,
                 connection_timeout: self.connection_timeout,
+                tcp_nodelay: self.tcp_nodelay,
                 #[cfg(feature = "test-utils")]
                 injected_packet_channels,
             },


### PR DESCRIPTION
## Summary

Add a new API to Set `TCP_NODELAY`. This allow customers to chose between lower latency/lower throughput or the opposite.

## Testing

This is a minimal change that calls a standard Tokio API. The `set_nodelay` call cannot fail on a connected socket under normal conditions.