### PR TITLE
add CLI option --target to enable non-envoy generation

### DIFF
--- a/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/TargetSdk.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/TargetSdk.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+namespace Azure.Iot.Operations.CodeGeneration
+{
+    public enum TargetSdk
+    {
+        Aio,
+        None,
+    }
+}

--- a/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/EnvoyGenerator.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/EnvoyGenerator.cs
@@ -15,6 +15,7 @@ namespace Azure.Iot.Operations.EnvoyGenerator
         public static List<GeneratedItem> GenerateEnvoys(
             IEnumerable<ParsedThing> parsedThings,
             List<SerializationFormat> serializationFormats,
+            TargetSdk targetSdk,
             TargetLanguage targetLanguage,
             string genNamespace,
             string commonNs,
@@ -25,7 +26,7 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             bool generateProject,
             bool defaultImpl)
         {
-            EnvoyTransformFactory envoyFactory = new(targetLanguage, new MultiCodeName(genNamespace), new MultiCodeName(commonNs), projectName, srcSubdir, defaultImpl);
+            EnvoyTransformFactory envoyFactory = new(targetSdk, targetLanguage, new MultiCodeName(genNamespace), new MultiCodeName(commonNs), projectName, srcSubdir, defaultImpl);
 
             Dictionary<string, IEnvoyTemplateTransform> transforms = new();
             Dictionary<string, ErrorSpec> errorSpecs = new();

--- a/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/EnvoyTransformFactory.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.EnvoyGenerator/EnvoyTransformFactory.cs
@@ -15,6 +15,7 @@ namespace Azure.Iot.Operations.EnvoyGenerator
 
     internal class EnvoyTransformFactory
     {
+        private readonly TargetSdk targetSdk;
         private readonly TargetLanguage targetLanguage;
         private readonly MultiCodeName genNamespace;
         private readonly MultiCodeName commonNs;
@@ -23,6 +24,7 @@ namespace Azure.Iot.Operations.EnvoyGenerator
         private readonly bool defaultImpl;
 
         internal EnvoyTransformFactory(
+            TargetSdk targetSdk,
             TargetLanguage targetLanguage,
             MultiCodeName genNamespace,
             MultiCodeName commonNs,
@@ -30,6 +32,7 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             string srcSubdir,
             bool defaultImpl)
         {
+            this.targetSdk = targetSdk;
             this.targetLanguage = targetLanguage;
             this.genNamespace = genNamespace;
             this.commonNs = commonNs;
@@ -119,6 +122,11 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             bool generateClient,
             bool generateServer)
         {
+            if (this.targetSdk == TargetSdk.None)
+            {
+                yield break;
+            }
+
             string serializerClassName = format.GetSerializerClassName();
             EmptyTypeName serializerEmptyType = format.GetEmptyTypeName();
 
@@ -272,6 +280,11 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             bool generateClient,
             bool generateServer)
         {
+            if (this.targetSdk == TargetSdk.None)
+            {
+                yield break;
+            }
+
             string readSerializerClassName = readFormat.GetSerializerClassName();
             EmptyTypeName readSerializerEmptyType = readFormat.GetEmptyTypeName();
             string writeSerializerClassName = writeFormat.GetSerializerClassName();
@@ -401,6 +414,11 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             bool generateClient,
             bool generateServer)
         {
+            if (this.targetSdk == TargetSdk.None)
+            {
+                yield break;
+            }
+
             string serializerClassName = format.GetSerializerClassName();
             EmptyTypeName serializerEmptyType = format.GetEmptyTypeName();
 
@@ -524,6 +542,11 @@ namespace Azure.Iot.Operations.EnvoyGenerator
             bool generateClient,
             bool generateServer)
         {
+            if (this.targetSdk == TargetSdk.None)
+            {
+                yield break;
+            }
+
             switch (targetLanguage)
             {
                 case TargetLanguage.CSharp:

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/CommandHandler.cs
@@ -13,6 +13,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
         private const ConsoleColor ErrorColor = ConsoleColor.Red;
         private const ConsoleColor WarningColor = ConsoleColor.Yellow;
 
+        public static readonly string[] SupportedSdkTargets = CommandPerformer.SdkTargetMap.Keys.ToArray();
         public static readonly string[] SupportedLanguages = CommandPerformer.LanguageMap.Keys.ToArray();
 
         public static int GenerateCode(OptionContainer options)

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompiler/Program.cs
@@ -75,6 +75,13 @@ namespace Azure.Iot.Operations.ProtocolCompiler
                 HelpName = "NAMESPACE",
             };
 
+            var targetOption = new Option<string>("--target")
+            {
+                DefaultValueFactory = (_) => "aio",
+                Description = $"SDK that will be targeted by generated code",
+                HelpName = string.Join('|', CommandHandler.SupportedSdkTargets),
+            };
+
             var sdkPathOption = new Option<string?>("--sdkPath")
             {
                 Description = "Local path or feed URL for Azure.Iot.Operations.Protocol SDK",
@@ -112,6 +119,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
             rootCommand.Add(workingDirOption);
             rootCommand.Add(namespaceOption);
             rootCommand.Add(commonOption);
+            rootCommand.Add(targetOption);
             rootCommand.Add(sdkPathOption);
             rootCommand.Add(langOption);
             rootCommand.Add(prefixSchemasOption);
@@ -137,6 +145,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler
                     WorkingDir = Path.IsPathRooted(workingDir) ? new DirectoryInfo(workingDir) : new DirectoryInfo(Path.Combine(outputDir.FullName, workingDir)),
                     GenNamespace = parseResult.GetValue(namespaceOption)!,
                     CommonNamespace = parseResult.GetValue(commonOption)!,
+                    SdkTarget = parseResult.GetValue(targetOption)!,
                     SdkPath = parseResult.GetValue(sdkPathOption),
                     Language = parseResult.GetValue(langOption)!,
                     PrefixSchemas = parseResult.GetValue(prefixSchemasOption),

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/CommandPerformer.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/CommandPerformer.cs
@@ -24,6 +24,12 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
         public const string DefaultOutDir = ".";
         public const string DefaultWorkingDir = "schemas";
 
+        public static readonly Dictionary<string, TargetSdk> SdkTargetMap = new()
+        {
+            { "aio", TargetSdk.Aio },
+            { "none", TargetSdk.None },
+        };
+
         public static readonly Dictionary<string, LanguageInfo> LanguageMap = new()
         {
             { "csharp", new LanguageInfo(TargetLanguage.CSharp, "", new Regex(@"^[A-Z][a-zA-Z0-9]*(?:\.[A-Z][a-zA-Z0-9]*)*$"), true, false, "Generated", "", "must have PascalCase name segments separated by dots") },
@@ -45,6 +51,7 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
                 }
 
                 string projectName = LegalizeProjectName(options.OutputDir.Name);
+                TargetSdk targetSdk = SdkTargetMap[options.SdkTarget.ToLowerInvariant()];
                 LanguageInfo languageInfo = LanguageMap[options.Language.ToLowerInvariant()];
 
                 string genNamespace = options.GenNamespace ?? languageInfo.DefaultNamespace;
@@ -131,6 +138,7 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
                 List<GeneratedItem> generatedEnvoys = EnvoyGenerator.GenerateEnvoys(
                     filepathToTitleToParsedThingMap.Values.SelectMany(titleToParsedThingMap => titleToParsedThingMap.Values),
                     serializationFormats.ToList(),
+                    targetSdk,
                     languageInfo.TargetLanguage,
                     genNamespace,
                     commonNs,
@@ -382,6 +390,12 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
             if (!anyThingFiles && !anySchemaFiles)
             {
                 AddUnlocatableError(ErrorCondition.ElementMissing, $"no Thing Model files specified, and no schema files {(options.SchemaFiles.Length > 0 ? "found" : "specified")}.  Use option --help for CLI usage and options.", errorLog);
+                return;
+            }
+
+            if (!SdkTargetMap.ContainsKey(options.SdkTarget))
+            {
+                AddUnlocatableError(ErrorCondition.PropertyUnsupportedValue, $"SDK target '{options.SdkTarget}' not recognized; SDK target must be {string.Join(" or ", SdkTargetMap.Keys.Select(s => $"'{s}'"))} (use 'none' to skip SDK target generation)", errorLog);
                 return;
             }
 

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/CommandPerformer.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/CommandPerformer.cs
@@ -393,13 +393,15 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
                 return;
             }
 
-            if (!SdkTargetMap.ContainsKey(options.SdkTarget))
+            string sdkTargetKey = options.SdkTarget?.ToLowerInvariant() ?? string.Empty;
+            if (!SdkTargetMap.ContainsKey(sdkTargetKey))
             {
                 AddUnlocatableError(ErrorCondition.PropertyUnsupportedValue, $"SDK target '{options.SdkTarget}' not recognized; SDK target must be {string.Join(" or ", SdkTargetMap.Keys.Select(s => $"'{s}'"))} (use 'none' to skip SDK target generation)", errorLog);
                 return;
             }
 
-            if (!LanguageMap.ContainsKey(options.Language))
+            string languageKey = options.Language?.ToLowerInvariant() ?? string.Empty;
+            if (!LanguageMap.ContainsKey(languageKey))
             {
                 string langCondition = string.IsNullOrEmpty(options.Language) ? "language not specified" : $"language '{options.Language}' not recognized";
                 AddUnlocatableError(ErrorCondition.PropertyUnsupportedValue, $"{langCondition}; language must be {string.Join(" or ", LanguageMap.Keys.Select(l => $"'{l}'"))} (use 'none' for no code generation)", errorLog);

--- a/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/OptionContainer.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/OptionContainer.cs
@@ -37,6 +37,9 @@ namespace Azure.Iot.Operations.ProtocolCompilerLib
         /// <summary>Gets or sets a namespace for common code.</summary>
         public required string? CommonNamespace { get; set; }
 
+        /// <summary>Gets or sets the SDK that will be targeted by generated code.</summary>
+        public required string SdkTarget { get; set; }
+
         /// <summary>Gets or sets a local path or feed URL for Azure.Iot.Operations.Protocol SDK.</summary>
         public string? SdkPath { get; set; }
 

--- a/wot-codegen/test/Azure.Iot.Operations.ProtocolCompiler.UnitTests/ProtocolCompilerTester.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.ProtocolCompiler.UnitTests/ProtocolCompilerTester.cs
@@ -212,6 +212,7 @@ namespace Azure.Iot.Operations.ProtocolCompiler.UnitTests
                 WorkingDir = workingDir,
                 GenNamespace = commandLine.GenNamespace,
                 CommonNamespace = commandLine.CommonNamespace,
+                SdkTarget = commandLine.SdkTarget ?? "none",
                 SdkPath = commandLine.SdkPath,
                 Language = commandLine.Language ?? "none",
                 NoProj = commandLine.NoProj,

--- a/wot-codegen/test/Azure.Iot.Operations.ProtocolCompiler.UnitTests/TestCommandLine.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.ProtocolCompiler.UnitTests/TestCommandLine.cs
@@ -35,6 +35,9 @@ namespace Azure.Iot.Operations.ProtocolCompiler.UnitTests
         [JsonPropertyName("common")]
         public string? CommonNamespace { get; set; }
 
+        [JsonPropertyName("target")]
+        public string? SdkTarget { get; set; }
+
         [JsonPropertyName("sdkPath")]
         public string? SdkPath { get; set; }
 

--- a/wot-codegen/test/test-cases/failure/UnsupportedTarget.json
+++ b/wot-codegen/test/test-cases/failure/UnsupportedTarget.json
@@ -1,0 +1,17 @@
+{
+  "success": false,
+  "commandLine": {
+    "things": [ "valid/Noop.TM.json" ],
+    "target": "mcp",
+    "lang": "rust"
+  },
+  "errors": [
+    {
+      "condition": "PropertyUnsupportedValue",
+      "filename": "",
+      "line": 0,
+      "cfLine": 0,
+      "crossRef": ""
+    }
+  ]
+}


### PR DESCRIPTION
The actual functional change in this PR is enabling the ProtocolCompiler to generate schema definitions and schema code without generating envoy binder code.  But the CLI is structured to be broader than this narrow case.  The new `--target` CLI option allows the user to specify which SDK to target:

- a value of `aio` maintains the current behavior
- a value of `none` generates no envoy binder code

This design allows for future expansion to target other SDKs beyond the AIO SDK.  In particular, we may add an option to target a minimal envoy that will be hosted in a WASM container.