### PR TITLE
Hardcode disabling Nagle algorithm (TCP_NODELAY) in Rust MQTT transport

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
@@ -27,6 +27,8 @@ where
     BP: BufferPool,
 {
     let stream = TcpStream::connect(addr).await?;
+    // Disable the Nagle algorithm (hardcoded) to minimize latency.
+    stream.set_nodelay(true)?;
     Ok(connect_inner(stream, reader_pool, writer_pool))
 }
 

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
@@ -92,6 +92,8 @@ pub(crate) async fn connect_inner(
         let connector = connector.build();
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        // Disable the Nagle algorithm (hardcoded) to minimize latency.
+        tcp_stream.set_nodelay(true)?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -129,6 +131,8 @@ pub(crate) async fn connect_inner(
         let connector = connector.build();
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        // Disable the Nagle algorithm (hardcoded) to minimize latency.
+        tcp_stream.set_nodelay(true)?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -148,6 +152,8 @@ pub(crate) async fn connect_inner(
         debug_assert_eq!(method, TLS_METHOD_USERSPACE);
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        // Disable the Nagle algorithm (hardcoded) to minimize latency.
+        tcp_stream.set_nodelay(true)?;
 
         let connector = connector.build().configure()?;
 

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -54,7 +54,12 @@ where
     };
     let stream = match scheme {
         "https" | "wss" => tokio_tls::connect_inner(addr, port.unwrap_or(443), tls_config).await?,
-        "http" | "ws" => Either::Left(TcpStream::connect((addr, port.unwrap_or(80))).await?),
+        "http" | "ws" => {
+            let tcp_stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
+            // Disable the Nagle algorithm (hardcoded) to minimize latency.
+            tcp_stream.set_nodelay(true)?;
+            Either::Left(tcp_stream)
+        }
         _ => {
             return Err(IoError::new(
                 io::ErrorKind::InvalidInput,


### PR DESCRIPTION
Set TCP_NODELAY on all TCP connect paths (plain TCP, kTLS, userspace TLS, and WebSocket) to minimize latency.