### PR TITLE
[Rust][MQTT] Reserved property refactor + `$high_priority` broker backpressure bypass

### DIFF
--- a/rust/azure_iot_operations_protocol/src/common.rs
+++ b/rust/azure_iot_operations_protocol/src/common.rs
@@ -16,7 +16,7 @@ pub mod aio_protocol_error;
 pub(crate) mod topic_processor;
 
 /// This module contains string values for Azure IoT Operations Protocol defined user properties.
-pub mod user_properties;
+pub(crate) mod user_properties;
 
 /// This module contains the sending side cloud event implementation for the Azure IoT Operations Protocol.
 pub(crate) mod cloud_event;

--- a/rust/azure_iot_operations_protocol/src/common/aio_protocol_error.rs
+++ b/rust/azure_iot_operations_protocol/src/common/aio_protocol_error.rs
@@ -10,7 +10,7 @@ use crate::common::{
     topic_processor::{TopicPatternError, TopicPatternErrorKind},
 };
 
-use super::user_properties::UserProperty;
+use super::user_properties::ProtocolReservedUserProperty;
 
 /// Represents the kind of error that occurs in an Azure IoT Operations Protocol
 #[derive(Debug, PartialEq)]
@@ -609,7 +609,7 @@ impl From<HLCError> for AIOProtocolError {
 impl From<ParseHLCError> for AIOProtocolError {
     fn from(error: ParseHLCError) -> Self {
         AIOProtocolError::new_header_invalid_error(
-            format!("{}", UserProperty::Timestamp).as_str(),
+            format!("{}", ProtocolReservedUserProperty::Timestamp).as_str(),
             error.input.as_str(),
             false,
             Some(format!("{error}")),

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -224,7 +224,7 @@ mod tests {
     fn test_unrestricted_broker_property_allowed_by_invoker_validation() {
         let props = vec![(
             BrokerReservedUserProperty::HighPriority.to_string(),
-            "true".to_string(),
+            String::new(),
         )];
         assert!(validate_user_properties(&props).is_ok());
         assert!(validate_invoker_user_properties(&props).is_ok());

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -25,7 +25,7 @@ pub(crate) enum BrokerReservedUserProperty {
 }
 
 impl BrokerReservedUserProperty {
-    /// Indicates if the user property is restricted from being set by, or provided to the end-user.
+    /// Indicates if the user property is restricted from being set by the end-user.
     pub(crate) fn is_user_restricted(&self) -> bool {
         #[allow(clippy::match_same_arms)]
         match self {

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -141,7 +141,9 @@ pub(crate) fn validate_invoker_user_properties(
         }
         if let Ok(broker_prop) = BrokerReservedUserProperty::from_str(key) {
             if broker_prop.is_user_restricted() {
-                return Err(format!("User data key '{key}' is a restricted broker property"));
+                return Err(format!(
+                    "User data key '{key}' is a restricted broker property"
+                ));
             }
         }
     }
@@ -183,7 +185,10 @@ mod tests {
     #[test_case(ProtocolReservedUserProperty::SupportedMajorVersions; "supported_major_versions")]
     #[test_case(ProtocolReservedUserProperty::RequestProtocolVersion; "request_protocol_version")]
     fn test_to_from_string(prop: ProtocolReservedUserProperty) {
-        assert_eq!(prop, ProtocolReservedUserProperty::from_str(&prop.to_string()).unwrap());
+        assert_eq!(
+            prop,
+            ProtocolReservedUserProperty::from_str(&prop.to_string()).unwrap()
+        );
     }
 
     /// Tests failure: Custom user data key is malformed utf-8 and an error is returned
@@ -206,21 +211,30 @@ mod tests {
 
     #[test]
     fn test_restricted_broker_property_rejected_by_invoker_validation() {
-        let props = vec![(BrokerReservedUserProperty::Partition.to_string(), "abcdef".to_string())];
+        let props = vec![(
+            BrokerReservedUserProperty::Partition.to_string(),
+            "abcdef".to_string(),
+        )];
         assert!(validate_user_properties(&props).is_ok());
         assert!(validate_invoker_user_properties(&props).is_err());
     }
 
     #[test]
     fn test_unrestricted_broker_property_allowed_by_invoker_validation() {
-        let props = vec![(BrokerReservedUserProperty::HighPriority.to_string(), "true".to_string())];
+        let props = vec![(
+            BrokerReservedUserProperty::HighPriority.to_string(),
+            "true".to_string(),
+        )];
         assert!(validate_user_properties(&props).is_ok());
         assert!(validate_invoker_user_properties(&props).is_ok());
     }
 
     #[test]
     fn test_persist_broker_property_allowed_by_invoker_validation() {
-        let props = vec![(BrokerReservedUserProperty::Persist.to_string(), "true".to_string())];
+        let props = vec![(
+            BrokerReservedUserProperty::Persist.to_string(),
+            "true".to_string(),
+        )];
         assert!(validate_user_properties(&props).is_ok());
         assert!(validate_invoker_user_properties(&props).is_ok());
     }

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -6,17 +6,62 @@ use std::{
     str::FromStr,
 };
 
-/// Partition key used by the MQ broker for RPC operations with shared subscriptions.
-/// It is added as a user property key in the MQTT message, with the client ID as its value.
-/// Users cannot set this property on the invoker. For more details, see: [shared_subscriptions.md](https://github.com/Azure/iot-operations-sdks/blob/main/doc/reference/shared-subscriptions.md).
-pub(crate) const PARTITION_KEY: &str = "$partition";
+// NOTE: The use of these broker/protocol properties is currently rather inconsistent.
+// The current implementation does not necessarily capture the intent, do not read too much into
+// the design choices.
 
-/// Persist key used by the MQ broker to indicate disk-persistence.
-pub(crate) const PERSIST_KEY: &str = "aio-persistence";
+/// Enum representing user properties that are AIO MQ broker-owned/reserved.
+/// They correspond to broker-specific functionality and may be set by the protocols.
+/// May or may not be restricted from the end-user (case-by-case)
+pub(crate) enum BrokerReservedUserProperty {
+    /// The partition ID that the MQ broker uses to determine which subscriber in a shared subscription
+    /// receives a given message. Partition ID should correspond with an MQTT client ID.
+    /// For more details, see: [shared_subscriptions.md](https://github.com/Azure/iot-operations-sdks/blob/main/doc/reference/shared-subscriptions.md).
+    Partition,
+    /// Flag indicating high priority for the message (i.e. backpressure bypass). No associated value.
+    HighPriority,
+    /// Indicates that the message should be persisted to disk by the MQ broker.
+    Persist,
+}
+
+impl BrokerReservedUserProperty {
+    /// Indicates if the user property is restricted from being set by, or provided to the end-user.
+    pub(crate) fn is_user_restricted(&self) -> bool {
+        match self {
+            BrokerReservedUserProperty::Partition => true,
+            BrokerReservedUserProperty::HighPriority => false,
+            BrokerReservedUserProperty::Persist => false,
+        }
+    }
+}
+
+impl Display for BrokerReservedUserProperty {
+    /// Get the string representation of the broker user property.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            BrokerReservedUserProperty::Partition => write!(f, "$partition"),
+            BrokerReservedUserProperty::HighPriority => write!(f, "$high_priority"),
+            BrokerReservedUserProperty::Persist => write!(f, "aio-persistence"),
+        }
+    }
+}
+
+impl FromStr for BrokerReservedUserProperty {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "$partition" => Ok(BrokerReservedUserProperty::Partition),
+            "$high_priority" => Ok(BrokerReservedUserProperty::HighPriority),
+            "aio-persistence" => Ok(BrokerReservedUserProperty::Persist),
+            _ => Err(()),
+        }
+    }
+}
 
 /// Enum representing the system properties.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum UserProperty {
+pub(crate) enum ProtocolReservedUserProperty {
     /// A [`HybridLogicalClock`](super::hybrid_logical_clock::HybridLogicalClock) timestamp associated with the request or response.
     Timestamp,
     /// User Property indicating an HTTP status code.
@@ -42,39 +87,39 @@ pub enum UserProperty {
     RequestProtocolVersion,
 }
 
-impl Display for UserProperty {
+impl Display for ProtocolReservedUserProperty {
     /// Get the string representation of the user property.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            UserProperty::Timestamp => write!(f, "__ts"),
-            UserProperty::Status => write!(f, "__stat"),
-            UserProperty::StatusMessage => write!(f, "__stMsg"),
-            UserProperty::IsApplicationError => write!(f, "__apErr"),
-            UserProperty::SourceId => write!(f, "__srcId"),
-            UserProperty::InvalidPropertyName => write!(f, "__propName"),
-            UserProperty::InvalidPropertyValue => write!(f, "__propVal"),
-            UserProperty::ProtocolVersion => write!(f, "__protVer"),
-            UserProperty::SupportedMajorVersions => write!(f, "__supProtMajVer"),
-            UserProperty::RequestProtocolVersion => write!(f, "__requestProtVer"),
+            ProtocolReservedUserProperty::Timestamp => write!(f, "__ts"),
+            ProtocolReservedUserProperty::Status => write!(f, "__stat"),
+            ProtocolReservedUserProperty::StatusMessage => write!(f, "__stMsg"),
+            ProtocolReservedUserProperty::IsApplicationError => write!(f, "__apErr"),
+            ProtocolReservedUserProperty::SourceId => write!(f, "__srcId"),
+            ProtocolReservedUserProperty::InvalidPropertyName => write!(f, "__propName"),
+            ProtocolReservedUserProperty::InvalidPropertyValue => write!(f, "__propVal"),
+            ProtocolReservedUserProperty::ProtocolVersion => write!(f, "__protVer"),
+            ProtocolReservedUserProperty::SupportedMajorVersions => write!(f, "__supProtMajVer"),
+            ProtocolReservedUserProperty::RequestProtocolVersion => write!(f, "__requestProtVer"),
         }
     }
 }
 
-impl FromStr for UserProperty {
+impl FromStr for ProtocolReservedUserProperty {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "__ts" => Ok(UserProperty::Timestamp),
-            "__stat" => Ok(UserProperty::Status),
-            "__stMsg" => Ok(UserProperty::StatusMessage),
-            "__apErr" => Ok(UserProperty::IsApplicationError),
-            "__srcId" => Ok(UserProperty::SourceId),
-            "__propName" => Ok(UserProperty::InvalidPropertyName),
-            "__propVal" => Ok(UserProperty::InvalidPropertyValue),
-            "__protVer" => Ok(UserProperty::ProtocolVersion),
-            "__supProtMajVer" => Ok(UserProperty::SupportedMajorVersions),
-            "__requestProtVer" => Ok(UserProperty::RequestProtocolVersion),
+            "__ts" => Ok(ProtocolReservedUserProperty::Timestamp),
+            "__stat" => Ok(ProtocolReservedUserProperty::Status),
+            "__stMsg" => Ok(ProtocolReservedUserProperty::StatusMessage),
+            "__apErr" => Ok(ProtocolReservedUserProperty::IsApplicationError),
+            "__srcId" => Ok(ProtocolReservedUserProperty::SourceId),
+            "__propName" => Ok(ProtocolReservedUserProperty::InvalidPropertyName),
+            "__propVal" => Ok(ProtocolReservedUserProperty::InvalidPropertyValue),
+            "__protVer" => Ok(ProtocolReservedUserProperty::ProtocolVersion),
+            "__supProtMajVer" => Ok(ProtocolReservedUserProperty::SupportedMajorVersions),
+            "__requestProtVer" => Ok(ProtocolReservedUserProperty::RequestProtocolVersion),
             _ => Err(()),
         }
     }
@@ -84,7 +129,7 @@ impl FromStr for UserProperty {
 ///
 /// # Errors
 /// Returns a `String` describing the error if any of `property_list`'s keys are invalid utf-8
-/// or are the reserved key [`PARTITION_KEY`].
+/// or are a user-restricted broker reserved property.
 pub(crate) fn validate_invoker_user_properties(
     property_list: &[(String, String)],
 ) -> Result<(), String> {
@@ -94,8 +139,10 @@ pub(crate) fn validate_invoker_user_properties(
                 "Invalid user data key '{key}' or value '{value}' isn't valid utf-8"
             ));
         }
-        if key == PARTITION_KEY {
-            return Err(format!("User data key '{PARTITION_KEY}'"));
+        if let Ok(broker_prop) = BrokerReservedUserProperty::from_str(key) {
+            if broker_prop.is_user_restricted() {
+                return Err(format!("User data key '{key}' is a restricted broker property"));
+            }
         }
     }
     Ok(())
@@ -123,20 +170,20 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use crate::common::user_properties::UserProperty;
+    use crate::common::user_properties::ProtocolReservedUserProperty;
 
-    #[test_case(UserProperty::Timestamp; "timestamp")]
-    #[test_case(UserProperty::Status; "status")]
-    #[test_case(UserProperty::StatusMessage; "status_message")]
-    #[test_case(UserProperty::IsApplicationError; "is_application_error")]
-    #[test_case(UserProperty::SourceId; "source_id")]
-    #[test_case(UserProperty::InvalidPropertyName; "invalid_property_name")]
-    #[test_case(UserProperty::InvalidPropertyValue; "invalid_property_value")]
-    #[test_case(UserProperty::ProtocolVersion; "protocol_version")]
-    #[test_case(UserProperty::SupportedMajorVersions; "supported_major_versions")]
-    #[test_case(UserProperty::RequestProtocolVersion; "request_protocol_version")]
-    fn test_to_from_string(prop: UserProperty) {
-        assert_eq!(prop, UserProperty::from_str(&prop.to_string()).unwrap());
+    #[test_case(ProtocolReservedUserProperty::Timestamp; "timestamp")]
+    #[test_case(ProtocolReservedUserProperty::Status; "status")]
+    #[test_case(ProtocolReservedUserProperty::StatusMessage; "status_message")]
+    #[test_case(ProtocolReservedUserProperty::IsApplicationError; "is_application_error")]
+    #[test_case(ProtocolReservedUserProperty::SourceId; "source_id")]
+    #[test_case(ProtocolReservedUserProperty::InvalidPropertyName; "invalid_property_name")]
+    #[test_case(ProtocolReservedUserProperty::InvalidPropertyValue; "invalid_property_value")]
+    #[test_case(ProtocolReservedUserProperty::ProtocolVersion; "protocol_version")]
+    #[test_case(ProtocolReservedUserProperty::SupportedMajorVersions; "supported_major_versions")]
+    #[test_case(ProtocolReservedUserProperty::RequestProtocolVersion; "request_protocol_version")]
+    fn test_to_from_string(prop: ProtocolReservedUserProperty) {
+        assert_eq!(prop, ProtocolReservedUserProperty::from_str(&prop.to_string()).unwrap());
     }
 
     /// Tests failure: Custom user data key is malformed utf-8 and an error is returned
@@ -158,9 +205,23 @@ mod tests {
     }
 
     #[test]
-    fn test_partition_key_user_property() {
-        let partition_key_user_properties = vec![(PARTITION_KEY.to_string(), "abcdef".to_string())];
-        assert!(validate_user_properties(&partition_key_user_properties).is_ok());
-        assert!(validate_invoker_user_properties(&partition_key_user_properties).is_err());
+    fn test_restricted_broker_property_rejected_by_invoker_validation() {
+        let props = vec![(BrokerReservedUserProperty::Partition.to_string(), "abcdef".to_string())];
+        assert!(validate_user_properties(&props).is_ok());
+        assert!(validate_invoker_user_properties(&props).is_err());
+    }
+
+    #[test]
+    fn test_unrestricted_broker_property_allowed_by_invoker_validation() {
+        let props = vec![(BrokerReservedUserProperty::HighPriority.to_string(), "true".to_string())];
+        assert!(validate_user_properties(&props).is_ok());
+        assert!(validate_invoker_user_properties(&props).is_ok());
+    }
+
+    #[test]
+    fn test_persist_broker_property_allowed_by_invoker_validation() {
+        let props = vec![(BrokerReservedUserProperty::Persist.to_string(), "true".to_string())];
+        assert!(validate_user_properties(&props).is_ok());
+        assert!(validate_invoker_user_properties(&props).is_ok());
     }
 }

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -18,7 +18,7 @@ pub(crate) enum BrokerReservedUserProperty {
     /// receives a given message. Partition ID should correspond with an MQTT client ID.
     /// For more details, see: [shared_subscriptions.md](https://github.com/Azure/iot-operations-sdks/blob/main/doc/reference/shared-subscriptions.md).
     Partition,
-    /// Flag indicating high priority for the message (i.e. backpressure bypass). No associated value.
+    /// Flag indicating high priority for the message (i.e. backpressure bypass). The broker ignores the value; presence of the key is what matters.
     HighPriority,
     /// Indicates that the message should be persisted to disk by the MQ broker.
     Persist,

--- a/rust/azure_iot_operations_protocol/src/common/user_properties.rs
+++ b/rust/azure_iot_operations_protocol/src/common/user_properties.rs
@@ -27,6 +27,7 @@ pub(crate) enum BrokerReservedUserProperty {
 impl BrokerReservedUserProperty {
     /// Indicates if the user property is restricted from being set by, or provided to the end-user.
     pub(crate) fn is_user_restricted(&self) -> bool {
+        #[allow(clippy::match_same_arms)]
         match self {
             BrokerReservedUserProperty::Partition => true,
             BrokerReservedUserProperty::HighPriority => false,

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1552,6 +1552,8 @@ where
             ));
         }
 
+        user_properties.push((BrokerReservedUserProperty::HighPriority.to_string(), "".to_string()));
+
         // Create publish properties
         publish_properties.payload_format_indicator = serialized_payload.format_indicator.into();
         publish_properties.topic_alias = None;

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -31,7 +31,9 @@ use crate::{
             DeserializationError, FormatIndicator, PayloadSerialize, SerializedPayload,
         },
         topic_processor::{TopicPattern, contains_invalid_char, is_valid_replacement},
-        user_properties::{BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties},
+        user_properties::{
+            BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties,
+        },
     },
     rpc_command::{
         DEFAULT_RPC_COMMAND_PROTOCOL_VERSION, DEFAULT_RPC_RESPONSE_CLOUD_EVENT_EVENT_TYPE,
@@ -1065,7 +1067,8 @@ where
                         let mut request_protocol_version = DEFAULT_RPC_COMMAND_PROTOCOL_VERSION; // assume default version if none is provided
                         if let Some((_, protocol_version)) =
                             properties.user_properties.iter().find(|(key, _)| {
-                                ProtocolReservedUserProperty::from_str(key) == Ok(ProtocolReservedUserProperty::ProtocolVersion)
+                                ProtocolReservedUserProperty::from_str(key)
+                                    == Ok(ProtocolReservedUserProperty::ProtocolVersion)
                             })
                         {
                             if let Some(request_version) =
@@ -1110,8 +1113,10 @@ where
                                                 response_arguments.status_message = Some(format!(
                                                     "Failure updating application HLC against {value}: {e}"
                                                 ));
-                                                response_arguments.invalid_property_name =
-                                                    Some(ProtocolReservedUserProperty::Timestamp.to_string());
+                                                response_arguments.invalid_property_name = Some(
+                                                    ProtocolReservedUserProperty::Timestamp
+                                                        .to_string(),
+                                                );
                                                 response_arguments.invalid_property_value =
                                                     Some(value);
                                                 match e.kind() {
@@ -1132,8 +1137,9 @@ where
                                             response_arguments.status_code = StatusCode::BadRequest;
                                             response_arguments.status_message =
                                                 Some(format!("Timestamp invalid: {e}"));
-                                            response_arguments.invalid_property_name =
-                                                Some(ProtocolReservedUserProperty::Timestamp.to_string());
+                                            response_arguments.invalid_property_name = Some(
+                                                ProtocolReservedUserProperty::Timestamp.to_string(),
+                                            );
                                             response_arguments.invalid_property_value = Some(value);
                                             break 'process_request;
                                         }
@@ -1147,7 +1153,9 @@ where
                                 }
                                 Err(()) => {
                                     // Not a protocol-reserved property, check if it's a broker-reserved property.
-                                    if let Ok(broker_prop) = BrokerReservedUserProperty::from_str(&key) {
+                                    if let Ok(broker_prop) =
+                                        BrokerReservedUserProperty::from_str(&key)
+                                    {
                                         // Strip any broker-reserved user properties that are restricted from the end user, if they are present.
                                         if broker_prop.is_user_restricted() {
                                             continue;
@@ -1515,7 +1523,10 @@ where
         // If there are errors updating the HLC (unlikely when updating against now),
         // the timestamp will not be added.
         if let Ok(timestamp_str) = application_hlc.update_now() {
-            user_properties.push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
+            user_properties.push((
+                ProtocolReservedUserProperty::Timestamp.to_string(),
+                timestamp_str,
+            ));
         }
 
         if let Some(status_message) = response_arguments.status_message {
@@ -1525,15 +1536,24 @@ where
                 pkid,
                 status_message
             );
-            user_properties.push((ProtocolReservedUserProperty::StatusMessage.to_string(), status_message));
+            user_properties.push((
+                ProtocolReservedUserProperty::StatusMessage.to_string(),
+                status_message,
+            ));
         }
 
         if let Some(name) = response_arguments.invalid_property_name {
-            user_properties.push((ProtocolReservedUserProperty::InvalidPropertyName.to_string(), name));
+            user_properties.push((
+                ProtocolReservedUserProperty::InvalidPropertyName.to_string(),
+                name,
+            ));
         }
 
         if let Some(value) = response_arguments.invalid_property_value {
-            user_properties.push((ProtocolReservedUserProperty::InvalidPropertyValue.to_string(), value));
+            user_properties.push((
+                ProtocolReservedUserProperty::InvalidPropertyValue.to_string(),
+                value,
+            ));
         }
 
         if let Some(supported_protocol_major_versions) =
@@ -1552,7 +1572,10 @@ where
             ));
         }
 
-        user_properties.push((BrokerReservedUserProperty::HighPriority.to_string(), "".to_string()));
+        user_properties.push((
+            BrokerReservedUserProperty::HighPriority.to_string(),
+            "".to_string(),
+        ));
 
         // Create publish properties
         publish_properties.payload_format_indicator = serialized_payload.format_indicator.into();

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1153,16 +1153,11 @@ where
                                 }
                                 Err(()) => {
                                     // Not a protocol-reserved property, check if it's a broker-reserved property.
-                                    if let Ok(broker_prop) =
-                                        BrokerReservedUserProperty::from_str(&key)
-                                    {
-                                        // Strip any broker-reserved user properties that are restricted from the end user, if they are present.
-                                        if broker_prop.is_user_restricted() {
-                                            continue;
-                                        }
+                                    // All broker-reserved properties are stripped on receive — they are
+                                    // SDK/broker internals and should never appear in user-facing custom_user_data.
+                                    if BrokerReservedUserProperty::from_str(&key).is_ok() {
+                                        continue;
                                     }
-                                    // Otherwise, whether a non-reserved property, or a broker-reserved property that is not restricted,
-                                    // include the property in the user data.
                                     user_data.push((key, value));
                                 }
                                 _ => {

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -31,7 +31,7 @@ use crate::{
             DeserializationError, FormatIndicator, PayloadSerialize, SerializedPayload,
         },
         topic_processor::{TopicPattern, contains_invalid_char, is_valid_replacement},
-        user_properties::{PARTITION_KEY, UserProperty, validate_user_properties},
+        user_properties::{BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties},
     },
     rpc_command::{
         DEFAULT_RPC_COMMAND_PROTOCOL_VERSION, DEFAULT_RPC_RESPONSE_CLOUD_EVENT_EVENT_TYPE,
@@ -361,7 +361,7 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
     ///
     /// # Errors
     /// Returns a `String` describing the error if any of `custom_user_data`'s keys or values are invalid utf-8
-    /// or the reserved [`PARTITION_KEY`] key is used.
+    /// or a reserved Cloud Event key is used.
     fn validate(&self) -> Result<(), String> {
         if let Some(custom_user_data) = &self.custom_user_data {
             for (key, _) in custom_user_data {
@@ -371,6 +371,9 @@ impl<TResp: PayloadSerialize> ResponseBuilder<TResp> {
                     ));
                 }
             }
+            // NOTE: This does NOT validate the broker-reserved user properties.
+            // This is done to maintain existing behavior that the documentation had been wrong about.
+            // Consider changing this as a clearer story regarding how certain values are restricted emerges.
             validate_user_properties(custom_user_data)?;
         }
         // If there's a cloud event, make sure the content type is valid for the cloud event spec version
@@ -1062,7 +1065,7 @@ where
                         let mut request_protocol_version = DEFAULT_RPC_COMMAND_PROTOCOL_VERSION; // assume default version if none is provided
                         if let Some((_, protocol_version)) =
                             properties.user_properties.iter().find(|(key, _)| {
-                                UserProperty::from_str(key) == Ok(UserProperty::ProtocolVersion)
+                                ProtocolReservedUserProperty::from_str(key) == Ok(ProtocolReservedUserProperty::ProtocolVersion)
                             })
                         {
                             if let Some(request_version) =
@@ -1098,8 +1101,8 @@ where
                         let mut timestamp = None;
                         let mut invoker_id = None;
                         for (key, value) in properties.user_properties {
-                            match UserProperty::from_str(&key) {
-                                Ok(UserProperty::Timestamp) => {
+                            match ProtocolReservedUserProperty::from_str(&key) {
+                                Ok(ProtocolReservedUserProperty::Timestamp) => {
                                     match HybridLogicalClock::from_str(&value) {
                                         Ok(ts) => {
                                             // Update application HLC against received __ts
@@ -1108,7 +1111,7 @@ where
                                                     "Failure updating application HLC against {value}: {e}"
                                                 ));
                                                 response_arguments.invalid_property_name =
-                                                    Some(UserProperty::Timestamp.to_string());
+                                                    Some(ProtocolReservedUserProperty::Timestamp.to_string());
                                                 response_arguments.invalid_property_value =
                                                     Some(value);
                                                 match e.kind() {
@@ -1130,23 +1133,28 @@ where
                                             response_arguments.status_message =
                                                 Some(format!("Timestamp invalid: {e}"));
                                             response_arguments.invalid_property_name =
-                                                Some(UserProperty::Timestamp.to_string());
+                                                Some(ProtocolReservedUserProperty::Timestamp.to_string());
                                             response_arguments.invalid_property_value = Some(value);
                                             break 'process_request;
                                         }
                                     }
                                 }
-                                Ok(UserProperty::SourceId) => {
+                                Ok(ProtocolReservedUserProperty::SourceId) => {
                                     invoker_id = Some(value);
                                 }
-                                Ok(UserProperty::ProtocolVersion) => {
+                                Ok(ProtocolReservedUserProperty::ProtocolVersion) => {
                                     // skip, already processed
                                 }
                                 Err(()) => {
-                                    if key == PARTITION_KEY {
-                                        // Ignore partition key, it is meant for the broker
-                                        continue;
+                                    // Not a protocol-reserved property, check if it's a broker-reserved property.
+                                    if let Ok(broker_prop) = BrokerReservedUserProperty::from_str(&key) {
+                                        // Strip any broker-reserved user properties that are restricted from the end user, if they are present.
+                                        if broker_prop.is_user_restricted() {
+                                            continue;
+                                        }
                                     }
+                                    // Otherwise, whether a non-reserved property, or a broker-reserved property that is not restricted,
+                                    // include the property in the user data.
                                     user_data.push((key, value));
                                 }
                                 _ => {
@@ -1483,23 +1491,23 @@ where
             || response_arguments.status_code != StatusCode::NoContent
         {
             user_properties.push((
-                UserProperty::IsApplicationError.to_string(),
+                ProtocolReservedUserProperty::IsApplicationError.to_string(),
                 response_arguments.is_application_error.to_string(),
             ));
         }
 
         user_properties.push((
-            UserProperty::Status.to_string(),
+            ProtocolReservedUserProperty::Status.to_string(),
             (response_arguments.status_code as u16).to_string(),
         ));
 
         user_properties.push((
-            UserProperty::ProtocolVersion.to_string(),
+            ProtocolReservedUserProperty::ProtocolVersion.to_string(),
             RPC_COMMAND_PROTOCOL_VERSION.to_string(),
         ));
 
         user_properties.push((
-            UserProperty::SourceId.to_string(),
+            ProtocolReservedUserProperty::SourceId.to_string(),
             client.client_id().to_string(),
         ));
 
@@ -1507,7 +1515,7 @@ where
         // If there are errors updating the HLC (unlikely when updating against now),
         // the timestamp will not be added.
         if let Ok(timestamp_str) = application_hlc.update_now() {
-            user_properties.push((UserProperty::Timestamp.to_string(), timestamp_str));
+            user_properties.push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
         }
 
         if let Some(status_message) = response_arguments.status_message {
@@ -1517,29 +1525,29 @@ where
                 pkid,
                 status_message
             );
-            user_properties.push((UserProperty::StatusMessage.to_string(), status_message));
+            user_properties.push((ProtocolReservedUserProperty::StatusMessage.to_string(), status_message));
         }
 
         if let Some(name) = response_arguments.invalid_property_name {
-            user_properties.push((UserProperty::InvalidPropertyName.to_string(), name));
+            user_properties.push((ProtocolReservedUserProperty::InvalidPropertyName.to_string(), name));
         }
 
         if let Some(value) = response_arguments.invalid_property_value {
-            user_properties.push((UserProperty::InvalidPropertyValue.to_string(), value));
+            user_properties.push((ProtocolReservedUserProperty::InvalidPropertyValue.to_string(), value));
         }
 
         if let Some(supported_protocol_major_versions) =
             response_arguments.supported_protocol_major_versions
         {
             user_properties.push((
-                UserProperty::SupportedMajorVersions.to_string(),
+                ProtocolReservedUserProperty::SupportedMajorVersions.to_string(),
                 supported_protocol_major_versions_to_string(&supported_protocol_major_versions),
             ));
         }
 
         if let Some(request_protocol_version) = response_arguments.request_protocol_version {
             user_properties.push((
-                UserProperty::RequestProtocolVersion.to_string(),
+                ProtocolReservedUserProperty::RequestProtocolVersion.to_string(),
                 request_protocol_version,
             ));
         }

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -1574,7 +1574,7 @@ where
 
         user_properties.push((
             BrokerReservedUserProperty::HighPriority.to_string(),
-            "".to_string(),
+            String::new(),
         ));
 
         // Create publish properties

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -1180,12 +1180,6 @@ where
             subscription_identifiers: Vec::new(),
         };
 
-        // Add backpressure bypass
-        // publish_properties.user_properties.push((
-        //     UserProperty::BackpressureBypass.to_string(),
-        //     "true".to_string(),
-        // ));
-
         // Subscribe to the response topic if we're not already subscribed and the invoker hasn't been shutdown
         {
             let mut invoker_state = self.state_mutex.lock().await;

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::common::{
     cloud_event as protocol_cloud_event,
-    user_properties::{PARTITION_KEY, validate_invoker_user_properties},
+    user_properties::{BrokerReservedUserProperty, validate_invoker_user_properties},
 };
 use crate::{
     ProtocolVersion,
@@ -37,7 +37,7 @@ use crate::{
             DeserializationError, FormatIndicator, PayloadSerialize, SerializedPayload,
         },
         topic_processor::{TopicPattern, contains_invalid_char},
-        user_properties::UserProperty,
+        user_properties::ProtocolReservedUserProperty,
     },
     parse_supported_protocol_major_versions,
     rpc_command::{
@@ -504,21 +504,21 @@ where
 
         // Parse user properties
         let expected_aio_properties = [
-            UserProperty::Timestamp,
-            UserProperty::Status,
-            UserProperty::StatusMessage,
-            UserProperty::SourceId,
-            UserProperty::IsApplicationError,
-            UserProperty::InvalidPropertyName,
-            UserProperty::InvalidPropertyValue,
-            UserProperty::ProtocolVersion,
-            UserProperty::SupportedMajorVersions,
-            UserProperty::RequestProtocolVersion,
+            ProtocolReservedUserProperty::Timestamp,
+            ProtocolReservedUserProperty::Status,
+            ProtocolReservedUserProperty::StatusMessage,
+            ProtocolReservedUserProperty::SourceId,
+            ProtocolReservedUserProperty::IsApplicationError,
+            ProtocolReservedUserProperty::InvalidPropertyName,
+            ProtocolReservedUserProperty::InvalidPropertyValue,
+            ProtocolReservedUserProperty::ProtocolVersion,
+            ProtocolReservedUserProperty::SupportedMajorVersions,
+            ProtocolReservedUserProperty::RequestProtocolVersion,
         ];
         let mut response_custom_user_data = vec![];
         let mut response_aio_data = HashMap::new();
         for (key, value) in publish_properties.user_properties {
-            match UserProperty::from_str(&key) {
+            match ProtocolReservedUserProperty::from_str(&key) {
                 Ok(p) if expected_aio_properties.contains(&p) => {
                     response_aio_data.insert(p, value);
                 }
@@ -538,7 +538,7 @@ where
         // If the protocol version is not supported, or cannot be parsed, all bets are off
         // regarding what anything else even means, so this *must* be done first
         let protocol_version = {
-            match response_aio_data.get(&UserProperty::ProtocolVersion) {
+            match response_aio_data.get(&ProtocolReservedUserProperty::ProtocolVersion) {
                 Some(protocol_version) => {
                     if let Some(version) = ProtocolVersion::parse_protocol_version(protocol_version)
                     {
@@ -573,12 +573,12 @@ where
         // Check the status code.
         // We will use this to determine which data format to serialize to.
         let status_code = {
-            match response_aio_data.get(&UserProperty::Status) {
+            match response_aio_data.get(&ProtocolReservedUserProperty::Status) {
                 Some(s) => match StatusCode::from_str(s) {
                     Ok(code) => code,
                     Err(StatusCodeParseError::UnparsableStatusCode(s)) => {
                         return Err(AIOProtocolError::new_header_invalid_error(
-                            &UserProperty::Status.to_string(),
+                            &ProtocolReservedUserProperty::Status.to_string(),
                             &s,
                             false,
                             Some(format!(
@@ -589,7 +589,7 @@ where
                     }
                     Err(StatusCodeParseError::UnknownStatusCode(_)) => {
                         let status_message = response_aio_data
-                            .remove(&UserProperty::StatusMessage)
+                            .remove(&ProtocolReservedUserProperty::StatusMessage)
                             .unwrap_or(String::from("Unknown"));
                         let mut unknown_err = AIOProtocolError::new_unknown_error(
                             true,
@@ -600,20 +600,20 @@ where
                         );
                         // Add any invalid properties that might be included for extra information
                         unknown_err.property_name =
-                            response_aio_data.remove(&UserProperty::InvalidPropertyName);
+                            response_aio_data.remove(&ProtocolReservedUserProperty::InvalidPropertyName);
                         unknown_err.property_value = response_aio_data
-                            .remove(&UserProperty::InvalidPropertyValue)
+                            .remove(&ProtocolReservedUserProperty::InvalidPropertyValue)
                             .map(Value::String);
                         return Err(unknown_err);
                     }
                 },
                 None => {
                     return Err(AIOProtocolError::new_header_missing_error(
-                        &UserProperty::Status.to_string(),
+                        &ProtocolReservedUserProperty::Status.to_string(),
                         false,
                         Some(format!(
                             "Response missing MQTT user property '{}'",
-                            UserProperty::Status
+                            ProtocolReservedUserProperty::Status
                         )),
                         None,
                     ));
@@ -623,7 +623,7 @@ where
 
         // Get HLC here since we will need it no matter what type of result we are processing
         let timestamp = response_aio_data
-            .get(&UserProperty::Timestamp)
+            .get(&ProtocolReservedUserProperty::Timestamp)
             .map(|s| HybridLogicalClock::from_str(s))
             .transpose()?;
 
@@ -676,23 +676,23 @@ where
                     format_indicator,
                     custom_user_data: response_custom_user_data,
                     timestamp,
-                    executor_id: response_aio_data.remove(&UserProperty::SourceId),
+                    executor_id: response_aio_data.remove(&ProtocolReservedUserProperty::SourceId),
                 })
             }
             // RemoteError
             _ => Self::Err(RemoteError {
                 status_code,
                 protocol_version,
-                status_message: response_aio_data.remove(&UserProperty::StatusMessage),
+                status_message: response_aio_data.remove(&ProtocolReservedUserProperty::StatusMessage),
                 is_application_error: response_aio_data
-                    .get(&UserProperty::IsApplicationError)
+                    .get(&ProtocolReservedUserProperty::IsApplicationError)
                     .is_some_and(|v| v == "true"),
-                invalid_property_name: response_aio_data.remove(&UserProperty::InvalidPropertyName),
+                invalid_property_name: response_aio_data.remove(&ProtocolReservedUserProperty::InvalidPropertyName),
                 invalid_property_value: response_aio_data
-                    .remove(&UserProperty::InvalidPropertyValue),
+                    .remove(&ProtocolReservedUserProperty::InvalidPropertyValue),
                 timestamp,
                 supported_protocol_major_versions: response_aio_data
-                    .get(&UserProperty::SupportedMajorVersions)
+                    .get(&ProtocolReservedUserProperty::SupportedMajorVersions)
                     .map(|s| parse_supported_protocol_major_versions(s)),
             }),
         };
@@ -1138,18 +1138,18 @@ where
 
         // Add internal user properties
         request.custom_user_data.push((
-            UserProperty::SourceId.to_string(),
+            ProtocolReservedUserProperty::SourceId.to_string(),
             self.mqtt_client.client_id().to_string(),
         ));
         request
             .custom_user_data
-            .push((UserProperty::Timestamp.to_string(), timestamp_str));
+            .push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
         request.custom_user_data.push((
-            UserProperty::ProtocolVersion.to_string(),
+            ProtocolReservedUserProperty::ProtocolVersion.to_string(),
             RPC_COMMAND_PROTOCOL_VERSION.to_string(),
         ));
         request.custom_user_data.push((
-            PARTITION_KEY.to_string(),
+            BrokerReservedUserProperty::Partition.to_string(),
             self.mqtt_client.client_id().to_string(),
         ));
 
@@ -1172,6 +1172,12 @@ where
             topic_alias: None,
             subscription_identifiers: Vec::new(),
         };
+
+        // Add backpressure bypass
+        // publish_properties.user_properties.push((
+        //     UserProperty::BackpressureBypass.to_string(),
+        //     "true".to_string(),
+        // ));
 
         // Subscribe to the response topic if we're not already subscribed and the invoker hasn't been shutdown
         {

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -1157,7 +1157,7 @@ where
         ));
         request.custom_user_data.push((
             BrokerReservedUserProperty::HighPriority.to_string(),
-            "".to_string(),
+            String::new(),
         ));
 
         // Cloud Events headers

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -529,6 +529,11 @@ where
                     response_custom_user_data.push((key, value));
                 }
                 Err(()) => {
+                    // Strip broker-reserved properties — they are SDK/broker internals
+                    // and should never appear in user-facing custom_user_data.
+                    if BrokerReservedUserProperty::from_str(&key).is_ok() {
+                        continue;
+                    }
                     response_custom_user_data.push((key, value));
                 }
             }

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -599,8 +599,8 @@ where
                             None,
                         );
                         // Add any invalid properties that might be included for extra information
-                        unknown_err.property_name =
-                            response_aio_data.remove(&ProtocolReservedUserProperty::InvalidPropertyName);
+                        unknown_err.property_name = response_aio_data
+                            .remove(&ProtocolReservedUserProperty::InvalidPropertyName);
                         unknown_err.property_value = response_aio_data
                             .remove(&ProtocolReservedUserProperty::InvalidPropertyValue)
                             .map(Value::String);
@@ -683,11 +683,13 @@ where
             _ => Self::Err(RemoteError {
                 status_code,
                 protocol_version,
-                status_message: response_aio_data.remove(&ProtocolReservedUserProperty::StatusMessage),
+                status_message: response_aio_data
+                    .remove(&ProtocolReservedUserProperty::StatusMessage),
                 is_application_error: response_aio_data
                     .get(&ProtocolReservedUserProperty::IsApplicationError)
                     .is_some_and(|v| v == "true"),
-                invalid_property_name: response_aio_data.remove(&ProtocolReservedUserProperty::InvalidPropertyName),
+                invalid_property_name: response_aio_data
+                    .remove(&ProtocolReservedUserProperty::InvalidPropertyName),
                 invalid_property_value: response_aio_data
                     .remove(&ProtocolReservedUserProperty::InvalidPropertyValue),
                 timestamp,
@@ -1141,9 +1143,10 @@ where
             ProtocolReservedUserProperty::SourceId.to_string(),
             self.mqtt_client.client_id().to_string(),
         ));
-        request
-            .custom_user_data
-            .push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
+        request.custom_user_data.push((
+            ProtocolReservedUserProperty::Timestamp.to_string(),
+            timestamp_str,
+        ));
         request.custom_user_data.push((
             ProtocolReservedUserProperty::ProtocolVersion.to_string(),
             RPC_COMMAND_PROTOCOL_VERSION.to_string(),

--- a/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/invoker.rs
@@ -1152,6 +1152,10 @@ where
             BrokerReservedUserProperty::Partition.to_string(),
             self.mqtt_client.client_id().to_string(),
         ));
+        request.custom_user_data.push((
+            BrokerReservedUserProperty::HighPriority.to_string(),
+            "".to_string(),
+        ));
 
         // Cloud Events headers
         if let Some(cloud_event) = request.cloud_event {

--- a/rust/azure_iot_operations_protocol/src/telemetry/receiver.rs
+++ b/rust/azure_iot_operations_protocol/src/telemetry/receiver.rs
@@ -18,7 +18,7 @@ use crate::{
         hybrid_logical_clock::HybridLogicalClock,
         payload_serialize::{FormatIndicator, PayloadSerialize},
         topic_processor::TopicPattern,
-        user_properties::UserProperty,
+        user_properties::ProtocolReservedUserProperty,
     },
     telemetry::DEFAULT_TELEMETRY_PROTOCOL_VERSION,
 };
@@ -87,14 +87,14 @@ where
 
         // Parse user properties
         let expected_aio_properties = [
-            UserProperty::Timestamp,
-            UserProperty::ProtocolVersion,
-            UserProperty::SourceId,
+            ProtocolReservedUserProperty::Timestamp,
+            ProtocolReservedUserProperty::ProtocolVersion,
+            ProtocolReservedUserProperty::SourceId,
         ];
         let mut telemetry_custom_user_data = vec![];
         let mut telemetry_aio_data = HashMap::new();
         for (key, value) in publish_properties.user_properties {
-            match UserProperty::from_str(&key) {
+            match ProtocolReservedUserProperty::from_str(&key) {
                 Ok(p) if expected_aio_properties.contains(&p) => {
                     telemetry_aio_data.insert(p, value);
                 }
@@ -114,7 +114,7 @@ where
         // If the protocol version is not supported, or cannot be parsed, all bets are off
         // regarding what anything else even means, so this *must* be done first
         let protocol_version = {
-            match telemetry_aio_data.get(&UserProperty::ProtocolVersion) {
+            match telemetry_aio_data.get(&ProtocolReservedUserProperty::ProtocolVersion) {
                 Some(protocol_version) => {
                     if let Some(version) = ProtocolVersion::parse_protocol_version(protocol_version)
                     {
@@ -136,7 +136,7 @@ where
 
         // Format HLC timestamp
         let timestamp = telemetry_aio_data
-            .get(&UserProperty::Timestamp)
+            .get(&ProtocolReservedUserProperty::Timestamp)
             .map(|s| HybridLogicalClock::from_str(s))
             .transpose()
             .map_err(|e| e.to_string())?;
@@ -163,7 +163,7 @@ where
             content_type,
             format_indicator,
             custom_user_data: telemetry_custom_user_data,
-            sender_id: telemetry_aio_data.remove(&UserProperty::SourceId),
+            sender_id: telemetry_aio_data.remove(&ProtocolReservedUserProperty::SourceId),
             timestamp,
             // NOTE: Topic Tokens cannot be created from just a Publish, they need additional information
             topic_tokens: HashMap::default(),

--- a/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
+++ b/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
@@ -19,7 +19,7 @@ use crate::{
         cloud_event as protocol_cloud_event, is_invalid_utf8,
         payload_serialize::{PayloadSerialize, SerializedPayload},
         topic_processor::TopicPattern,
-        user_properties::{PERSIST_KEY, UserProperty, validate_user_properties},
+        user_properties::{BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties},
     },
     telemetry::{DEFAULT_TELEMETRY_CLOUD_EVENT_EVENT_TYPE, TELEMETRY_PROTOCOL_VERSION},
 };
@@ -447,21 +447,21 @@ where
         if message.persist {
             message
                 .custom_user_data
-                .push((PERSIST_KEY.to_string(), true.to_string()));
+                .push((BrokerReservedUserProperty::Persist.to_string(), true.to_string()));
         }
 
         // Add internal user properties
         message
             .custom_user_data
-            .push((UserProperty::Timestamp.to_string(), timestamp_str));
+            .push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
 
         message.custom_user_data.push((
-            UserProperty::ProtocolVersion.to_string(),
+            ProtocolReservedUserProperty::ProtocolVersion.to_string(),
             TELEMETRY_PROTOCOL_VERSION.to_string(),
         ));
 
         message.custom_user_data.push((
-            UserProperty::SourceId.to_string(),
+            ProtocolReservedUserProperty::SourceId.to_string(),
             self.mqtt_client.client_id().to_string(),
         ));
 

--- a/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
+++ b/rust/azure_iot_operations_protocol/src/telemetry/sender.rs
@@ -19,7 +19,9 @@ use crate::{
         cloud_event as protocol_cloud_event, is_invalid_utf8,
         payload_serialize::{PayloadSerialize, SerializedPayload},
         topic_processor::TopicPattern,
-        user_properties::{BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties},
+        user_properties::{
+            BrokerReservedUserProperty, ProtocolReservedUserProperty, validate_user_properties,
+        },
     },
     telemetry::{DEFAULT_TELEMETRY_CLOUD_EVENT_EVENT_TYPE, TELEMETRY_PROTOCOL_VERSION},
 };
@@ -445,15 +447,17 @@ where
 
         // Persist header
         if message.persist {
-            message
-                .custom_user_data
-                .push((BrokerReservedUserProperty::Persist.to_string(), true.to_string()));
+            message.custom_user_data.push((
+                BrokerReservedUserProperty::Persist.to_string(),
+                true.to_string(),
+            ));
         }
 
         // Add internal user properties
-        message
-            .custom_user_data
-            .push((ProtocolReservedUserProperty::Timestamp.to_string(), timestamp_str));
+        message.custom_user_data.push((
+            ProtocolReservedUserProperty::Timestamp.to_string(),
+            timestamp_str,
+        ));
 
         message.custom_user_data.push((
             ProtocolReservedUserProperty::ProtocolVersion.to_string(),


### PR DESCRIPTION
* Fixed an incorrect API leak of internally used types related to properties
  * Technically, this is breaking, however there was no utility of using the exposed types as they were not intended to be exposed. If this breaks someone for some reason, we can add back in a compatibility fix.
* Made a formal split between broker-reserved properties (defined/owned by the MQ broker) and protocol-reserved properties (defined/owned by the protocol)
* Added the concept of broker properties being "user-restricted", as not all values are treated the same way wrt validation. There probably needs to be more work done on this story.
* Added the `HighPriority` broker-reserved property (i.e. `$high_priority`) to support broker backpressure bypass functionality.
  * It is NOT user-restricted, so the user can currently set it.
  * It is always used for RPC protocol but not set for Telemetry
* Fixed some documentation regarding validation that was incorrect.
* Added a few tests related to properties and their restrictions.

Writing this PR revealed some inconsistency in how properties are handled both within Rust and across languages. I have added some notes to that effect inline, but fixing them is out of scope for this PR and needs wider alignment.