### PR TITLE
[Rust][MQTT] Disable Nagle's algorithm (TCP_NODELAY)

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
@@ -137,6 +137,10 @@ impl Default for ClientOptions {
 pub struct ConnectionTransportConfig {
     pub transport_type: ConnectionTransportType,
     pub timeout: Option<Duration>,
+    /// Whether to disable Nagle's algorithm (`TCP_NODELAY`) on the underlying TCP socket.
+    /// Setting this to `true` reduces latency for small, frequent packets at the cost of slightly
+    /// more packet overhead.
+    pub tcp_nodelay: bool,
 }
 
 /// The type of transport to use for the new connection.
@@ -642,6 +646,7 @@ impl ConnectHandle {
         let ConnectionTransportConfig {
             transport_type,
             timeout,
+            tcp_nodelay,
         } = transport_config;
         Ok(match transport_type {
             ConnectionTransportType::Tcp { hostname, port } => {
@@ -649,6 +654,7 @@ impl ConnectHandle {
                     timeout,
                     crate::azure_mqtt::io::tokio_tcp::connect(
                         (hostname, port),
+                        tcp_nodelay,
                         &self.reader_pool,
                         &self.writer_pool,
                     ),
@@ -667,6 +673,7 @@ impl ConnectHandle {
                         &hostname,
                         port,
                         config,
+                        tcp_nodelay,
                         &self.reader_pool,
                         &self.writer_pool,
                     ),
@@ -681,7 +688,12 @@ impl ConnectHandle {
             } => {
                 maybe_timeout(
                     timeout,
-                    crate::azure_mqtt::io::tokio_ws::connect(request, tls_config, &self.reader_pool),
+                    crate::azure_mqtt::io::tokio_ws::connect(
+                        request,
+                        tls_config,
+                        tcp_nodelay,
+                        &self.reader_pool,
+                    ),
                 )
                 .await??
             }

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tcp.rs
@@ -20,6 +20,7 @@ use crate::azure_mqtt::io::{ReadableStream, Reader, WritableStream, Writer};
 // TODO: Also take max packet size and forward it to `Reader`.
 pub async fn connect<BP>(
     addr: impl ToSocketAddrs,
+    tcp_nodelay: bool,
     reader_pool: &BP,
     writer_pool: &BP,
 ) -> io::Result<(Reader<BP>, Writer<BP>)>
@@ -27,6 +28,7 @@ where
     BP: BufferPool,
 {
     let stream = TcpStream::connect(addr).await?;
+    stream.set_nodelay(tcp_nodelay)?;
     Ok(connect_inner(stream, reader_pool, writer_pool))
 }
 

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_tls.rs
@@ -44,13 +44,14 @@ pub async fn connect<BP>(
     hostname: &str,
     port: u16,
     config: ConnectionTransportTlsConfig,
+    tcp_nodelay: bool,
     reader_pool: &BP,
     writer_pool: &BP,
 ) -> io::Result<(Reader<BP>, Writer<BP>)>
 where
     BP: BufferPool,
 {
-    Ok(match connect_inner(hostname, port, config).await? {
+    Ok(match connect_inner(hostname, port, config, tcp_nodelay).await? {
         Either::Left(tcp_stream) => tokio_tcp::connect_inner(tcp_stream, reader_pool, writer_pool),
 
         Either::Right(ssl_stream) => {
@@ -70,6 +71,7 @@ pub(crate) async fn connect_inner(
     hostname: &str,
     port: u16,
     config: ConnectionTransportTlsConfig,
+    tcp_nodelay: bool,
 ) -> io::Result<Either<TcpStream, SslStream<TcpStream>>> {
     /// We haven't attempted to create a TLS connection yet, so whether the kernel supports TLS or not
     /// is not yet known.
@@ -92,6 +94,7 @@ pub(crate) async fn connect_inner(
         let connector = connector.build();
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        tcp_stream.set_nodelay(tcp_nodelay)?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -129,6 +132,7 @@ pub(crate) async fn connect_inner(
         let connector = connector.build();
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        tcp_stream.set_nodelay(tcp_nodelay)?;
 
         let std_tcp_stream = {
             let fd = tcp_stream.as_fd();
@@ -148,6 +152,7 @@ pub(crate) async fn connect_inner(
         debug_assert_eq!(method, TLS_METHOD_USERSPACE);
 
         let tcp_stream = TcpStream::connect((hostname, port)).await?;
+        tcp_stream.set_nodelay(tcp_nodelay)?;
 
         let connector = connector.build().configure()?;
 

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -29,6 +29,7 @@ use crate::azure_mqtt::io::{ReadableStream, Reader, WritableStream, Writer, toki
 pub async fn connect<BP>(
     request: impl IntoClientRequest,
     tls_config: ConnectionTransportTlsConfig,
+    tcp_nodelay: bool,
     reader_pool: &BP,
 ) -> io::Result<(Reader<BP>, Writer<BP>)>
 where
@@ -53,8 +54,14 @@ where
         ));
     };
     let stream = match scheme {
-        "https" | "wss" => tokio_tls::connect_inner(addr, port.unwrap_or(443), tls_config).await?,
-        "http" | "ws" => Either::Left(TcpStream::connect((addr, port.unwrap_or(80))).await?),
+        "https" | "wss" => {
+            tokio_tls::connect_inner(addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
+        }
+        "http" | "ws" => {
+            let stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
+            stream.set_nodelay(tcp_nodelay)?;
+            Either::Left(stream)
+        }
         _ => {
             return Err(IoError::new(
                 io::ErrorKind::InvalidInput,

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
@@ -176,7 +176,7 @@ fn create_connection_transport_config(
     Ok(ConnectionTransportConfig {
         transport_type,
         timeout: Some(timeout),
-        // Disable the Nagle algorithm (hardcoded) to minimize latency
+        // Disable Nagle's algorithm (`TCP_NODELAY`) (hardcoded) to minimize latency
         tcp_nodelay: true,
     })
 }

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
@@ -176,6 +176,8 @@ fn create_connection_transport_config(
     Ok(ConnectionTransportConfig {
         transport_type,
         timeout: Some(timeout),
+        // Disable the Nagle algorithm (hardcoded) to minimize latency
+        tcp_nodelay: true,
     })
 }
 
@@ -235,6 +237,7 @@ impl AzureMqttConnectParameters {
                     outgoing_packets: outgoing_packets_tx,
                 },
                 timeout: Some(self.connection_timeout),
+                tcp_nodelay: true,
             });
         }
 


### PR DESCRIPTION
* Added transport configuration for `tcp_nodelay`
* Hardcoded the setting to `true` for the AIO `Session`

Re-implementation of #1344 and #1358 so that gateway tests can be passed from an internal branch.