### PR TITLE
[Services][Edge Registry] Rename Validated schema type to ValidationStatus

### DIFF
--- a/eng/wot/edge-registry/core-xregistry/ValidationStatus.schema.json
+++ b/eng/wot/edge-registry/core-xregistry/ValidationStatus.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "title": "Validated",
+  "title": "ValidationStatus",
   "description": "Indicates whether validation was performed, and if not, the reason why not (e.g., \"unsupported format\", \"validation disabled\").",
   "type": "object",
   "additionalProperties": false,

--- a/eng/wot/edge-registry/core-xregistry/Version.schema.json
+++ b/eng/wot/edge-registry/core-xregistry/Version.schema.json
@@ -85,11 +85,11 @@
     },
     "formatValidated": {
       "description": "When format validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its `format` attribute.",
-      "$ref": "Validated.schema.json"
+      "$ref": "ValidationStatus.schema.json"
     },
     "compatibilityValidated": {
       "description": "When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.",
-      "$ref": "Validated.schema.json"
+      "$ref": "ValidationStatus.schema.json"
     },
     "document": {
       "description": "The raw document content for this Version as base64-encoded bytes. The interpretation (schema, thing description, thing model, …) is determined by the parent Resource's type.",

--- a/eng/wot/edge-registry/schema-extension/SchemaVersion.schema.json
+++ b/eng/wot/edge-registry/schema-extension/SchemaVersion.schema.json
@@ -97,11 +97,11 @@
     },
     "formatValidated": {
       "description": "When format validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its `format` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "compatibilityValidated": {
       "description": "When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "extensions": {
       "description": "Extension-specific attributes.",

--- a/eng/wot/edge-registry/thing-description-extension/ThingDescriptionVersion.schema.json
+++ b/eng/wot/edge-registry/thing-description-extension/ThingDescriptionVersion.schema.json
@@ -97,11 +97,11 @@
     },
     "formatValidated": {
       "description": "When format validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its `format` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "compatibilityValidated": {
       "description": "When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "extensions": {
       "description": "Extension-specific attributes.",

--- a/eng/wot/edge-registry/thing-model-extension/ThingModelVersion.schema.json
+++ b/eng/wot/edge-registry/thing-model-extension/ThingModelVersion.schema.json
@@ -97,11 +97,11 @@
     },
     "formatValidated": {
       "description": "When format validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its `format` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "compatibilityValidated": {
       "description": "When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.",
-      "$ref": "../core-xregistry/Validated.schema.json"
+      "$ref": "../core-xregistry/ValidationStatus.schema.json"
     },
     "extensions": {
       "description": "Extension-specific attributes.",

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry.rs
@@ -196,7 +196,7 @@ mod thing_model_version_serialization;
 mod thing_model_version_xid;
 mod thing_model_version_xid_list;
 mod thing_model_version_xid_list_serialization;
-mod validated;
+mod validation_status;
 mod version;
 mod version_attributes;
 mod version_serialization;
@@ -341,7 +341,7 @@ pub mod client {
     pub use super::thing_model_version::*;
     pub use super::thing_model_version_xid::*;
     pub use super::thing_model_version_xid_list::*;
-    pub use super::validated::*;
+    pub use super::validation_status::*;
     pub use super::version::*;
     pub use super::version_attributes::*;
     pub use super::version_xid::*;

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/schema_version.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/schema_version.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use super::super::common_types::{b64::Bytes, date_only::Date, decimal::Decimal, time_only::Time};
 use super::label::Label;
-use super::validated::Validated;
+use super::validation_status::ValidationStatus;
 
 /// A specific Version of a Schema. Self-contained: combines the generic Version fields and the schema-specific fields into one schema, with integer-typed versionId and ancestor.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -89,13 +89,13 @@ pub struct SchemaVersion {
     #[serde(rename = "formatValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub format_validated: Option<Validated>,
+    pub format_validated: Option<ValidationStatus>,
 
     /// When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.
     #[serde(rename = "compatibilityValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub compatibility_validated: Option<Validated>,
+    pub compatibility_validated: Option<ValidationStatus>,
 
     /// Extension-specific attributes.
     #[builder(default)]

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_description_version.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_description_version.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use super::super::common_types::{b64::Bytes, date_only::Date, decimal::Decimal, time_only::Time};
 use super::label::Label;
-use super::validated::Validated;
+use super::validation_status::ValidationStatus;
 
 /// A specific Version of a Thing Description. Self-contained: combines the generic Version fields and the thing description-specific fields into one schema, with integer-typed versionId and ancestor.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -89,13 +89,13 @@ pub struct ThingDescriptionVersion {
     #[serde(rename = "formatValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub format_validated: Option<Validated>,
+    pub format_validated: Option<ValidationStatus>,
 
     /// When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.
     #[serde(rename = "compatibilityValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub compatibility_validated: Option<Validated>,
+    pub compatibility_validated: Option<ValidationStatus>,
 
     /// Extension-specific attributes.
     #[builder(default)]

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_model_version.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_model_version.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use super::super::common_types::{b64::Bytes, date_only::Date, decimal::Decimal, time_only::Time};
 use super::label::Label;
-use super::validated::Validated;
+use super::validation_status::ValidationStatus;
 
 /// A specific Version of a Thing Model. Self-contained: combines the generic Version fields and the thing model-specific fields into one schema, with integer-typed versionId and ancestor.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -89,13 +89,13 @@ pub struct ThingModelVersion {
     #[serde(rename = "formatValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub format_validated: Option<Validated>,
+    pub format_validated: Option<ValidationStatus>,
 
     /// When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.
     #[serde(rename = "compatibilityValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub compatibility_validated: Option<Validated>,
+    pub compatibility_validated: Option<ValidationStatus>,
 
     /// Extension-specific attributes.
     #[builder(default)]

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/validation_status.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/validation_status.rs
@@ -13,7 +13,7 @@ use super::super::common_types::{b64::Bytes, date_only::Date, decimal::Decimal, 
 
 /// Indicates whether validation was performed, and if not, the reason why not (e.g., "unsupported format", "validation disabled").
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
-pub struct Validated {
+pub struct ValidationStatus {
     /// True if validation was performed and the entity adheres to the rules; false if validation was not performed.
     pub validated: bool,
 

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use super::super::common_types::{b64::Bytes, date_only::Date, decimal::Decimal, time_only::Time};
 use super::label::Label;
-use super::validated::Validated;
+use super::validation_status::ValidationStatus;
 
 /// A specific Version of a Resource.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -84,13 +84,13 @@ pub struct Version {
     #[serde(rename = "formatValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub format_validated: Option<Validated>,
+    pub format_validated: Option<ValidationStatus>,
 
     /// When compatibility validation is enabled, indicates whether the server has validated that the Version conforms to the rules defined by its Resource's `meta.compatibility` attribute.
     #[serde(rename = "compatibilityValidated")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
-    pub compatibility_validated: Option<Validated>,
+    pub compatibility_validated: Option<ValidationStatus>,
 
     /// The raw document content for this Version as base64-encoded bytes. The interpretation (schema, thing description, thing model, …) is determined by the parent Resource's type.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
@@ -31,8 +31,8 @@ pub enum Validated {
     False(String),
 }
 
-impl From<client_gen::Validated> for Validated {
-    fn from(value: client_gen::Validated) -> Self {
+impl From<client_gen::ValidationStatus> for Validated {
+    fn from(value: client_gen::ValidationStatus) -> Self {
         if value.validated {
             // Per the model, `reason` MUST NOT be present when `validated` is true.
             // Any value is dropped here, as the `True` variant carries no reason.


### PR DESCRIPTION
This pull request updates the schema reference for validation status across multiple JSON schema files to improve clarity and consistency. The main change is renaming the `Validated.schema.json` file to `ValidationStatus.schema.json` and updating all references to use the new name. This helps make the purpose of the schema clearer and ensures all related files point to the correct, consistently named schema.

**Schema renaming and reference updates:**

* Renamed `Validated.schema.json` to `ValidationStatus.schema.json` and updated the `$title` field accordingly.
* Updated all references from `Validated.schema.json` to `ValidationStatus.schema.json` in the following files:
  * `Version.schema.json`
  * `SchemaVersion.schema.json`
  * `ThingDescriptionVersion.schema.json`
  * `ThingModelVersion.schema.json`