### PR TITLE
[Rust] Make TLS config optional for WS connections

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
@@ -157,7 +157,7 @@ pub enum ConnectionTransportType {
     #[cfg(feature = "test-utils")]
     Ws {
         request: async_tungstenite::tungstenite::handshake::client::Request,
-        tls_config: ConnectionTransportTlsConfig,
+        tls_config: Option<ConnectionTransportTlsConfig>,
     },
     #[cfg(feature = "test-utils")]
     Test {

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -48,7 +48,6 @@ where
         ));
     };
     let port = request.uri().port_u16();
-
     let Some(scheme) = request.uri().scheme_str() else {
         return Err(io::Error::other(
             "request URI does not contain a scheme component",

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -11,7 +11,11 @@ use std::{
 use async_tungstenite::{
     WebSocketStream as TungsteniteWebSocketStream,
     tokio::TokioAdapter,
-    tungstenite::{self, Bytes, Message, client::IntoClientRequest, http::HeaderValue},
+    tungstenite::{
+        self, Bytes, Message,
+        client::IntoClientRequest,
+        http::{HeaderMap, HeaderValue, header as http_header},
+    },
 };
 use either::Either;
 use futures_util::{Sink, Stream};
@@ -38,16 +42,16 @@ where
     let mut request = request
         .into_client_request()
         .map_err(tungstenite_err_to_io_err)?;
-    request
-        .headers_mut()
-        .insert("Sec-WebSocket-Protocol", HeaderValue::from_static("mqtt"));
 
-    let Some(addr) = request.uri().host() else {
+    let Some(addr) = request.uri().host().map(ToString::to_string) else {
         return Err(io::Error::other(
             "request URI does not contain a host component",
         ));
     };
     let port = request.uri().port_u16();
+
+    set_websocket_headers(&addr, port, request.headers_mut())?;
+
     let Some(scheme) = request.uri().scheme_str() else {
         return Err(io::Error::other(
             "request URI does not contain a scheme component",
@@ -55,7 +59,7 @@ where
     };
     let stream = match scheme {
         "https" | "wss" => {
-            tokio_tls::connect_inner(addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
+            tokio_tls::connect_inner(&addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
         }
         "http" | "ws" => {
             let stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
@@ -104,6 +108,60 @@ where
             ))
         }
     }
+}
+
+/// Adds defaults for unspecified WebSockets handshake headers.
+fn set_websocket_headers(addr: &str, port: Option<u16>, headers: &mut HeaderMap) -> io::Result<()> {
+    if !headers.contains_key(http_header::HOST) {
+        let host = if let Some(port) = port {
+            HeaderValue::from_str(&format!("{addr}:{port}"))
+        } else {
+            HeaderValue::from_str(addr)
+        }
+        .map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid http host: {err}"),
+            )
+        })?;
+
+        headers.insert(http_header::HOST, host);
+    }
+
+    if !headers.contains_key(http_header::CONNECTION) {
+        headers.insert(http_header::CONNECTION, HeaderValue::from_static("upgrade"));
+    }
+
+    if !headers.contains_key(http_header::UPGRADE) {
+        headers.insert(http_header::UPGRADE, HeaderValue::from_static("websocket"));
+    }
+
+    if !headers.contains_key(http_header::SEC_WEBSOCKET_KEY) {
+        let key = async_tungstenite::tungstenite::handshake::client::generate_key();
+        let key = HeaderValue::from_str(&key).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid sec-websocket-key: {err}"),
+            )
+        })?;
+        headers.insert(http_header::SEC_WEBSOCKET_KEY, key);
+    }
+
+    if !headers.contains_key(http_header::SEC_WEBSOCKET_PROTOCOL) {
+        headers.insert(
+            http_header::SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("mqtt"),
+        );
+    }
+
+    if !headers.contains_key(http_header::SEC_WEBSOCKET_VERSION) {
+        headers.insert(
+            http_header::SEC_WEBSOCKET_VERSION,
+            HeaderValue::from_static("13"),
+        );
+    }
+
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -32,7 +32,7 @@ use crate::azure_mqtt::io::{ReadableStream, Reader, WritableStream, Writer, toki
 /// and use the given buffer pools to initialize the buffers for the stream reader and writer.
 pub async fn connect<BP>(
     request: impl IntoClientRequest,
-    tls_config: ConnectionTransportTlsConfig,
+    tls_config: Option<ConnectionTransportTlsConfig>,
     tcp_nodelay: bool,
     reader_pool: &BP,
 ) -> io::Result<(Reader<BP>, Writer<BP>)>
@@ -57,22 +57,22 @@ where
             "request URI does not contain a scheme component",
         ));
     };
-    let stream = match scheme {
-        "https" | "wss" => {
-            tokio_tls::connect_inner(&addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
-        }
-        "http" | "ws" => {
-            let stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
-            stream.set_nodelay(tcp_nodelay)?;
-            Either::Left(stream)
-        }
-        _ => {
-            return Err(IoError::new(
-                io::ErrorKind::InvalidInput,
-                format!("unsupported WebSocket URI scheme: {scheme}"),
-            ));
-        }
+
+    if !["http", "https", "ws", "wss"].contains(&scheme) {
+        return Err(IoError::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsupported WebSocket URI scheme: {scheme}"),
+        ));
+    }
+
+    let stream = if let Some(tls_config) = tls_config {
+        tokio_tls::connect_inner(&addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
+    } else {
+        let stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
+        stream.set_nodelay(tcp_nodelay)?;
+        Either::Left(stream)
     };
+
     match stream {
         Either::Left(stream) => {
             let (stream, _response) = async_tungstenite::tokio::client_async(request, stream)

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -11,11 +11,7 @@ use std::{
 use async_tungstenite::{
     WebSocketStream as TungsteniteWebSocketStream,
     tokio::TokioAdapter,
-    tungstenite::{
-        self, Bytes, Message,
-        client::IntoClientRequest,
-        http::{HeaderMap, HeaderValue, header as http_header},
-    },
+    tungstenite::{self, Bytes, Message, client::IntoClientRequest, http::HeaderValue},
 };
 use either::Either;
 use futures_util::{Sink, Stream};
@@ -42,6 +38,9 @@ where
     let mut request = request
         .into_client_request()
         .map_err(tungstenite_err_to_io_err)?;
+    request
+        .headers_mut()
+        .insert("Sec-WebSocket-Protocol", HeaderValue::from_static("mqtt"));
 
     let Some(addr) = request.uri().host().map(ToString::to_string) else {
         return Err(io::Error::other(
@@ -49,8 +48,6 @@ where
         ));
     };
     let port = request.uri().port_u16();
-
-    set_websocket_headers(&addr, port, request.headers_mut())?;
 
     let Some(scheme) = request.uri().scheme_str() else {
         return Err(io::Error::other(
@@ -108,60 +105,6 @@ where
             ))
         }
     }
-}
-
-/// Adds defaults for unspecified WebSockets handshake headers.
-fn set_websocket_headers(addr: &str, port: Option<u16>, headers: &mut HeaderMap) -> io::Result<()> {
-    if !headers.contains_key(http_header::HOST) {
-        let host = if let Some(port) = port {
-            HeaderValue::from_str(&format!("{addr}:{port}"))
-        } else {
-            HeaderValue::from_str(addr)
-        }
-        .map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("invalid http host: {err}"),
-            )
-        })?;
-
-        headers.insert(http_header::HOST, host);
-    }
-
-    if !headers.contains_key(http_header::CONNECTION) {
-        headers.insert(http_header::CONNECTION, HeaderValue::from_static("upgrade"));
-    }
-
-    if !headers.contains_key(http_header::UPGRADE) {
-        headers.insert(http_header::UPGRADE, HeaderValue::from_static("websocket"));
-    }
-
-    if !headers.contains_key(http_header::SEC_WEBSOCKET_KEY) {
-        let key = async_tungstenite::tungstenite::handshake::client::generate_key();
-        let key = HeaderValue::from_str(&key).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid sec-websocket-key: {err}"),
-            )
-        })?;
-        headers.insert(http_header::SEC_WEBSOCKET_KEY, key);
-    }
-
-    if !headers.contains_key(http_header::SEC_WEBSOCKET_PROTOCOL) {
-        headers.insert(
-            http_header::SEC_WEBSOCKET_PROTOCOL,
-            HeaderValue::from_static("mqtt"),
-        );
-    }
-
-    if !headers.contains_key(http_header::SEC_WEBSOCKET_VERSION) {
-        headers.insert(
-            http_header::SEC_WEBSOCKET_VERSION,
-            HeaderValue::from_static("13"),
-        );
-    }
-
-    Ok(())
 }
 
 #[derive(Debug)]

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/io/tokio_ws.rs
@@ -42,7 +42,7 @@ where
         .headers_mut()
         .insert("Sec-WebSocket-Protocol", HeaderValue::from_static("mqtt"));
 
-    let Some(addr) = request.uri().host().map(ToString::to_string) else {
+    let Some(addr) = request.uri().host() else {
         return Err(io::Error::other(
             "request URI does not contain a host component",
         ));
@@ -63,7 +63,7 @@ where
     }
 
     let stream = if let Some(tls_config) = tls_config {
-        tokio_tls::connect_inner(&addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
+        tokio_tls::connect_inner(addr, port.unwrap_or(443), tls_config, tcp_nodelay).await?
     } else {
         let stream = TcpStream::connect((addr, port.unwrap_or(80))).await?;
         stream.set_nodelay(tcp_nodelay)?;


### PR DESCRIPTION
Makes the TLS config optional for plain WS transport types, as it's not needed.