### PR TITLE
Bump .NET Services version to 1.3.0-beta1 for 6/30/2026 release

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -6,7 +6,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
+++ b/dotnet/src/Azure.Iot.Operations.Services/Azure.Iot.Operations.Services.csproj
@@ -7,6 +7,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <Authors>Microsoft</Authors>
     <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionSuffix>beta1</VersionSuffix>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Bumps `Azure.Iot.Operations.Services` from 1.2.2 to 1.3.0-beta1.

Minor (semver) bump for the new backward-compatible xRegistry / Edge Registry client APIs added since the last .NET release (#1371):
- #1374 Core xRegistry APIs
- #1381 Schema, TM and TD Edge Registry client extensions
- #1386 Delete options, Core-prefix generic models

No other packages (Mqtt, Protocol, Connector) changed since the last release, so only Services is bumped.