### PR TITLE
Bump statestore-cli AIO SDK deps to 1.x-rc

### DIFF
--- a/.github/workflows/ci-statestore-cli.yml
+++ b/.github/workflows/ci-statestore-cli.yml
@@ -28,6 +28,6 @@ jobs:
     with:
       name: statestore-cli
       path: tools/statestore-cli
-      aio-sdks-registry: true
+      aio-sdks-registry: false
     secrets:
       aio-sdks-token: ${{ secrets.CARGO_REGISTRIES_AIO_SDKS_TOKEN }}

--- a/tools/statestore-cli/.cargo/config.toml
+++ b/tools/statestore-cli/.cargo/config.toml
@@ -1,2 +1,0 @@
-[registries]
-aio-sdks = { index = "sparse+https://pkgs.dev.azure.com/azure-iot-sdks/iot-operations/_packaging/preview/Cargo/index/" }

--- a/tools/statestore-cli/Cargo.toml
+++ b/tools/statestore-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "statestore-cli"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Azure IoT Operations State Store Command-Line-Interface Tool"
@@ -14,9 +14,9 @@ readme = "readme.md"
 publish = false
 
 [dependencies]
-azure_iot_operations_protocol = { version = "1.0.1-rc1", registry = "aio-sdks" }
-azure_iot_operations_mqtt = { version = "1.1.0-rc1", registry = "aio-sdks" }
-azure_iot_operations_services = { version = "1.3.0-rc1", registry = "aio-sdks", features = ["state_store"]}
+azure_iot_operations_protocol = { version = "1.0.1-rc1" }
+azure_iot_operations_mqtt = { version = "1.1.0-rc1" }
+azure_iot_operations_services = { version = "1.3.0-rc1", features = ["state_store"]}
 log = "0.4.21"
 tokio = { version = "1.41", features = ["rt", "time", "sync"] }
 clap = { version = "4.0", features = ["derive"] }

--- a/tools/statestore-cli/Cargo.toml
+++ b/tools/statestore-cli/Cargo.toml
@@ -14,9 +14,9 @@ readme = "readme.md"
 publish = false
 
 [dependencies]
-azure_iot_operations_protocol = { version = "0.9", registry = "aio-sdks" }
-azure_iot_operations_mqtt = { version = "0.9", registry = "aio-sdks" }
-azure_iot_operations_services = { version = "0.8", registry = "aio-sdks", features = ["state_store"]}
+azure_iot_operations_protocol = { version = "1.0.1-rc1", registry = "aio-sdks" }
+azure_iot_operations_mqtt = { version = "1.1.0-rc1", registry = "aio-sdks" }
+azure_iot_operations_services = { version = "1.3.0-rc1", registry = "aio-sdks", features = ["state_store"]}
 log = "0.4.21"
 tokio = { version = "1.41", features = ["rt", "time", "sync"] }
 clap = { version = "4.0", features = ["derive"] }

--- a/tools/statestore-cli/Dockerfile
+++ b/tools/statestore-cli/Dockerfile
@@ -14,9 +14,8 @@ RUN tdnf remove -y rust; \
     tdnf install -y openssl-devel clang; \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION --profile minimal
 
-RUN --mount=type=secret,id=CARGO_TOKEN,target=/run/secrets/cargo_token \
-    CARGO_REGISTRIES_AIO_SDKS_TOKEN=$(cat /run/secrets/cargo_token) \
-    cargo build -p "statestore-cli" --release
+# AIO SDK deps resolve from public crates.io (no aio-sdks feed), so no CARGO_TOKEN secret is needed.
+RUN cargo build -p "statestore-cli" --release
 
 # Finalize image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS final

--- a/tools/statestore-cli/Dockerfile
+++ b/tools/statestore-cli/Dockerfile
@@ -3,13 +3,13 @@
 FROM mcr.microsoft.com/azurelinux/base/rust:1.75 AS build
 
 # RUST_VERSION should be the value of "channel" in rust-toolchain.toml
-ARG RUST_VERSION=1.89
+ARG RUST_VERSION=1.88
 
 # Move source code from build context into /app folder
 COPY --link / /app
 WORKDIR /app
 
-# Force Install Rust 1.89
+# Force Install Rust 1.88
 RUN tdnf remove -y rust; \
     tdnf install -y openssl-devel clang; \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION --profile minimal

--- a/tools/statestore-cli/rust-toolchain.toml
+++ b/tools/statestore-cli/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89"
+channel = "1.88"
 components = ["clippy", "rustfmt"]

--- a/tools/statestore-cli/src/main.rs
+++ b/tools/statestore-cli/src/main.rs
@@ -8,16 +8,15 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 use env_logger::Builder;
 
+use azure_iot_operations_mqtt::aio::connection_settings::MqttConnectionSettingsBuilder;
 use azure_iot_operations_mqtt::session::{
-    Session, SessionConnectionMonitor, SessionExitHandle, SessionManagedClient,
-    SessionOptionsBuilder,
+    Session, SessionExitHandle, SessionManagedClient, SessionMonitor, SessionOptionsBuilder,
 };
-use azure_iot_operations_mqtt::MqttConnectionSettingsBuilder;
 use azure_iot_operations_protocol::application::{ApplicationContext, ApplicationContextBuilder};
 use azure_iot_operations_services::state_store::{self, SetOptions};
 
 const TOOL_NAME: &str = "statestore-cli";
-const TOOL_VERSION: &str = "0.0.2";
+const TOOL_VERSION: &str = "0.1.0";
 const TOOL_ABOUT_SHORT: &str = "Azure Device State Store CLI";
 const TOOL_ABOUT_LONG: &str = "Allows managing key/value pairs in the Azure State Store.";
 
@@ -130,7 +129,7 @@ async fn main() {
             let get_join_handle = tokio::task::spawn(state_store_get_value(
                 application_context.clone(),
                 session.create_managed_client(),
-                session.create_connection_monitor(),
+                session.create_session_monitor(),
                 session.create_exit_handle(),
                 key,
                 valuefile,
@@ -153,7 +152,7 @@ async fn main() {
             let set_join_handle = tokio::task::spawn(state_store_set_value(
                 application_context.clone(),
                 session.create_managed_client(),
-                session.create_connection_monitor(),
+                session.create_session_monitor(),
                 session.create_exit_handle(),
                 key,
                 actual_value,
@@ -167,7 +166,7 @@ async fn main() {
             let delete_join_handle = tokio::task::spawn(state_store_delete_key(
                 application_context.clone(),
                 session.create_managed_client(),
-                session.create_connection_monitor(),
+                session.create_session_monitor(),
                 session.create_exit_handle(),
                 key,
             ));
@@ -184,7 +183,7 @@ async fn main() {
 async fn state_store_get_value(
     context: ApplicationContext,
     client: SessionManagedClient,
-    connection_monitor: SessionConnectionMonitor,
+    connection_monitor: SessionMonitor,
     exit_handle: SessionExitHandle,
     key: String,
     valuefile: Option<String>,
@@ -219,7 +218,7 @@ async fn state_store_get_value(
         None => 1,
     };
 
-    match exit_handle.try_exit().await {
+    match exit_handle.try_exit() {
         Ok(_exit_result) => {}
         Err(_exit_error) => {}
     }
@@ -230,7 +229,7 @@ async fn state_store_get_value(
 async fn state_store_set_value(
     context: ApplicationContext,
     client: SessionManagedClient,
-    connection_monitor: SessionConnectionMonitor,
+    connection_monitor: SessionMonitor,
     exit_handle: SessionExitHandle,
     key: String,
     value: String,
@@ -266,7 +265,7 @@ async fn state_store_set_value(
     // i32::from does false -> 0 and true -> 1, but we want to return 0 on success and 1 on failure, so we check if the response is false rather than true.
     let result = i32::from(!set_response.response);
 
-    match exit_handle.try_exit().await {
+    match exit_handle.try_exit() {
         Ok(_exit_result) => {}
         Err(_exit_error) => {}
     }
@@ -277,7 +276,7 @@ async fn state_store_set_value(
 async fn state_store_delete_key(
     context: ApplicationContext,
     client: SessionManagedClient,
-    connection_monitor: SessionConnectionMonitor,
+    connection_monitor: SessionMonitor,
     exit_handle: SessionExitHandle,
     key: String,
 ) -> i32 {
@@ -302,7 +301,7 @@ async fn state_store_delete_key(
     // i32::from does false -> 0 and true -> 1, but we want to return 0 on success and 1 on failure, so we are evaluating a boolean where the failure case evaluates to true.
     let result = i32::from(delete_response.response != 1);
 
-    match exit_handle.try_exit().await {
+    match exit_handle.try_exit() {
         Ok(_exit_result) => {}
         Err(_exit_error) => {}
     }


### PR DESCRIPTION
Bumps the AIO SDK crates consumed by `statestore-cli` to the 2607 target release candidates, and switches dependency resolution to **public crates.io** — these crates (incl. `-rc`) are published there by `microsoft-oss-releases`, so this tool no longer needs the private `aio-sdks` Cargo feed.

| crate | from | to |
|---|---|---|
| `azure_iot_operations_protocol` | 0.9 | **1.0.1-rc1** |
| `azure_iot_operations_mqtt` | 0.9 | **1.1.0-rc1** |
| `azure_iot_operations_services` | 0.8 | **1.3.0-rc1** |

These match the versions the host-app (`tinykube`) already consumes.

**Changes (`tools/statestore-cli/`):**
- `Cargo.toml` — bump the three SDK deps (above) and **drop the `registry = "aio-sdks"` annotations** so they resolve from crates.io; bump the crate's own `version` `0.0.2 → 0.1.0`.
- **Delete `.cargo/config.toml`** — the `aio-sdks` registry index is no longer referenced.
- `Dockerfile` + `rust-toolchain.toml` — pin the Rust toolchain `1.89 → 1.88`.

**Verification:** the `CI-statestore-cli` workflow auto-runs on this PR (path `tools/statestore-cli/**`).

_Draft — automated SDK-version bump. A human reviews / merges / releases._
