### PR TITLE
[Cherry-Pick][Rust][MQTT][Protocol][Services] Remove -rc version suffixes for some 2607 releases (#1410)

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 publish = true
 
 [dependencies]
-azure_iot_operations_protocol = { version = "1.0.1-rc1", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.3.0-rc1", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
-azure_iot_operations_mqtt = { version = "1.1.0-rc1", path = "../azure_iot_operations_mqtt" }
+azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
+azure_iot_operations_services = { version = "1.3", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 chrono.workspace = true
 derive_builder.workspace = true
 derive-getters.workspace = true

--- a/rust/azure_iot_operations_mqtt/Cargo.toml
+++ b/rust/azure_iot_operations_mqtt/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_mqtt"
-version = "1.1.0-rc1"
+version = "1.1.0"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"

--- a/rust/azure_iot_operations_protocol/Cargo.toml
+++ b/rust/azure_iot_operations_protocol/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_protocol"
-version = "1.0.1-rc1"
+version = "1.0.1"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 publish = true
 
 [dependencies]
-azure_iot_operations_mqtt = { version = "1.1.0-rc1", path = "../azure_iot_operations_mqtt" }
+azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 bytes.workspace = true
 derive_builder.workspace = true
 iso8601-duration = "0.2.0"
@@ -28,7 +28,7 @@ thiserror.workspace = true
 [dev-dependencies]
 async-std = "1.12"
 async-trait = "0.1.81"
-azure_iot_operations_mqtt = { version = "1.1.0-rc1", path = "../azure_iot_operations_mqtt", features = ["test-utils"] }
+azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt", features = ["test-utils"] }
 ctor = "0.2"
 datatest-stable = "0.2"
 env_logger.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "1.3.0-rc1"
+version = "1.3.0"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"
@@ -51,8 +51,8 @@ azure_device_registry = [
 ]
 
 [dependencies]
-azure_iot_operations_protocol = { version = "1.0.1-rc1", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_mqtt = { version = "1.1.0-rc1", path = "../azure_iot_operations_mqtt" }
+azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
+azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 bytes = { workspace = true, optional = true }
 derive_builder.workspace = true
 log.workspace = true


### PR DESCRIPTION
MQTT, Protocol and Service crates did not need to be rc'd as they were not related to 2607 AIO directly