### PR TITLE
[Rust][Protocol] Add `Request::into_parts` to split command requests into `RequestParts` and `Responder`

### DIFF
--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -95,10 +95,9 @@ where
     pub invoker_id: Option<String>,
     /// Resolved static and dynamic topic tokens from the incoming request's topic.
     pub topic_tokens: HashMap<String, String>,
-    // Internal fields
-    command_name: String,
-    response_tx: oneshot::Sender<Response<TResp>>,
-    publish_completion_rx: oneshot::Receiver<Result<(), AIOProtocolError>>,
+    // Internal handle used to respond to the invoker. Kept private so that all response logic
+    // lives on `Responder` and `Request` simply delegates to it.
+    responder: Responder<TResp>,
 }
 
 impl<TReq, TResp> Request<TReq, TResp>
@@ -128,8 +127,7 @@ where
     /// [`AIOProtocolError`] of kind [`InternalLogicError`](crate::common::aio_protocol_error::AIOProtocolErrorKind::InternalLogicError)
     /// if the response publish completion fails. This should not happen.
     pub async fn complete(self, response: Response<TResp>) -> Result<(), AIOProtocolError> {
-        let (_parts, responder) = self.into_parts();
-        responder.complete(response).await
+        self.responder.complete(response).await
     }
 
     /// Splits the command request into its owned data ([`RequestParts`]) and a [`Responder`] used
@@ -152,29 +150,37 @@ where
     /// ```
     #[must_use]
     pub fn into_parts(self) -> (RequestParts<TReq>, Responder<TResp>) {
+        let Request {
+            payload,
+            content_type,
+            format_indicator,
+            custom_user_data,
+            timestamp,
+            invoker_id,
+            topic_tokens,
+            responder,
+        } = self;
+
         (
             RequestParts {
-                payload: self.payload,
-                content_type: self.content_type,
-                format_indicator: self.format_indicator,
-                custom_user_data: self.custom_user_data,
-                timestamp: self.timestamp,
-                invoker_id: self.invoker_id,
-                topic_tokens: self.topic_tokens,
+                payload,
+                content_type,
+                format_indicator,
+                custom_user_data,
+                timestamp,
+                invoker_id,
+                topic_tokens,
             },
-            Responder {
-                command_name: self.command_name,
-                response_tx: self.response_tx,
-                publish_completion_rx: self.publish_completion_rx,
-            },
+            responder,
         )
     }
 
     /// Check if the command response is no longer expected.
     ///
     /// Returns true if the response is no longer expected, otherwise returns false.
+    #[must_use]
     pub fn is_cancelled(&self) -> bool {
-        self.response_tx.is_closed()
+        self.responder.is_cancelled()
     }
 }
 
@@ -266,8 +272,6 @@ where
     /// Check if the command response is no longer expected.
     ///
     /// Returns true if the response is no longer expected, otherwise returns false.
-    // Intentionally mirrors `Request::is_cancelled`: both check the same `response_tx`, but expose
-    // the check across the two stages of a request's lifecycle (before and after `into_parts`).
     #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.response_tx.is_closed()
@@ -299,7 +303,7 @@ pub fn cloud_event_from_request<TReq: PayloadSerialize, TResp: PayloadSerialize>
 /// [`RequestCloudEventParseError`] if
 /// - the [`RequestParts`] does not contain the required fields for a [`RequestCloudEvent`].
 /// - any of the field values are not valid for a [`RequestCloudEvent`].
-pub fn cloud_event_from_request_parts<TReq: PayloadSerialize>(
+pub fn cloud_event_from_request_parts<TReq>(
     request_parts: &RequestParts<TReq>,
 ) -> Result<RequestCloudEvent, RequestCloudEventParseError> {
     RequestCloudEvent::try_from((
@@ -1347,9 +1351,11 @@ where
                             timestamp,
                             invoker_id,
                             topic_tokens,
-                            command_name: self.command_name.clone(),
-                            response_tx,
-                            publish_completion_rx,
+                            responder: Responder {
+                                command_name: self.command_name.clone(),
+                                response_tx,
+                                publish_completion_rx,
+                            },
                         };
 
                         // Check the command has not expired, if it has, we do not respond to the invoker.
@@ -2032,9 +2038,11 @@ mod tests {
             timestamp: None,
             invoker_id: Some("test_invoker_id".to_string()),
             topic_tokens: HashMap::from([("commandName".to_string(), "test".to_string())]),
-            command_name: "test_command_name".to_string(),
-            response_tx,
-            publish_completion_rx,
+            responder: Responder {
+                command_name: "test_command_name".to_string(),
+                response_tx,
+                publish_completion_rx,
+            },
         };
 
         (request, response_rx, publish_completion_tx)

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -173,7 +173,6 @@ where
     /// Check if the command response is no longer expected.
     ///
     /// Returns true if the response is no longer expected, otherwise returns false.
-    #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.response_tx.is_closed()
     }

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -266,6 +266,8 @@ where
     /// Check if the command response is no longer expected.
     ///
     /// Returns true if the response is no longer expected, otherwise returns false.
+    // Intentionally mirrors `Request::is_cancelled`: both check the same `response_tx`, but expose
+    // the check across the two stages of a request's lifecycle (before and after `into_parts`).
     #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.response_tx.is_closed()
@@ -2802,6 +2804,31 @@ mod tests {
         };
 
         assert!(cloud_event_from_request_parts(&parts).is_err());
+    }
+
+    #[test]
+    fn test_cloud_event_from_request_parts_success() {
+        let parts: RequestParts<MockPayload> = RequestParts {
+            payload: MockPayload::new(),
+            content_type: Some("application/json".to_string()),
+            format_indicator: FormatIndicator::Utf8EncodedCharacterData,
+            custom_user_data: vec![
+                ("id".to_string(), "test-id".to_string()),
+                ("source".to_string(), "test-source".to_string()),
+                ("specversion".to_string(), "1.0".to_string()),
+                ("type".to_string(), "test-type".to_string()),
+            ],
+            timestamp: None,
+            invoker_id: None,
+            topic_tokens: HashMap::new(),
+        };
+
+        let cloud_event =
+            cloud_event_from_request_parts(&parts).expect("valid fields should parse");
+        assert_eq!(cloud_event.id, "test-id");
+        assert_eq!(cloud_event.source, "test-source");
+        assert_eq!(cloud_event.spec_version, "1.0");
+        assert_eq!(cloud_event.event_type, "test-type");
     }
 }
 

--- a/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
+++ b/rust/azure_iot_operations_protocol/src/rpc_command/executor.rs
@@ -128,6 +128,119 @@ where
     /// [`AIOProtocolError`] of kind [`InternalLogicError`](crate::common::aio_protocol_error::AIOProtocolErrorKind::InternalLogicError)
     /// if the response publish completion fails. This should not happen.
     pub async fn complete(self, response: Response<TResp>) -> Result<(), AIOProtocolError> {
+        let (_parts, responder) = self.into_parts();
+        responder.complete(response).await
+    }
+
+    /// Splits the command request into its owned data ([`RequestParts`]) and a [`Responder`] used
+    /// to respond to the invoker.
+    ///
+    /// This allows the request payload (or any other field) to be moved out and retained while
+    /// still being able to respond to the invoker later via the returned [`Responder`], avoiding
+    /// the need to clone the payload.
+    ///
+    /// Note that, just like the [`Request`], dropping the returned [`Responder`] without calling
+    /// [`Responder::complete`] will cause the executor to send an error response to the invoker.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let (parts, responder) = request.into_parts();
+    /// // The payload can now be moved out and stored without cloning.
+    /// let payload = parts.payload;
+    /// // ... later ...
+    /// responder.complete(response).await?;
+    /// ```
+    #[must_use]
+    pub fn into_parts(self) -> (RequestParts<TReq>, Responder<TResp>) {
+        (
+            RequestParts {
+                payload: self.payload,
+                content_type: self.content_type,
+                format_indicator: self.format_indicator,
+                custom_user_data: self.custom_user_data,
+                timestamp: self.timestamp,
+                invoker_id: self.invoker_id,
+                topic_tokens: self.topic_tokens,
+            },
+            Responder {
+                command_name: self.command_name,
+                response_tx: self.response_tx,
+                publish_completion_rx: self.publish_completion_rx,
+            },
+        )
+    }
+
+    /// Check if the command response is no longer expected.
+    ///
+    /// Returns true if the response is no longer expected, otherwise returns false.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.response_tx.is_closed()
+    }
+}
+
+/// Owned data extracted from a [`Request`] via [`Request::into_parts`].
+///
+/// Contains all of the public data of the command request but no ability to respond to the
+/// invoker. Responding is done via the corresponding [`Responder`]. Dropping a [`RequestParts`]
+/// has no effect on the command response.
+pub struct RequestParts<TReq> {
+    /// Payload of the command request.
+    pub payload: TReq,
+    /// Content Type of the command request.
+    pub content_type: Option<String>,
+    /// Format Indicator of the command request.
+    pub format_indicator: FormatIndicator,
+    /// Custom user data set as custom MQTT User Properties on the request message.
+    pub custom_user_data: Vec<(String, String)>,
+    /// Timestamp of the command request.
+    pub timestamp: Option<HybridLogicalClock>,
+    /// If present, contains the client ID of the invoker of the command.
+    pub invoker_id: Option<String>,
+    /// Resolved static and dynamic topic tokens from the incoming request's topic.
+    pub topic_tokens: HashMap<String, String>,
+}
+
+/// Handle used to respond to a [`Request`] after its data has been extracted via
+/// [`Request::into_parts`].
+///
+/// If dropped without calling [`Responder::complete`], the executor will send an error response
+/// to the invoker (identical to dropping the [`Request`]).
+pub struct Responder<TResp>
+where
+    TResp: PayloadSerialize,
+{
+    command_name: String,
+    response_tx: oneshot::Sender<Response<TResp>>,
+    publish_completion_rx: oneshot::Receiver<Result<(), AIOProtocolError>>,
+}
+
+impl<TResp> Responder<TResp>
+where
+    TResp: PayloadSerialize,
+{
+    /// Consumes the responder and reports the response to the executor. An attempt is made to
+    /// send the response to the invoker.
+    ///
+    /// Returns Ok(()) on success, otherwise returns [`AIOProtocolError`].
+    ///
+    /// # Arguments
+    /// * `response` - The [`Response`] to send.
+    ///
+    /// # Errors
+    ///
+    /// [`AIOProtocolError`] of kind [`Timeout`](crate::common::aio_protocol_error::AIOProtocolErrorKind::Timeout) if the command request
+    /// has expired.
+    ///
+    /// [`AIOProtocolError`] of kind [`ClientError`](crate::common::aio_protocol_error::AIOProtocolErrorKind::ClientError) if the response
+    /// acknowledgement returns an error.
+    ///
+    /// [`AIOProtocolError`] of kind [`Cancellation`](crate::common::aio_protocol_error::AIOProtocolErrorKind::Cancellation) if the
+    /// executor is dropped.
+    ///
+    /// [`AIOProtocolError`] of kind [`InternalLogicError`](crate::common::aio_protocol_error::AIOProtocolErrorKind::InternalLogicError)
+    /// if the response publish completion fails. This should not happen.
+    pub async fn complete(self, response: Response<TResp>) -> Result<(), AIOProtocolError> {
         // We can ignore the error here. If the receiver of the response is dropped it may be
         // because the executor is shutting down in which case the receive below will fail.
         // If the executor is not shutting down, the receive below will succeed and we'll receive a
@@ -154,6 +267,7 @@ where
     /// Check if the command response is no longer expected.
     ///
     /// Returns true if the response is no longer expected, otherwise returns false.
+    #[must_use]
     pub fn is_cancelled(&self) -> bool {
         self.response_tx.is_closed()
     }
@@ -175,6 +289,22 @@ pub fn cloud_event_from_request<TReq: PayloadSerialize, TResp: PayloadSerialize>
     request: &Request<TReq, TResp>,
 ) -> Result<RequestCloudEvent, RequestCloudEventParseError> {
     RequestCloudEvent::try_from((&request.custom_user_data, request.content_type.as_deref()))
+}
+
+/// Parse a [`RequestCloudEvent`] from a [`RequestParts`].
+/// Note that this will return an error if the [`RequestParts`] does not contain the required fields for a [`RequestCloudEvent`].
+///
+/// # Errors
+/// [`RequestCloudEventParseError`] if
+/// - the [`RequestParts`] does not contain the required fields for a [`RequestCloudEvent`].
+/// - any of the field values are not valid for a [`RequestCloudEvent`].
+pub fn cloud_event_from_request_parts<TReq: PayloadSerialize>(
+    request_parts: &RequestParts<TReq>,
+) -> Result<RequestCloudEvent, RequestCloudEventParseError> {
+    RequestCloudEvent::try_from((
+        &request_parts.custom_user_data,
+        request_parts.content_type.as_deref(),
+    ))
 }
 
 /// Command Executor Response struct.
@@ -1881,6 +2011,54 @@ mod tests {
         ])
     }
 
+    /// Builds a [`Request`] with the given payload for testing
+    #[allow(clippy::type_complexity)]
+    fn build_test_request(
+        payload: MockPayload,
+    ) -> (
+        Request<MockPayload, MockPayload>,
+        oneshot::Receiver<Response<MockPayload>>,
+        oneshot::Sender<Result<(), AIOProtocolError>>,
+    ) {
+        let (response_tx, response_rx) = oneshot::channel();
+        let (publish_completion_tx, publish_completion_rx) = oneshot::channel();
+
+        let request = Request {
+            payload,
+            content_type: Some("application/json".to_string()),
+            format_indicator: FormatIndicator::Utf8EncodedCharacterData,
+            custom_user_data: vec![("key".to_string(), "value".to_string())],
+            timestamp: None,
+            invoker_id: Some("test_invoker_id".to_string()),
+            topic_tokens: HashMap::from([("commandName".to_string(), "test".to_string())]),
+            command_name: "test_command_name".to_string(),
+            response_tx,
+            publish_completion_rx,
+        };
+
+        (request, response_rx, publish_completion_tx)
+    }
+
+    fn build_test_response() -> Response<MockPayload> {
+        let mut mock_response_payload = MockPayload::new();
+        mock_response_payload
+            .expect_serialize()
+            .returning(|| {
+                Ok(SerializedPayload {
+                    payload: Vec::new(),
+                    content_type: "application/json".to_string(),
+                    format_indicator: FormatIndicator::Utf8EncodedCharacterData,
+                })
+            })
+            .times(1);
+
+        ResponseBuilder::default()
+            .payload(mock_response_payload)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn test_new_defaults() {
         let session = create_session();
@@ -2527,6 +2705,104 @@ mod tests {
 
         let range = 1..=u32::MAX; // note, range is memory efficient
         assert!(range.contains(&response_message_expiry_interval.unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_into_parts_splits_fields() {
+        // The request payload should be moved into the parts unchanged. We tag it via a distinct
+        // serialized content type so we can assert it wasn't cloned/replaced.
+        let mut request_payload = MockPayload::new();
+        request_payload
+            .expect_serialize()
+            .returning(|| {
+                Ok(SerializedPayload {
+                    payload: Vec::new(),
+                    content_type: "request-payload-marker".to_string(),
+                    format_indicator: FormatIndicator::Utf8EncodedCharacterData,
+                })
+            })
+            .times(1);
+
+        let (request, _response_rx, _publish_completion_tx) = build_test_request(request_payload);
+
+        let (parts, responder) = request.into_parts();
+
+        assert_eq!(parts.content_type, Some("application/json".to_string()));
+        assert_eq!(
+            parts.format_indicator,
+            FormatIndicator::Utf8EncodedCharacterData
+        );
+        assert_eq!(
+            parts.custom_user_data,
+            vec![("key".to_string(), "value".to_string())]
+        );
+        assert_eq!(parts.invoker_id, Some("test_invoker_id".to_string()));
+        assert_eq!(
+            parts.topic_tokens.get("commandName"),
+            Some(&"test".to_string())
+        );
+        // The payload was moved (not cloned) into the parts.
+        assert_eq!(
+            parts.payload.serialize().unwrap().content_type,
+            "request-payload-marker"
+        );
+        // The responder still expects a response.
+        assert!(!responder.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_into_parts_responder_completes() {
+        let (request, response_rx, publish_completion_tx) = build_test_request(MockPayload::new());
+        let (_parts, responder) = request.into_parts();
+        let response = build_test_response();
+
+        let complete_handle = tokio::spawn(async move { responder.complete(response).await });
+
+        // The executor side receives the response...
+        let _received = response_rx.await.expect("response should be received");
+        // ...and signals successful publish completion.
+        publish_completion_tx.send(Ok(())).unwrap();
+
+        assert!(complete_handle.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_into_parts_responder_is_cancelled() {
+        let (request, response_rx, _publish_completion_tx) = build_test_request(MockPayload::new());
+        let (_parts, responder) = request.into_parts();
+
+        assert!(!responder.is_cancelled());
+        // When the executor stops expecting a response, the responder reports cancellation.
+        drop(response_rx);
+        assert!(responder.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_into_parts_dropping_responder_sends_no_response() {
+        let (request, response_rx, _publish_completion_tx) = build_test_request(MockPayload::new());
+        let (parts, responder) = request.into_parts();
+
+        // Dropping the parts is inert; dropping the responder without completing behaves like
+        // dropping the request: the executor receives no response.
+        drop(parts);
+        drop(responder);
+
+        assert!(response_rx.await.is_err());
+    }
+
+    #[test]
+    fn test_cloud_event_from_request_parts_missing_fields() {
+        let parts: RequestParts<MockPayload> = RequestParts {
+            payload: MockPayload::new(),
+            content_type: Some("application/json".to_string()),
+            format_indicator: FormatIndicator::Utf8EncodedCharacterData,
+            custom_user_data: Vec::new(),
+            timestamp: None,
+            invoker_id: None,
+            topic_tokens: HashMap::new(),
+        };
+
+        assert!(cloud_event_from_request_parts(&parts).is_err());
     }
 }
 


### PR DESCRIPTION
This PR:

- Adds `Request::into_parts`, splitting an RPC command `Request` into owned `RequestParts` and a `Responder`.
  - Lets callers move out the payload (and other fields) without cloning, while still responding to the invoker later via the `Responder`.
- Introduces the public `RequestParts<TReq>` and `Responder<TResp>` types, and re-implements `Request::complete` on top of them (no behavior change).
- Adds `cloud_event_from_request_parts` to parse a `RequestCloudEvent` from `RequestParts`.
- Adds `#[must_use]` to `into_parts` and `is_cancelled`, plus unit tests covering field-splitting, responder completion, cancellation, and drop-without-complete semantics for code coverage.