### PR TITLE
fix(rust): bound queued incoming QoS 0 publishes

### DIFF
--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code)]
 #![allow(clippy::unused_async)]
 
-use std::{future::Future, io, num::NonZeroU16, pin::pin, time::Duration};
+use std::{future::Future, io, num::NonZeroU16, pin::pin, sync::Arc, time::Duration};
 
 use bytes::{Bytes, BytesMut};
 use futures_util::future::{self, FutureExt as _};
@@ -77,9 +77,12 @@ pub fn new_client(options: ClientOptions) -> (Client, ConnectHandle, Receiver) {
     let (sub_tx, sub_rx) = tokio::sync::mpsc::channel(1);
     let (ack_tx, ack_rx) = tokio::sync::mpsc::channel(1);
     let (auth_tx, auth_rx) = tokio::sync::mpsc::channel(1);
-    // NOTE: We use an unbounded channel for incoming publishes, as messages read off the network must go
-    // somewhere.
+    // QoS 1 and 2 are bounded by MQTT Receive Maximum. QoS 0 has no protocol-level
+    // flow control, so permits cap how many QoS 0 publishes may occupy this channel.
     let (i_pub_tx, i_pub_rx) = tokio::sync::mpsc::unbounded_channel();
+    let incoming_qos0_permits = Arc::new(tokio::sync::Semaphore::new(
+        options.incoming_qos0_queue_size,
+    ));
     let client = Client {
         pub_qos0_tx: o_pub_q0_tx,
         pub_qos12_tx: o_pub_q12_tx,
@@ -95,6 +98,7 @@ pub fn new_client(options: ClientOptions) -> (Client, ConnectHandle, Receiver) {
         ack_rx,
         auth_rx,
         i_pub_tx,
+        incoming_qos0_permits,
         ack_tx,
         auth_tx,
         options.max_packet_identifier,
@@ -120,6 +124,10 @@ pub struct ClientOptions {
     pub publish_qos0_queue_size: usize,
     /// Maximum size of the outgoing queue for QoS 1 and 2 PUBLISH packets.
     pub publish_qos1_qos2_queue_size: usize,
+    /// Maximum number of incoming QoS 0 PUBLISH packets waiting to be received.
+    ///
+    /// Additional QoS 0 packets are dropped when this limit is reached.
+    pub incoming_qos0_queue_size: usize,
     // TODO: Consider using a Builder pattern?
 }
 
@@ -130,6 +138,7 @@ impl Default for ClientOptions {
             max_packet_identifier: PacketIdentifier::MAX,
             publish_qos0_queue_size: 100,
             publish_qos1_qos2_queue_size: 100,
+            incoming_qos0_queue_size: 100,
         }
     }
 }
@@ -1059,7 +1068,7 @@ pub enum ManualAcknowledgement {
 impl From<channel_data::IncomingPublishAndToken<Bytes>> for (Publish, ManualAcknowledgement) {
     fn from(inner: channel_data::IncomingPublishAndToken<Bytes>) -> Self {
         match inner {
-            channel_data::IncomingPublishAndToken::QoS0(publish) => {
+            channel_data::IncomingPublishAndToken::QoS0(publish, _permit) => {
                 (publish.into(), ManualAcknowledgement::QoS0)
             }
             channel_data::IncomingPublishAndToken::QoS1(publish, token) => (

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client/channel_data.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client/channel_data.rs
@@ -3,6 +3,8 @@
 
 //! Types that define requests for an MQTT operation
 
+use tokio::sync::OwnedSemaphorePermit;
+
 use crate::azure_mqtt::buffer_pool::Shared;
 use crate::azure_mqtt::client::token::{
     acknowledgement::buffered::{PubAckToken, PubRecToken},
@@ -103,7 +105,7 @@ pub enum IncomingPublishAndToken<S>
 where
     S: Shared,
 {
-    QoS0(Publish<S>),
+    QoS0(Publish<S>, OwnedSemaphorePermit),
     QoS1(Publish<S>, PubAckToken<S>),
     QoS2(Publish<S>, PubRecToken<S>),
 }

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt/client/session.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt/client/session.rs
@@ -3,13 +3,17 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Poll;
 
 use derive_where::derive_where;
 use futures_util::future::FutureExt as _;
 use futures_util::stream::{Peekable, Stream, StreamExt as _};
 use indexmap::IndexMap;
-use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
+use tokio::sync::{
+    Semaphore,
+    mpsc::{Receiver, Sender, UnboundedSender},
+};
 use tokio::time::Duration;
 
 use crate::azure_mqtt::buffer_pool::{Owned, Shared};
@@ -79,6 +83,7 @@ where
         ack_rx: Receiver<AcknowledgementRequest<O::Shared>>,
         auth_rx: Receiver<ReauthRequest<O::Shared>>,
         i_pub_tx: UnboundedSender<IncomingPublishAndToken<O::Shared>>,
+        incoming_qos0_permits: Arc<Semaphore>,
         ack_tx: Sender<AcknowledgementRequest<O::Shared>>,
         auth_tx: Sender<ReauthRequest<O::Shared>>,
         max_pkid: PacketIdentifier,
@@ -92,6 +97,7 @@ where
             ack_rx,
             auth_rx,
             i_pub_tx,
+            incoming_qos0_permits,
             ack_tx,
             auth_tx,
         };
@@ -544,7 +550,13 @@ where
     /// An incoming PUBLISH packet has been received from the server
     pub fn incoming_publish(&mut self, publish: Publish<O::Shared>) {
         let incoming = match publish.packet_identifier_dup_qos {
-            PacketIdentifierDupQoS::AtMostOnce => IncomingPublishAndToken::QoS0(publish),
+            PacketIdentifierDupQoS::AtMostOnce => {
+                let Ok(permit) = self.ch.incoming_qos0_permits.clone().try_acquire_owned() else {
+                    log::debug!("incoming QoS 0 PUBLISH dropped because the receive queue is full");
+                    return;
+                };
+                IncomingPublishAndToken::QoS0(publish, permit)
+            }
             PacketIdentifierDupQoS::AtLeastOnce(packet_identifier, _) => {
                 let r = self
                     .in_application
@@ -755,6 +767,8 @@ where
     auth_rx: Receiver<ReauthRequest<S>>,
     /// Channel for sending incoming PUBLISHes and associated acknowledgement tokens
     i_pub_tx: UnboundedSender<IncomingPublishAndToken<S>>,
+    /// Limits the number of queued incoming QoS 0 PUBLISH packets
+    incoming_qos0_permits: Arc<Semaphore>,
 
     // --- Channels stored here to be cloned, and should not be used directly ---
     // TODO: Is this really the correct place for these?

--- a/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
+++ b/rust/azure_iot_operations_mqtt/src/azure_mqtt_adapter.rs
@@ -276,6 +276,7 @@ impl MqttConnectionSettings {
             max_packet_identifier,
             publish_qos0_queue_size,
             publish_qos1_qos2_queue_size,
+            ..Default::default()
         };
 
         let ping_after =

--- a/rust/azure_iot_operations_mqtt/tests/low_level_receive_queue.rs
+++ b/rust/azure_iot_operations_mqtt/tests/low_level_receive_queue.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(feature = "test-utils")]
+
+use std::{pin::pin, time::Duration};
+
+use azure_iot_operations_mqtt::azure_mqtt::{
+    client::{
+        ClientOptions, ConnectResult, Connection, DisconnectedEvent, KeepAliveConfig,
+        ManualAcknowledgement, Receiver, new_client,
+    },
+    mqtt_proto::{
+        self, ConnectReasonCode, Packet, PacketIdentifier, PacketIdentifierDupQoS, topic,
+    },
+    packet::{ConnAck, ConnectProperties},
+    transport::{ConnectionTransportConfig, ConnectionTransportType},
+};
+use bytes::Bytes;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+async fn connect(
+    incoming_qos0_queue_size: usize,
+) -> (
+    UnboundedSender<Packet<Bytes>>,
+    UnboundedReceiver<Packet<Bytes>>,
+    Connection,
+    Receiver,
+) {
+    let options = ClientOptions {
+        client_id: Some("receive-queue-test".to_string()),
+        incoming_qos0_queue_size,
+        ..Default::default()
+    };
+    let (_client, connect_handle, receiver) = new_client(options);
+    let (incoming_packets_tx, incoming_packets_rx) = unbounded_channel();
+    let (outgoing_packets_tx, mut outgoing_packets_rx) = unbounded_channel();
+
+    incoming_packets_tx
+        .send(Packet::ConnAck(mqtt_proto::ConnAck {
+            reason_code: ConnectReasonCode::Success {
+                session_present: false,
+            },
+            other_properties: mqtt_proto::ConnAckOtherProperties::default(),
+        }))
+        .unwrap();
+
+    let ConnectResult::Success(connection, connack, _disconnect_handle) = connect_handle
+        .connect(
+            ConnectionTransportConfig {
+                transport_type: ConnectionTransportType::Test {
+                    incoming_packets: incoming_packets_rx,
+                    outgoing_packets: outgoing_packets_tx,
+                },
+                timeout: None,
+                proxy: None,
+                tcp_nodelay: true,
+            },
+            false,
+            KeepAliveConfig::Infinite,
+            None,
+            None,
+            None,
+            ConnectProperties::default(),
+            None,
+        )
+        .await
+    else {
+        panic!("expected successful connect")
+    };
+
+    assert!(matches!(
+        outgoing_packets_rx.recv().await,
+        Some(Packet::Connect(_))
+    ));
+    assert!(matches!(connack, ConnAck { .. }));
+
+    (
+        incoming_packets_tx,
+        outgoing_packets_rx,
+        connection,
+        receiver,
+    )
+}
+
+fn qos0_publish(payload: &'static [u8]) -> Packet<Bytes> {
+    Packet::Publish(mqtt_proto::Publish {
+        topic_name: topic("incoming/qos0"),
+        packet_identifier_dup_qos: PacketIdentifierDupQoS::AtMostOnce,
+        retain: false,
+        payload: Bytes::from_static(payload),
+        other_properties: mqtt_proto::PublishOtherProperties::default(),
+    })
+}
+
+fn qos1_publish(packet_identifier: u16, payload: &'static [u8]) -> Packet<Bytes> {
+    Packet::Publish(mqtt_proto::Publish {
+        topic_name: topic("incoming/qos1"),
+        packet_identifier_dup_qos: PacketIdentifierDupQoS::AtLeastOnce(
+            PacketIdentifier::new(packet_identifier).unwrap(),
+            false,
+        ),
+        retain: false,
+        payload: Bytes::from_static(payload),
+        other_properties: mqtt_proto::PublishOtherProperties::default(),
+    })
+}
+
+#[tokio::test(start_paused = true)]
+async fn incoming_qos0_queue_drops_overflow_and_recovers_capacity() {
+    let (incoming_packets_tx, _outgoing_packets_rx, connection, mut receiver) = connect(1).await;
+    let mut connection = pin!(connection.run_until_disconnect());
+
+    incoming_packets_tx.send(qos0_publish(b"accepted")).unwrap();
+    incoming_packets_tx
+        .send(qos0_publish(b"dropped-1"))
+        .unwrap();
+    incoming_packets_tx
+        .send(qos0_publish(b"dropped-2"))
+        .unwrap();
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), &mut connection)
+            .await
+            .is_err()
+    );
+
+    let (publish, acknowledgement) = receiver.recv().await.unwrap();
+    assert_eq!(publish.payload, Bytes::from_static(b"accepted"));
+    assert!(matches!(acknowledgement, ManualAcknowledgement::QoS0));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(1), receiver.recv())
+            .await
+            .is_err()
+    );
+
+    incoming_packets_tx
+        .send(qos0_publish(b"accepted-after-drain"))
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), &mut connection)
+            .await
+            .is_err()
+    );
+
+    let (publish, acknowledgement) = receiver.recv().await.unwrap();
+    assert_eq!(publish.payload, Bytes::from_static(b"accepted-after-drain"));
+    assert!(matches!(acknowledgement, ManualAcknowledgement::QoS0));
+
+    drop(incoming_packets_tx);
+    let (_connect_handle, disconnected_event) = connection.await;
+    assert!(matches!(disconnected_event, DisconnectedEvent::IoError(_)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn incoming_qos1_is_not_limited_by_qos0_queue_capacity() {
+    let (incoming_packets_tx, _outgoing_packets_rx, connection, mut receiver) = connect(1).await;
+    let mut connection = pin!(connection.run_until_disconnect());
+
+    incoming_packets_tx
+        .send(qos1_publish(1, b"qos1-1"))
+        .unwrap();
+    incoming_packets_tx
+        .send(qos1_publish(2, b"qos1-2"))
+        .unwrap();
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), &mut connection)
+            .await
+            .is_err()
+    );
+
+    for expected_payload in [b"qos1-1".as_slice(), b"qos1-2".as_slice()] {
+        let (publish, acknowledgement) = receiver.recv().await.unwrap();
+        assert_eq!(publish.payload.as_ref(), expected_payload);
+        assert!(matches!(acknowledgement, ManualAcknowledgement::QoS1(_)));
+    }
+
+    drop(incoming_packets_tx);
+    let (_connect_handle, disconnected_event) = connection.await;
+    assert!(matches!(disconnected_event, DisconnectedEvent::IoError(_)));
+}


### PR DESCRIPTION
## Summary

- mirror [Azure/ms-mqtt-client#96](https://github.com/Azure/ms-mqtt-client/pull/96) into the vendored `azure_mqtt` module
- cap queued incoming QoS 0 PUBLISH packets with a configurable permit budget
- drop excess QoS 0 without blocking MQTT connection progress
- preserve existing QoS 1/2 delivery and acknowledgement behavior

## Context

The low-level incoming application-message channel is unbounded. QoS 1/2 traffic is constrained by MQTT Receive Maximum and packet identifiers, but QoS 0 has no protocol-level flow control. If an application stops draining the low-level receiver, QoS 0 publishes can accumulate until the process runs out of memory.

This was found while investigating [Azure-NBC PR 16518887](https://msazure.visualstudio.com/One/_git/Azure-NBC/pullrequest/16518887). A physically bounded shared channel would either block keepalive/PUBACK/disconnect processing or risk dropping QoS 1. Instead, each queued QoS 0 publish owns a permit; overflow QoS 0 is discarded while the event loop continues running.

## Validation

- `make check`
- `MANIFEST=azure_iot_operations_mqtt/Cargo.toml make test`
- 371 tests passed, including new overflow, capacity-recovery, and QoS 1 non-regression coverage