### PR TITLE
[Rust][Connector] Version bump for 07-24-2026 release [Cherry-pick]

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.1.0-rc1"
+version = "2.1.0"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"


### PR DESCRIPTION
`connector`: `2.1.0-rc1` -> `2.1.0`