### PR TITLE
Remove GitHub fork contribution instructions

### DIFF
--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -7,4 +7,3 @@ For documentation on using the Azure IoT Operations SDKs for developing applicat
 ## Resources
 
 * [Packaging the SDKs](packaging.md) - How to create and push the SDK packages to the ADO feed
-* [GitHub](github.md) - Using GitHub and Codespaces to contribute code from a fork


### PR DESCRIPTION
Removed GitHub fork contribution instructions from README as it is now a dead link and this flow isn't supported.