### PR TITLE
[Rust] chore: Added `rust-analyzer` to toolchain for long-term compatibility

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -3,4 +3,4 @@
 
 [toolchain]
 channel = "1.88"    # This is the version that we will use for local dev to ensure we are on the same clippy and rustfmt.
-components = ["clippy", "llvm-tools-preview", "rustfmt"]
+components = ["clippy", "llvm-tools-preview", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
The Rust Analyzer extension for VS Code now ships expecting compiler 1.94 instead of our pinned 1.88. Adding `rust-analyzer` to the toolchain allows us to use legacy compatibility and keep the extension running.