### PR TITLE
Generate VariableTypes for OpcUaCore

### DIFF
--- a/wot-codegen/README.md
+++ b/wot-codegen/README.md
@@ -19,8 +19,8 @@ PowerShell:
 
 ```powershell
 .\generate_opcua_tms.ps1 `
-  -InputRoot C:\ode\UA-Nodeset `
-  -OutputDir C:\ode\smd\models
+  -InputRoot C:\code\UA-Nodeset `
+  -OutputDir C:\code\smd\models
 ```
 
 Bash:

--- a/wot-codegen/README.md
+++ b/wot-codegen/README.md
@@ -1,3 +1,47 @@
+# OPC UA NodeSet converter
+
+The `Azure.Iot.Operations.Opc2Wot` tool converts OPC UA NodeSet files into W3C WoT Thing Model collections. The repository provides PowerShell and Bash wrappers for regenerating the OPC UA companion models maintained in the sibling [Azure/smd](https://github.com/Azure/smd) repository.
+
+By default, both wrappers expect this sibling repository layout:
+
+```text
+<root>/
+  iot-operations-sdks/
+  UA-Nodeset/
+  smd/
+```
+
+The default output is non-integrated: generated Thing Models retain relative references to other generated TM files. Pass the integration option only when each output file must be self-contained.
+
+## Generate OPC UA Thing Models
+
+PowerShell:
+
+```powershell
+.\generate_opcua_tms.ps1 `
+  -InputRoot C:\ode\UA-Nodeset `
+  -OutputDir C:\ode\smd\models
+```
+
+Bash:
+
+```bash
+bash ./generate_opcua_tms.sh \
+  --input-root ../../UA-Nodeset \
+  --output-dir ../../smd/models
+```
+
+Both wrappers recursively process `*.NodeSet2.xml` below the input root. By default, they omit the UA-Nodeset demo, test, and example-only inputs that are not published to SMD. Use `-IncludeNonPublished` or `--include-non-published` to include them. Include the complete set of required NodeSets so inherited types, cross-model links, and referenced VariableTypes can be resolved.
+
+Optional converter flags:
+
+| PowerShell | Bash | Behavior |
+| --- | --- | --- |
+| `-Integrate` | `--integrate` | Integrate referenced models into each output file. |
+| `-InheritVars` | `--inherit-vars` | Add `dov:includeInherited` to applicable root forms. |
+| `-IncludeTDs` | `--include-tds` | Include Thing Descriptions in generated collections. |
+| `-IncludeNonPublished` | `--include-non-published` | Include UA-Nodeset demo, test, and example-only models. |
+
 # Protocol compiler
 
 The `Azure.IoT.Operations.ProtocolCompiler` accepts one or more WoT Thing Model files as input, and it outputs specializations of the AIO SDK client and server classes in the requested programming language.

--- a/wot-codegen/generate_opcua_tms.ps1
+++ b/wot-codegen/generate_opcua_tms.ps1
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License
+
+[CmdletBinding()]
+param(
+    [string]$InputRoot = (Join-Path $PSScriptRoot "..\..\UA-Nodeset"),
+    [string]$OutputDir = (Join-Path $PSScriptRoot "..\..\smd\models"),
+    [switch]$Integrate,
+    [switch]$InheritVars,
+    [switch]$IncludeTDs,
+    [switch]$IncludeNonPublished
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw "The .NET SDK is required, but 'dotnet' was not found on PATH."
+}
+
+if (-not (Test-Path -LiteralPath $InputRoot -PathType Container)) {
+    throw "The NodeSet input directory does not exist: $InputRoot"
+}
+
+$resolvedInputRoot = (Resolve-Path -LiteralPath $InputRoot).Path
+$resolvedOutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+$outputParent = Split-Path -Parent $resolvedOutputDir
+if (-not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+    throw "The output parent directory does not exist: $outputParent"
+}
+
+$projectPath = Join-Path $PSScriptRoot "src\Azure.Iot.Operations.Opc2Wot\Azure.Iot.Operations.Opc2Wot.csproj"
+$excludedRelativePaths = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@(
+        "DemoModel\DemoModel.NodeSet2.xml",
+        "LaserSystems\LaserSystem-Example.NodeSet2.xml",
+        "TestModel\TestModel.NodeSet2.xml"
+    ),
+    [System.StringComparer]::OrdinalIgnoreCase)
+$nodeSetFiles = Get-ChildItem -LiteralPath $resolvedInputRoot -Recurse -File -Filter "*.NodeSet2.xml" |
+    Where-Object {
+        $IncludeNonPublished -or
+        -not $excludedRelativePaths.Contains([System.IO.Path]::GetRelativePath($resolvedInputRoot, $_.FullName))
+    } |
+    Sort-Object FullName
+
+if ($nodeSetFiles.Count -eq 0) {
+    throw "No *.NodeSet2.xml files were found below: $resolvedInputRoot"
+}
+
+$arguments = @(
+    "run",
+    "--project", $projectPath,
+    "--configuration", "Debug",
+    "--",
+    "--nodeSets"
+)
+$arguments += $nodeSetFiles.FullName
+$arguments += @("--outDir", $resolvedOutputDir)
+
+if ($Integrate) {
+    $arguments += "--integrate"
+}
+if ($InheritVars) {
+    $arguments += "--inheritVars"
+}
+if ($IncludeTDs) {
+    $arguments += "--includeTDs"
+}
+
+Write-Host "Generating WoT Thing Models from '$resolvedInputRoot' into '$resolvedOutputDir'."
+& dotnet @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "OPC UA Thing Model generation failed with exit code $LASTEXITCODE."
+}

--- a/wot-codegen/generate_opcua_tms.sh
+++ b/wot-codegen/generate_opcua_tms.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+input_root="${script_dir}/../../UA-Nodeset"
+output_dir="${script_dir}/../../smd/models"
+integrate=false
+inherit_vars=false
+include_tds=false
+include_non_published=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --input-root <path>   Root directory containing recursive *.NodeSet2.xml inputs
+  --output-dir <path>   Directory that receives generated *.TM.json files
+  --integrate           Make each output file self-contained
+  --inherit-vars        Add dov:includeInherited to applicable root forms
+  --include-tds         Include Thing Descriptions in generated collections
+  --include-non-published
+                        Include UA-Nodeset demo, test, and example-only models
+  --help                Show this help
+EOF
+}
+
+while (($# > 0)); do
+    case "$1" in
+        --input-root)
+            [[ $# -ge 2 ]] || { echo "Missing value for --input-root." >&2; exit 2; }
+            input_root="$2"
+            shift 2
+            ;;
+        --output-dir)
+            [[ $# -ge 2 ]] || { echo "Missing value for --output-dir." >&2; exit 2; }
+            output_dir="$2"
+            shift 2
+            ;;
+        --integrate)
+            integrate=true
+            shift
+            ;;
+        --inherit-vars)
+            inherit_vars=true
+            shift
+            ;;
+        --include-tds)
+            include_tds=true
+            shift
+            ;;
+        --include-non-published)
+            include_non_published=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+command -v dotnet >/dev/null 2>&1 || {
+    echo "The .NET SDK is required, but 'dotnet' was not found on PATH." >&2
+    exit 1
+}
+
+[[ -d "$input_root" ]] || {
+    echo "The NodeSet input directory does not exist: $input_root" >&2
+    exit 1
+}
+
+input_root="$(cd "$input_root" && pwd)"
+output_parent="$(dirname "$output_dir")"
+[[ -d "$output_parent" ]] || {
+    echo "The output parent directory does not exist: $output_parent" >&2
+    exit 1
+}
+output_dir="$(cd "$output_parent" && pwd)/$(basename "$output_dir")"
+
+project_path="${script_dir}/src/Azure.Iot.Operations.Opc2Wot/Azure.Iot.Operations.Opc2Wot.csproj"
+node_set_files=()
+while IFS= read -r node_set_file; do
+    if ! $include_non_published; then
+        relative_path="${node_set_file#"${input_root}/"}"
+        case "$relative_path" in
+            DemoModel/DemoModel.NodeSet2.xml|LaserSystems/LaserSystem-Example.NodeSet2.xml|TestModel/TestModel.NodeSet2.xml)
+                continue
+                ;;
+        esac
+    fi
+    node_set_files+=("$node_set_file")
+done < <(find "$input_root" -type f -iname '*.NodeSet2.xml' -print | LC_ALL=C sort)
+
+((${#node_set_files[@]} > 0)) || {
+    echo "No *.NodeSet2.xml files were found below: $input_root" >&2
+    exit 1
+}
+
+arguments=(
+    run
+    --project "$project_path"
+    --configuration Debug
+    --
+    --nodeSets "${node_set_files[@]}"
+    --outDir "$output_dir"
+)
+
+$integrate && arguments+=(--integrate)
+$inherit_vars && arguments+=(--inheritVars)
+$include_tds && arguments+=(--includeTDs)
+
+echo "Generating WoT Thing Models from '$input_root' into '$output_dir'."
+dotnet "${arguments[@]}"

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
@@ -89,6 +89,8 @@ namespace Azure.Iot.Operations.Opc2Wot
                 }
             }
 
+            inputFiles.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.FullName, right.FullName));
+
             if (inputFiles.Count == 0)
             {
                 AddUnlocatableError(ErrorCondition.ItemNotFound, $"No files match the given glob pattern(s): {string.Join(", ", options.NodeSetsSpec)}", errorLog);

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
@@ -89,7 +89,11 @@ namespace Azure.Iot.Operations.Opc2Wot
                 }
             }
 
-            inputFiles.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.FullName, right.FullName));
+            inputFiles.Sort((left, right) =>
+            {
+                int comparison = StringComparer.OrdinalIgnoreCase.Compare(left.FullName, right.FullName);
+                return comparison != 0 ? comparison : StringComparer.Ordinal.Compare(left.FullName, right.FullName);
+            });
 
             if (inputFiles.Count == 0)
             {

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaGraph.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaGraph.cs
@@ -10,6 +10,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
     public class OpcUaGraph
     {
+        private bool referencesResolved;
+
         public const string OpcUaCoreModelUri = "http://opcfoundation.org/UA/";
 
         public static readonly XmlNamespaceManager NamespaceManager;
@@ -72,6 +74,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         public void AddNodeset(string xmlText)
         {
+            referencesResolved = false;
+
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(xmlText);
             ArgumentNullException.ThrowIfNull(xmlDoc.DocumentElement, nameof(xmlDoc.DocumentElement));
@@ -136,7 +140,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
                         break;
                     case "UAVariableType":
                         OpcUaVariableType opcUaVariableType = new OpcUaVariableType(modelInfo, NsUriToNsInfoMap, node);
-                        if (!opcUaVariableType.IsDeprecated)
+                        if (opcUaVariableType.IsSchemaEligible)
                         {
                             modelInfo.NodeIdToVariableTypeMap[opcUaVariableType.NodeId] = opcUaVariableType;
                         }
@@ -162,13 +166,28 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 }
             }
 
-            foreach (OpcUaObjectType opcUaObjectType in modelInfo.NodeIdToObjectTypeMap.Values)
+        }
+
+        public void ResolveReferences()
+        {
+            if (referencesResolved)
             {
-                foreach ((OpcUaNodeId, OpcUaObject) typeAndObjectOfReference in opcUaObjectType.TypeAndObjectOfReferences)
+                return;
+            }
+
+            foreach (OpcUaModelInfo modelInfo in ModelUriToModelMap.Values)
+            {
+                modelInfo.ReferencedObjectNodeIds.Clear();
+                foreach (OpcUaObjectType opcUaObjectType in modelInfo.NodeIdToObjectTypeMap.Values)
                 {
-                    modelInfo.ReferencedObjectNodeIds.Add(typeAndObjectOfReference.Item2.NodeId);
+                    foreach ((OpcUaNodeId, OpcUaObject) typeAndObjectOfReference in opcUaObjectType.TypeAndObjectOfReferences)
+                    {
+                        modelInfo.ReferencedObjectNodeIds.Add(typeAndObjectOfReference.Item2.NodeId);
+                    }
                 }
             }
+
+            referencesResolved = true;
         }
 
         private void SetDiscriminator(OpcUaNode newObjectType, Dictionary<string, OpcUaNode> effectiveNameToNodeMap)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaVariable.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaVariable.cs
@@ -75,25 +75,41 @@ namespace Azure.Iot.Operations.Opc2WotLib
             }
         }
 
-        public OpcUaVariableType? CustomVariableType
+        public OpcUaVariableType? VariableTypeDefinition
         {
             get
             {
-                if (HasTypeDefinitionNodeId == null ||
-                    DefiningModel.NamespaceUris[HasTypeDefinitionNodeId.NsIndex] == OpcUaGraph.OpcUaCoreModelUri)
+                OpcUaVariableType? variableType = HasTypeDefinition;
+                return variableType?.IsSchemaEligible == true ? variableType : null;
+            }
+        }
+
+        public OpcUaDataTypeSubtype? CustomDataTypeSubtype
+        {
+            get
+            {
+                if (EffectiveDataType == null || EffectiveDataType.NsIndex == 0)
                 {
                     return null;
                 }
 
-                return HasTypeDefinition;
+                return EffectiveDataTypeSource.GetReferencedOpcUaNode(EffectiveDataType) is OpcUaDataTypeSubtype subtype &&
+                    subtype.DefiningModel.ModelUri != OpcUaGraph.OpcUaCoreModelUri
+                    ? subtype
+                    : null;
             }
         }
+
+        public OpcUaNode? SchemaTypeReference =>
+            CanUseVariableTypeSchemaReference
+                ? VariableTypeDefinition
+                : CustomDataTypeSubtype;
 
         public bool CanUseVariableTypeSchemaReference
         {
             get
             {
-                OpcUaVariableType? variableType = CustomVariableType;
+                OpcUaVariableType? variableType = VariableTypeDefinition;
                 if (variableType == null)
                 {
                     return false;

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaVariableType.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaVariableType.cs
@@ -33,6 +33,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         public bool IsAbstract { get; }
 
+        public bool IsSchemaEligible => !IsDeprecated;
+
         public List<OpcUaVariableType> BaseTypes
         {
             get

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
@@ -28,7 +28,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.thingName = WotUtil.LegalizeName("VariableTypes", specName);
 
             Dictionary<OpcUaVariableType, string> schemaNames = WotVariableTypeSchema.GetSchemaNames(
-                variableTypes.Where(vt => !vt.IsDeprecated && vt.DefiningModel.ModelUri != OpcUaGraph.OpcUaCoreModelUri));
+                variableTypes.Where(vt => vt.IsSchemaEligible));
 
             this.schemaDefinitions = schemaNames
                 .OrderBy(kvp => kvp.Value, StringComparer.Ordinal)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotEvent.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotEvent.cs
@@ -23,7 +23,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.uaVariable = uaVariable;
             this.dataSchema = variableTypeSchemaName != null
                 ? new WotDataSchemaReference(variableTypeSchemaName)
-                : WotDataSchema.Create(uaVariable.EffectiveDataType, uaVariable.EffectiveValueRank, uaVariable.EffectiveDataTypeSource, uaVariable.Description, Enumerable.Empty<OpcUaNodeId>(), uaVariable.CustomVariableType);
+                : WotDataSchema.Create(uaVariable.EffectiveDataType, uaVariable.EffectiveValueRank, uaVariable.EffectiveDataTypeSource, uaVariable.Description, Enumerable.Empty<OpcUaNodeId>(), uaVariable.SchemaTypeReference);
             this.specName = specName;
             this.thingModelName = thingModelName;
             this.containedIn = containedIn;

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotProperty.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotProperty.cs
@@ -28,7 +28,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.dataSchema = variableTypeSchemaName != null
                 ? new WotDataSchemaReference(variableTypeSchemaName)
-                : WotDataSchema.Create(uaVariable.EffectiveDataType, uaVariable.EffectiveValueRank, uaVariable.EffectiveDataTypeSource, uaVariable.Description, Enumerable.Empty<OpcUaNodeId>(), uaVariable.CustomVariableType);
+                : WotDataSchema.Create(uaVariable.EffectiveDataType, uaVariable.EffectiveValueRank, uaVariable.EffectiveDataTypeSource, uaVariable.Description, Enumerable.Empty<OpcUaNodeId>(), uaVariable.SchemaTypeReference);
             this.browseNamespace = uaVariable.BrowseNamespace;
             this.isPlaceholder = uaVariable.IsPlaceholder;
             this.specName = specName;

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingCollection.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingCollection.cs
@@ -11,6 +11,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
     {
         public WotThingCollection(OpcUaGraph opcUaGraph, OpcUaModelInfo modelInfo, LinkRelRuleEngine linkRelRuleEngine, bool integrate, bool inheritVars, bool includeTDs)
         {
+            opcUaGraph.ResolveReferences();
+
             string specName = SpecMapper.GetSpecNameFromUri(modelInfo.ModelUri);
             this.ThingDescriptions = includeTDs ? modelInfo.NodeIdToObjectMap.Values.Where(o => !modelInfo.ReferencedObjectNodeIds.Contains(o.NodeId)).Select(o => new WotThingDescription(specName, o)).ToList() : new();
 

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
@@ -56,7 +56,9 @@ namespace Azure.Iot.Operations.Opc2WotLib
             }
 
             List<OpcUaVariableType> variableTypes = uaObjectType.VariableRecords.Values
-                .Select(r => r.UaVariable.CustomVariableType)
+                .Select(r => r.UaVariable)
+                .Where(v => v.CanUseVariableTypeSchemaReference)
+                .Select(v => v.VariableTypeDefinition)
                 .Where(vt => vt != null)
                 .Cast<OpcUaVariableType>()
                 .Distinct()
@@ -100,8 +102,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
         private static string? GetVariableTypeSchemaName(OpcUaVariable variable, Dictionary<OpcUaVariableType, string> schemaNames)
         {
             return variable.CanUseVariableTypeSchemaReference &&
-                variable.CustomVariableType != null &&
-                schemaNames.TryGetValue(variable.CustomVariableType, out string? schemaName)
+                variable.VariableTypeDefinition != null &&
+                schemaNames.TryGetValue(variable.VariableTypeDefinition, out string? schemaName)
                 ? schemaName
                 : null;
         }

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
@@ -11,6 +11,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
     public class HasAddInLinkTests
     {
         private const string ModelUri = "http://opcfoundation.org/UA/AddInTest/";
+        private const string ReferencingModelUri = "http://opcfoundation.org/UA/ReferenceOrderTest/";
 
         // Minimal, self-contained OPC UA nodeset. The base-type chain terminates locally
         // (no HasSubtype to a core ns=0 type), so the core Opc.Ua nodeset is not required.
@@ -59,6 +60,50 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             </UANodeSet>
             """;
 
+        private const string ReferencingNodeset = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+              <NamespaceUris>
+                <Uri>http://opcfoundation.org/UA/ReferenceOrderTest/</Uri>
+                <Uri>http://opcfoundation.org/UA/ReferencedModel/</Uri>
+              </NamespaceUris>
+              <Models>
+                <Model ModelUri="http://opcfoundation.org/UA/ReferenceOrderTest/" Version="1.0.0">
+                  <RequiredModel ModelUri="http://opcfoundation.org/UA/ReferencedModel/" Version="1.0.0" />
+                </Model>
+              </Models>
+              <Aliases>
+                <Alias Alias="HasComponent">i=47</Alias>
+              </Aliases>
+              <UAObjectType NodeId="ns=1;i=1" BrowseName="1:ContainerType">
+                <References>
+                  <Reference ReferenceType="HasComponent">ns=2;i=100</Reference>
+                </References>
+              </UAObjectType>
+            </UANodeSet>
+            """;
+
+        private const string ReferencedNodeset = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+              <NamespaceUris>
+                <Uri>http://opcfoundation.org/UA/ReferencedModel/</Uri>
+              </NamespaceUris>
+              <Models>
+                <Model ModelUri="http://opcfoundation.org/UA/ReferencedModel/" Version="1.0.0" />
+              </Models>
+              <Aliases>
+                <Alias Alias="HasTypeDefinition">i=40</Alias>
+              </Aliases>
+              <UAObjectType NodeId="ns=1;i=2" BrowseName="1:ModuleType" />
+              <UAObject NodeId="ns=1;i=100" BrowseName="1:Module">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">ns=1;i=2</Reference>
+                </References>
+              </UAObject>
+            </UANodeSet>
+            """;
+
         [Fact]
         public void HasAddInReference_IsPreservedAsWotLink()
         {
@@ -84,6 +129,29 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 
             JsonElement? componentLink = FindLinkByRefName(links, "Diagnostics");
             Assert.True(componentLink.HasValue, "HasComponent child 'Diagnostics' must be emitted as a WoT link.");
+        }
+
+        [Fact]
+        public void ReferencedModel_CanBeLoadedAfterReferencingModel()
+        {
+            OpcUaGraph graph = new OpcUaGraph();
+            graph.AddNodeset(ReferencingNodeset);
+            graph.AddNodeset(ReferencedNodeset);
+
+            WotThingCollection collection = new WotThingCollection(
+                graph,
+                graph.GetOpcUaModelInfo(ReferencingModelUri),
+                new LinkRelRuleEngine(),
+                integrate: false,
+                inheritVars: false,
+                includeTDs: false);
+
+            using JsonDocument doc = JsonDocument.Parse(collection.TransformText());
+            JsonElement container = doc.RootElement.EnumerateArray()
+                .Single(t => t.GetProperty("title").GetString()!.EndsWith("ContainerType", System.StringComparison.Ordinal));
+            JsonElement link = Assert.Single(container.GetProperty("links").EnumerateArray().Select(l => l.Clone()));
+
+            Assert.Equal("./ReferencedModel.TM.json#title=ReferencedModel_ModuleType", link.GetProperty("href").GetString());
         }
 
         private static JsonElement GetThingByTitleSuffix(string titleSuffix)

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
@@ -15,6 +15,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
         private const string ModelUri = "http://opcfoundation.org/UA/VariableTypeTest/";
         private const string BaseModelUri = "http://opcfoundation.org/UA/VariableTypeBase/";
         private const string RootModelUri = "http://opcfoundation.org/UA/VariableTypeRoot/";
+        private const string BuiltInWithoutCoreModelUri = "http://opcfoundation.org/UA/BuiltInWithoutCore/";
 
         private const string CoreNodeset = """
             <?xml version="1.0" encoding="utf-8" ?>
@@ -25,12 +26,28 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
               <Aliases>
                 <Alias Alias="HasSubtype">i=45</Alias>
               </Aliases>
+              <UADataType NodeId="i=1" BrowseName="Boolean" />
               <UADataType NodeId="i=6" BrowseName="Int32" />
               <UADataType NodeId="i=12" BrowseName="String" />
               <UAVariableType NodeId="i=62" BrowseName="BaseVariableType" IsAbstract="true" ValueRank="-2" />
               <UAVariableType NodeId="i=63" BrowseName="BaseDataVariableType" ValueRank="-2">
                 <References>
                   <Reference ReferenceType="HasSubtype" IsForward="false">i=62</Reference>
+                </References>
+              </UAVariableType>
+              <UAVariableType NodeId="i=68" BrowseName="PropertyType" ValueRank="-2">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=62</Reference>
+                </References>
+              </UAVariableType>
+              <UAVariableType NodeId="i=2372" BrowseName="DiscreteItemType" IsAbstract="true" ValueRank="-2">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=63</Reference>
+                </References>
+              </UAVariableType>
+              <UAVariableType NodeId="i=2373" BrowseName="TwoStateDiscreteType" DataType="i=1" ValueRank="-2">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=2372</Reference>
                 </References>
               </UAVariableType>
             </UANodeSet>
@@ -61,8 +78,27 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                   <Reference ReferenceType="HasComponent">ns=1;i=13</Reference>
                   <Reference ReferenceType="HasComponent">ns=1;i=14</Reference>
                   <Reference ReferenceType="HasComponent">ns=1;i=15</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=16</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=17</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=18</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=19</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=20</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=21</Reference>
+                  <Reference ReferenceType="HasComponent">ns=1;i=22</Reference>
                 </References>
               </UAObjectType>
+              <UAObject NodeId="ns=1;i=2" BrowseName="1:Container">
+                <References>
+                  <Reference ReferenceType="HasComponent">ns=1;i=30</Reference>
+                  <Reference ReferenceType="HasTypeDefinition">ns=1;i=1</Reference>
+                </References>
+              </UAObject>
+              <UAVariable NodeId="ns=1;i=30" BrowseName="1:UIElement" ParentNodeId="ns=1;i=2">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">ns=1;i=100</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2</Reference>
+                </References>
+              </UAVariable>
               <UAVariable NodeId="ns=1;i=10" BrowseName="1:UIElement" ParentNodeId="ns=1;i=1">
                 <References>
                   <Reference ReferenceType="HasTypeDefinition">ns=1;i=100</Reference>
@@ -105,6 +141,77 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                   <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
                 </References>
               </UAVariable>
+              <UAVariable NodeId="ns=1;i=16" BrowseName="1:CoreTwoState" ParentNodeId="ns=1;i=1" DataType="i=1">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=2373</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=17" BrowseName="1:CoreBaseData" ParentNodeId="ns=1;i=1">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=18" BrowseName="1:CoreProperty" ParentNodeId="ns=1;i=1">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=19" BrowseName="1:StructuredProperty" ParentNodeId="ns=1;i=1" DataType="ns=1;i=200">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=20" BrowseName="1:EnumProperty" ParentNodeId="ns=1;i=1" DataType="ns=1;i=201">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=21" BrowseName="1:StructuredArrayProperty" ParentNodeId="ns=1;i=1" DataType="ns=1;i=200" ValueRank="1">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UAVariable NodeId="ns=1;i=22" BrowseName="1:SubtypeProperty" ParentNodeId="ns=1;i=1" DataType="ns=1;i=202">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+                  <Reference ReferenceType="HasModellingRule">i=78</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+              <UADataType NodeId="ns=1;i=200" BrowseName="1:StructuredValueType">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+                </References>
+                <Definition Name="1:StructuredValueType">
+                  <Field Name="Name" DataType="i=12" />
+                </Definition>
+              </UADataType>
+              <UADataType NodeId="ns=1;i=201" BrowseName="1:ValueKind">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
+                </References>
+                <Definition Name="1:ValueKind">
+                  <Field Name="First" Value="0" />
+                  <Field Name="Second" Value="1" />
+                </Definition>
+              </UADataType>
+              <UADataType NodeId="ns=1;i=202" BrowseName="1:AbstractWeightType">
+                <References>
+                  <Reference ReferenceType="HasSubtype" IsForward="false">i=12</Reference>
+                </References>
+              </UADataType>
               <UAVariableType NodeId="ns=1;i=100" BrowseName="1:UIElementType" IsAbstract="true">
                 <DisplayName>UIElementType</DisplayName>
                 <Description>Semantic UI element value.</Description>
@@ -210,6 +317,33 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             </UANodeSet>
             """;
 
+        private const string BuiltInWithoutCoreNodeset = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+              <NamespaceUris>
+                <Uri>http://opcfoundation.org/UA/BuiltInWithoutCore/</Uri>
+              </NamespaceUris>
+              <Models>
+                <Model ModelUri="http://opcfoundation.org/UA/BuiltInWithoutCore/" Version="1.0.0" />
+              </Models>
+              <Aliases>
+                <Alias Alias="HasComponent">i=47</Alias>
+                <Alias Alias="HasTypeDefinition">i=40</Alias>
+              </Aliases>
+              <UAObjectType NodeId="ns=1;i=1" BrowseName="1:ContainerType">
+                <References>
+                  <Reference ReferenceType="HasComponent">ns=1;i=2</Reference>
+                </References>
+              </UAObjectType>
+              <UAVariable NodeId="ns=1;i=2" BrowseName="1:Text" ParentNodeId="ns=1;i=1" DataType="i=12">
+                <References>
+                  <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+                  <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1</Reference>
+                </References>
+              </UAVariable>
+            </UANodeSet>
+            """;
+
         [Fact]
         public void ReferencedVariableTypes_AreLocalSchemasAndAffordanceReferences()
         {
@@ -224,19 +358,64 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             Assert.Equal("#/schemaDefinitions/UIElementType", properties.GetProperty("UIElement").GetProperty("tm:ref").GetString());
             Assert.False(properties.GetProperty("UIElement").TryGetProperty("type", out _));
             Assert.Equal("integer", properties.GetProperty("BuiltIn").GetProperty("type").GetString());
+            Assert.False(properties.GetProperty("BuiltIn").TryGetProperty("tm:ref", out _));
+            Assert.False(properties.GetProperty("BuiltIn").TryGetProperty("dov:typeRef", out _));
+
+            Assert.Equal(
+                "#/schemaDefinitions/TwoStateDiscreteType",
+                properties.GetProperty("CoreTwoState").GetProperty("tm:ref").GetString());
+            Assert.Equal(
+                "#/schemaDefinitions/BaseDataVariableType",
+                properties.GetProperty("CoreBaseData").GetProperty("tm:ref").GetString());
+            Assert.Equal(
+                "#/schemaDefinitions/PropertyType",
+                properties.GetProperty("CoreProperty").GetProperty("tm:ref").GetString());
+
+            JsonElement twoStateDiscreteType = schemas.GetProperty("TwoStateDiscreteType");
+            Assert.Equal("boolean", twoStateDiscreteType.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.TwoStateDiscreteType",
+                twoStateDiscreteType.GetProperty("dov:typeRef").GetString());
 
             JsonElement specialized = properties.GetProperty("SpecializedUIElement");
             Assert.False(specialized.TryGetProperty("tm:ref", out _));
             Assert.Equal("integer", specialized.GetProperty("type").GetString());
-            Assert.Equal("org.opcfoundation.UA.VariableTypeTest.UIElementType", specialized.GetProperty("dov:typeRef").GetString());
+            Assert.False(specialized.TryGetProperty("dov:typeRef", out _));
 
             JsonElement scalarSample = properties.GetProperty("ScalarSample");
             Assert.False(scalarSample.TryGetProperty("tm:ref", out _));
             Assert.Equal("string", scalarSample.GetProperty("type").GetString());
-            Assert.Equal("org.opcfoundation.UA.VariableTypeTest.SampleArrayType", scalarSample.GetProperty("dov:typeRef").GetString());
+            Assert.False(scalarSample.TryGetProperty("dov:typeRef", out _));
+
+            JsonElement structuredProperty = properties.GetProperty("StructuredProperty");
+            Assert.False(structuredProperty.TryGetProperty("tm:ref", out _));
+            Assert.Equal("object", structuredProperty.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                structuredProperty.GetProperty("dov:typeRef").GetString());
+
+            JsonElement enumProperty = properties.GetProperty("EnumProperty");
+            Assert.False(enumProperty.TryGetProperty("tm:ref", out _));
+            Assert.Equal("integer", enumProperty.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.ValueKind",
+                enumProperty.GetProperty("dov:typeRef").GetString());
+
+            JsonElement structuredArrayProperty = properties.GetProperty("StructuredArrayProperty");
+            Assert.False(structuredArrayProperty.TryGetProperty("tm:ref", out _));
+            Assert.False(structuredArrayProperty.TryGetProperty("dov:typeRef", out _));
+            Assert.Equal("array", structuredArrayProperty.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                structuredArrayProperty.GetProperty("items").GetProperty("dov:typeRef").GetString());
 
             JsonElement events = thing.GetProperty("events");
             Assert.Equal("#/schemaDefinitions/UIElementType", events.GetProperty("UIElement").GetProperty("data").GetProperty("tm:ref").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                events.GetProperty("StructuredProperty").GetProperty("data").GetProperty("dov:typeRef").GetString());
+            Assert.False(
+                events.GetProperty("BuiltIn").GetProperty("data").TryGetProperty("dov:typeRef", out _));
         }
 
         [Fact]
@@ -256,6 +435,64 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
         }
 
         [Fact]
+        public void SpecializedSubtypeDataType_RetainsDataTypeReference()
+        {
+            JsonElement thing = GetThingByTitleSuffix("ContainerType");
+            JsonElement subtypeProperty = thing.GetProperty("properties").GetProperty("SubtypeProperty");
+
+            Assert.Equal("string", subtypeProperty.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.AbstractWeightType",
+                subtypeProperty.GetProperty("dov:typeRef").GetString());
+
+            JsonElement subtypeEventData = thing.GetProperty("events").GetProperty("SubtypeProperty").GetProperty("data");
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.AbstractWeightType",
+                subtypeEventData.GetProperty("dov:typeRef").GetString());
+        }
+
+        [Fact]
+        public void BuiltInDataType_DoesNotRequireCoreNodeset()
+        {
+            OpcUaGraph graph = new OpcUaGraph();
+            graph.AddNodeset(BuiltInWithoutCoreNodeset);
+
+            OpcUaVariable variable = graph.GetOpcUaModelInfo(BuiltInWithoutCoreModelUri)
+                .NodeIdToObjectTypeMap
+                .Values
+                .Single()
+                .VariableRecords
+                .Values
+                .Single()
+                .UaVariable;
+
+            Assert.Null(variable.CustomDataTypeSubtype);
+        }
+
+        [Fact]
+        public void ThingDescription_ExactVariableTypeRetainsTypeReference()
+        {
+            OpcUaGraph graph = CreateGraph();
+            WotThingCollection collection = new WotThingCollection(
+                graph,
+                graph.GetOpcUaModelInfo(ModelUri),
+                new LinkRelRuleEngine(),
+                integrate: false,
+                inheritVars: false,
+                includeTDs: true);
+
+            using JsonDocument doc = JsonDocument.Parse(collection.TransformText());
+            JsonElement thingDescription = doc.RootElement.EnumerateArray()
+                .Single(t => t.GetProperty("title").GetString() == "VariableTypeTest_Container");
+            JsonElement property = thingDescription.GetProperty("properties").GetProperty("UIElement");
+
+            Assert.Equal("string", property.GetProperty("type").GetString());
+            Assert.Equal(
+                "org.opcfoundation.UA.VariableTypeTest.UIElementType",
+                property.GetProperty("dov:typeRef").GetString());
+        }
+
+        [Fact]
         public void VariableTypeCatalog_ContainsAllNonDeprecatedCompanionTypes()
         {
             JsonElement catalog = GetThingByTitleSuffix("_VariableTypes");
@@ -271,7 +508,35 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
         }
 
         [Fact]
-        public void IntegratedOutput_IncludesRequiredCompanionVariableTypeCatalogsOnly()
+        public void CoreVariableTypeCatalog_ContainsAbstractAndConcreteTypes()
+        {
+            OpcUaGraph graph = new OpcUaGraph();
+            graph.AddNodeset(CoreNodeset);
+            WotThingCollection collection = new WotThingCollection(
+                graph,
+                graph.GetOpcUaModelInfo(OpcUaGraph.OpcUaCoreModelUri),
+                new LinkRelRuleEngine(),
+                integrate: false,
+                inheritVars: false,
+                includeTDs: false);
+
+            using JsonDocument doc = JsonDocument.Parse(collection.TransformText());
+            JsonElement catalog = Assert.Single(doc.RootElement.EnumerateArray().Select(t => t.Clone()));
+            Assert.Equal("OpcUaCore_VariableTypes", catalog.GetProperty("title").GetString());
+
+            string[] schemaNames = catalog.GetProperty("schemaDefinitions")
+                .EnumerateObject()
+                .Select(p => p.Name)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(
+                new[] { "BaseDataVariableType", "BaseVariableType", "DiscreteItemType", "PropertyType", "TwoStateDiscreteType" },
+                schemaNames);
+        }
+
+        [Fact]
+        public void IntegratedOutput_IncludesRequiredVariableTypeCatalogs()
         {
             OpcUaGraph graph = CreateGraph();
             WotThingCollection collection = new WotThingCollection(
@@ -286,9 +551,10 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             string[] catalogTitles = doc.RootElement.EnumerateArray()
                 .Select(t => t.GetProperty("title").GetString()!)
                 .Where(t => t.EndsWith("_VariableTypes", StringComparison.Ordinal))
+                .OrderBy(t => t, StringComparer.Ordinal)
                 .ToArray();
 
-            Assert.Equal(new[] { "VariableTypeTest_VariableTypes" }, catalogTitles);
+            Assert.Equal(new[] { "OpcUaCore_VariableTypes", "VariableTypeTest_VariableTypes" }, catalogTitles);
         }
 
         [Fact]


### PR DESCRIPTION
Added Azure.Iot.Operations.Opc2Wot tool with PowerShell and Bash wrappers for converting OPC UA NodeSets to WoT Thing Models. Improved NodeSet handling, explicit reference resolution, and schema/type reference logic. Enhanced WoT TM generation for correct schema integration and catalog inclusion. Expanded unit tests for model loading, type references, and integrated output. Various minor fixes and test coverage improvements.