### PR TITLE
[Rust][Dotnet][EdgeRegistry] Fix TM/TD Format field spelling for Edge Registry

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/ThingDescriptionFormat.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/ThingDescriptionFormat.g.cs
@@ -11,6 +11,6 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Generated
     public static class ThingDescriptionFormat
     {
         /// <summary>JSON-LD 1.1 format</summary>
-        public const string JsonLd11 = "JSON-LD/1.1";
+        public const string JsonLd11 = "JsonLD/1.1";
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/ThingModelFormat.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/ThingModelFormat.g.cs
@@ -11,6 +11,6 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Generated
     public static class ThingModelFormat
     {
         /// <summary>JSON-LD 1.1 format</summary>
-        public const string JsonLd11 = "JSON-LD/1.1";
+        public const string JsonLd11 = "JsonLD/1.1";
     }
 }

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/Version.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/Version.g.cs
@@ -123,7 +123,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Generated
         public string? ContentType { get; set; } = default;
 
         /// <summary>
-        /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+        /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
         /// </summary>
         [JsonPropertyName("format")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/VersionAttributes.g.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Generated/VersionAttributes.g.cs
@@ -66,7 +66,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Generated
         public string? ContentType { get; set; } = default;
 
         /// <summary>
-        /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+        /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
         /// </summary>
         [JsonPropertyName("format")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/CoreVersionAttributes.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/CoreVersionAttributes.cs
@@ -44,7 +44,7 @@ public class CoreVersionAttributes
     public string? ContentType { get; set; }
 
     /// <summary>
-    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     /// </summary>
     public string? Format { get; set; }
 

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/CoreVersionEntity.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/CoreVersionEntity.cs
@@ -79,7 +79,7 @@ public class CoreVersionEntity
     public string? ContentType { get; set; }
 
     /// <summary>
-    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     /// </summary>
     public string? Format { get; set; }
 

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/ThingDescriptionFormat.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/ThingDescriptionFormat.cs
@@ -12,7 +12,7 @@ public readonly struct ThingDescriptionFormat
 {
     private ThingDescriptionFormat(string value) => Value = value;
 
-    /// <summary>JSON-LD 1.1 format (<c>JSON-LD/1.1</c>).</summary>
+    /// <summary>JSON-LD 1.1 format (<c>JsonLD/1.1</c>).</summary>
     public static ThingDescriptionFormat JsonLd11 => new(Generated.ThingDescriptionFormat.JsonLd11);
 
     /// <summary>A format identifier not covered by the known formats.</summary>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/ThingModelFormat.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/Models/ThingModelFormat.cs
@@ -12,7 +12,7 @@ public readonly struct ThingModelFormat
 {
     private ThingModelFormat(string value) => Value = value;
 
-    /// <summary>JSON-LD 1.1 format (<c>JSON-LD/1.1</c>).</summary>
+    /// <summary>JSON-LD 1.1 format (<c>JsonLD/1.1</c>).</summary>
     public static ThingModelFormat JsonLd11 => new(Generated.ThingModelFormat.JsonLd11);
 
     /// <summary>A format identifier not covered by the known formats.</summary>

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/ThingDescriptionFormat.g.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/ThingDescriptionFormat.g.cs
@@ -11,6 +11,6 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Host.Generated
     public static class ThingDescriptionFormat
     {
         /// <summary>JSON-LD 1.1 format</summary>
-        public const string JsonLd11 = "JSON-LD/1.1";
+        public const string JsonLd11 = "JsonLD/1.1";
     }
 }

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/ThingModelFormat.g.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/ThingModelFormat.g.cs
@@ -11,6 +11,6 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Host.Generated
     public static class ThingModelFormat
     {
         /// <summary>JSON-LD 1.1 format</summary>
-        public const string JsonLd11 = "JSON-LD/1.1";
+        public const string JsonLd11 = "JsonLD/1.1";
     }
 }

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/Version.g.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/Version.g.cs
@@ -123,7 +123,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Host.Generated
         public string? ContentType { get; set; } = default;
 
         /// <summary>
-        /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+        /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
         /// </summary>
         [JsonPropertyName("format")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/VersionAttributes.g.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/Generated/VersionAttributes.g.cs
@@ -66,7 +66,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry.Host.Generated
         public string? ContentType { get; set; } = default;
 
         /// <summary>
-        /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+        /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
         /// </summary>
         [JsonPropertyName("format")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/eng/wot/edge-registry/ThingDescriptionExtensions.TM.json
+++ b/eng/wot/edge-registry/ThingDescriptionExtensions.TM.json
@@ -123,7 +123,7 @@
         "ThingDescriptionFormat": {
             "type": "object",
             "const": {
-                "JsonLD11": "JSON-LD/1.1"
+                "JsonLD11": "JsonLD/1.1"
             },
             "description": "Non-exhaustive supported WoT TD formats",
             "properties": {

--- a/eng/wot/edge-registry/ThingModelExtensions.TM.json
+++ b/eng/wot/edge-registry/ThingModelExtensions.TM.json
@@ -123,7 +123,7 @@
         "ThingModelFormat": {
             "type": "object",
             "const": {
-                "JsonLD11": "JSON-LD/1.1"
+                "JsonLD11": "JsonLD/1.1"
             },
             "description": "Non-exhaustive supported WoT TM formats",
             "properties": {

--- a/eng/wot/edge-registry/core-xregistry/Version.schema.json
+++ b/eng/wot/edge-registry/core-xregistry/Version.schema.json
@@ -80,7 +80,7 @@
       "type": "string"
     },
     "format": {
-      "description": "Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).",
+      "description": "Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).",
       "type": "string"
     },
     "formatValidated": {

--- a/eng/wot/edge-registry/core-xregistry/VersionAttributes.schema.json
+++ b/eng/wot/edge-registry/core-xregistry/VersionAttributes.schema.json
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "format": {
-      "description": "Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).",
+      "description": "Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).",
       "type": "string"
     },
     "document": {

--- a/rust/azure_iot_operations_services/src/edge_registry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry.rs
@@ -23,7 +23,7 @@ pub use client::Client;
 // modules are private), so the identifier is ambiguous.
 // TODO: consider generating the format identifiers into separate namespaces to avoid this ambiguity.
 /// JSON-LD 1.1 format.
-const JSON_LD11: &str = "JSON-LD/1.1";
+const JSON_LD11: &str = "JsonLD/1.1";
 
 // ~~~~~~~~~~~~~~~~~~~SDK Created Structs~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_description_format.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_description_format.rs
@@ -3,4 +3,4 @@
 // Non-exhaustive supported WoT TD formats
 
 /// JSON-LD 1.1 format
-pub const JSON_LD11: &str = "JSON-LD/1.1";
+pub const JSON_LD11: &str = "JsonLD/1.1";

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_model_format.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/thing_model_format.rs
@@ -3,4 +3,4 @@
 // Non-exhaustive supported WoT TM formats
 
 /// JSON-LD 1.1 format
-pub const JSON_LD11: &str = "JSON-LD/1.1";
+pub const JSON_LD11: &str = "JsonLD/1.1";

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version.rs
@@ -75,7 +75,7 @@ pub struct Version {
     #[builder(default = "None")]
     pub content_type: Option<String>,
 
-    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
     pub format: Option<String>,

--- a/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version_attributes.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/edge_registry_gen/edge_registry/version_attributes.rs
@@ -50,7 +50,7 @@ pub struct VersionAttributes {
     #[builder(default = "None")]
     pub content_type: Option<String>,
 
-    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "None")]
     pub format: Option<String>,

--- a/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
@@ -343,7 +343,7 @@ pub struct CoreVersionEntity {
     pub ancestor: String,
     /// The media type of the entity as defined by RFC9110.
     pub content_type: Option<String>,
-    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Identifies what the Version represents (e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     pub format: Option<String>,
     /// When format validation is enabled, indicates whether the server has validated that the
     /// Version conforms to the rules defined by its `format` attribute.
@@ -468,7 +468,7 @@ pub struct CoreVersionAttributes {
     pub ancestor: Option<String>,
     /// Content type of the Version document.
     pub content_type: Option<String>,
-    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JSON-LD/1.1`).
+    /// Format identifier of the Version document (resource-type-specific, e.g. `JsonSchema/draft-07`, `JsonLD/1.1`).
     pub format: Option<String>,
     /// Base64-encoded document content for the Version. The interpretation (schema, thing description, thing model, etc.) is determined by the Resource type.
     pub document: Option<Bytes>,


### PR DESCRIPTION
The correct string should have been `JsonLD/1.1` to be compatible with the Cloud Registry, this is a bug fix