### PR TITLE
[Rust][Services] Version bump 1.4.0-beta1 -> 1.4.0-beta2 for edge registry fixes

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -14,7 +14,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.4.0-beta1", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 chrono = { workspace = true, features = ["clock"] }
 derive_builder.workspace = true

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_services"
-version = "1.4.0-beta1"
+version = "1.4.0-beta2"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"

--- a/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
+++ b/rust/sample_applications/sample_connector_scaffolding/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 azure_iot_operations_connector = { version = "2.1", path = "../../azure_iot_operations_connector" }
-azure_iot_operations_services = { version = "1.4.0-beta1", path = "../../azure_iot_operations_services" }
+azure_iot_operations_services = { version = "1.4.0-beta2", path = "../../azure_iot_operations_services" }
 azure_iot_operations_protocol = { version = "1.1", path = "../../azure_iot_operations_protocol" }
 env_logger = "0.11.8"
 log = "0.4.21"


### PR DESCRIPTION
azure_iot_operations_services: 1.4.0-beta1 -> 1.4.0-beta2
Adds edge registry query by hash and a typo fix to work with the cloud service