### PR TITLE
[Rust][Connector] Version bump 2.1.0 -> 2.1.1

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_iot_operations_connector"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT"


### PR DESCRIPTION
## Summary

- Increment `azure_iot_operations_connector` from `2.1.0` to `2.1.1`.

## Validation

- `cargo check --manifest-path rust/Cargo.toml --package azure_iot_operations_connector`