### PR TITLE
Fix RFC 6901 JSON pointer resolution in ProtocolCompiler

### DIFF
--- a/codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/TypeGenerator/JsonSchemaStandardizer.cs
+++ b/codegen/src/Azure.Iot.Operations.ProtocolCompilerLib/TypeGenerator/JsonSchemaStandardizer.cs
@@ -124,7 +124,8 @@
                 }
             }
 
-            JsonElement referencedElt = rootElt.GetProperty(internalDefsKey).GetProperty(refString.Substring($"#/{internalDefsKey}/".Length));
+            string referenceToken = refString.Substring($"#/{internalDefsKey}/".Length);
+            JsonElement referencedElt = rootElt.GetProperty(internalDefsKey).GetProperty(DecodeJsonPointerToken(referenceToken));
 
             if (referencedElt.TryGetProperty("properties", out _) || referencedElt.TryGetProperty("enum", out _))
             {
@@ -134,6 +135,11 @@
             }
 
             return GetPrimitiveTypeFromJsonElement(rootElt, referencedElt, internalDefsKey, genNamespace, retriever);
+        }
+
+        private static string DecodeJsonPointerToken(string token)
+        {
+            return token.Replace("~1", "/", StringComparison.Ordinal).Replace("~0", "~", StringComparison.Ordinal);
         }
 
         private bool TryGetNestedNullableJsonElement(ref JsonElement jsonElement)

--- a/codegen/test/ProtocolCompiler.UnitTests/TypeGeneratorTests/JsonSchemaStandardizerTests.cs
+++ b/codegen/test/ProtocolCompiler.UnitTests/TypeGeneratorTests/JsonSchemaStandardizerTests.cs
@@ -1,0 +1,57 @@
+namespace Azure.Iot.Operations.ProtocolCompiler.UnitTests.TypeGeneratorTests
+{
+    using Azure.Iot.Operations.ProtocolCompilerLib;
+
+    public class JsonSchemaStandardizerTests
+    {
+        private const string RootPath = "../../../TypeGeneratorTests";
+
+        [Fact]
+        public void ResolvesRfc6901EncodedDefinitionReference()
+        {
+            string schemaText = File.ReadAllText(Path.Combine(RootPath, "MinimalTelemetry.schema.json"));
+
+            ObjectType telemetryType = StandardizeSingleObject(schemaText);
+            ObjectType.FieldInfo temperatureField = Assert.Single(telemetryType.FieldInfos).Value;
+
+            Assert.IsType<IntegerType>(temperatureField.SchemaType);
+        }
+
+        [Theory]
+        [InlineData("value~0name", "value~name")]
+        [InlineData("value~01name", "value~1name")]
+        public void ResolvesRfc6901EncodedDefinitionReferences(string referenceToken, string definitionName)
+        {
+            string schemaText = $$"""
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "title": "MinimalTelemetry",
+                  "type": "object",
+                  "properties": {
+                    "Temperature": { "$ref": "#/definitions/{{referenceToken}}" }
+                  },
+                  "definitions": {
+                    "{{definitionName}}": {
+                      "title": "Temperature",
+                      "type": "integer",
+                      "maximum": 2147483647
+                    }
+                  }
+                }
+                """;
+
+            ObjectType telemetryType = StandardizeSingleObject(schemaText);
+            ObjectType.FieldInfo temperatureField = Assert.Single(telemetryType.FieldInfos).Value;
+
+            Assert.IsType<IntegerType>(temperatureField.SchemaType);
+        }
+
+        private static ObjectType StandardizeSingleObject(string schemaText)
+        {
+            JsonSchemaStandardizer standardizer = new();
+
+            return Assert.IsType<ObjectType>(
+                Assert.Single(standardizer.GetStandardizedSchemas(schemaText, new CodeName("OpcUaAssets"), _ => throw new InvalidOperationException())));
+        }
+    }
+}

--- a/codegen/test/ProtocolCompiler.UnitTests/TypeGeneratorTests/MinimalTelemetry.schema.json
+++ b/codegen/test/ProtocolCompiler.UnitTests/TypeGeneratorTests/MinimalTelemetry.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MinimalTelemetry",
+  "type": "object",
+  "properties": {
+    "Temperature": {
+      "$ref": "#/definitions/nsu=http:~1~1contoso.com~1Boiler;i=1"
+    }
+  },
+  "definitions": {
+    "nsu=http://contoso.com/Boiler;i=1": {
+      "title": "Temperature",
+      "type": "integer",
+      "maximum": 2147483647
+    }
+  }
+}


### PR DESCRIPTION
Given a JSON schema using RFC 6901 JSON pointer like

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "MinimalTelemetry",
  "type": "object",
  "properties": {
    "Temperature": { "$ref": "#/definitions/nsu=http:~1~1contoso.com~1Boiler;i=1" }
  },
  "definitions": {
    "nsu=http://contoso.com/Boiler;i=1": {
      "title": "Temperature",
      "type": "integer",
      "maximum": 2147483647
    }
  }
}
```

should generate code classes when called with `Azure.Iot.Operations.ProtocolCompiler --namespace OpcUaAssets --outDir . --lang csharp` but fails with `Code generation failed with exception: The given key was not present in the dictionary.`

This PR fixes this.