### PR TITLE
Generate one TM.json file per type and add dov:typeRef for all TMs not only ObjectTypes

### DIFF
--- a/wot-codegen/README.md
+++ b/wot-codegen/README.md
@@ -1,6 +1,6 @@
 # OPC UA NodeSet converter
 
-The `Azure.Iot.Operations.Opc2Wot` tool converts OPC UA NodeSet files into W3C WoT Thing Model collections. The repository provides PowerShell and Bash wrappers for regenerating the OPC UA companion models maintained in the sibling [Azure/smd](https://github.com/Azure/smd) repository.
+The `Azure.Iot.Operations.Opc2Wot` tool converts OPC UA NodeSet files into standalone W3C WoT Thing Model documents. Each model is written to `<ShortOpcUaName>_<Type>.TM.json`, links between models use the target model's absolute `id`, and protocol-specific `forms` are omitted from Thing Models. The repository provides PowerShell and Bash wrappers for regenerating the OPC UA companion models maintained in the sibling [Azure/smd](https://github.com/Azure/smd) repository.
 
 By default, both wrappers expect this sibling repository layout:
 
@@ -39,7 +39,7 @@ Optional converter flags:
 | --- | --- | --- |
 | `-Integrate` | `--integrate` | Integrate referenced models into each output file. |
 | `-InheritVars` | `--inherit-vars` | Add `dov:includeInherited` to applicable root forms. |
-| `-IncludeTDs` | `--include-tds` | Include Thing Descriptions in generated collections. |
+| `-IncludeTDs` | `--include-tds` | Include standalone Thing Description documents in the generated output. |
 | `-IncludeNonPublished` | `--include-non-published` | Include UA-Nodeset demo, test, and example-only models. |
 
 # Protocol compiler

--- a/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/ThingValidator.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/ThingValidator.cs
@@ -120,12 +120,22 @@ namespace Azure.Iot.Operations.CodeGeneration
                 return false;
             }
 
-            if ((isDescription || this.requireThingModelForms) &&
-                (!TryValidateCrossFormConsistency(thing.Forms, thing.Actions)
-                || !TryValidateCrossFormConsistency(thing.Forms, thing.Properties, resolvingThing, validateReferences)
-                || !TryValidateCrossFormConsistency(thing.Forms, thing.Events, resolvingThing, validateReferences)))
+            if (isDescription || this.requireThingModelForms)
             {
-                hasError = true;
+                if (!TryValidateCrossFormConsistency(thing.Forms, thing.Actions))
+                {
+                    hasError = true;
+                }
+
+                if (!TryValidateCrossFormConsistency(thing.Forms, thing.Properties, resolvingThing, validateReferences))
+                {
+                    hasError = true;
+                }
+
+                if (!TryValidateCrossFormConsistency(thing.Forms, thing.Events, resolvingThing, validateReferences))
+                {
+                    hasError = true;
+                }
             }
 
             if (!TryValidateThingPropertyNames(thing.PropertyNames))

--- a/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/ThingValidator.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.CodeGeneration/ThingValidator.cs
@@ -21,12 +21,14 @@ namespace Azure.Iot.Operations.CodeGeneration
         private static readonly Regex EnumValueRegex = new(@"^[A-Za-z][A-Za-z0-9_]*$", RegexOptions.Compiled);
 
         private ErrorReporter errorReporter;
+        private bool requireThingModelForms;
         private MapTracker<TDDataSchema>? currentSchemaDefinitions;
         private bool currentThingIsDescription;
 
-        public ThingValidator(ErrorReporter errorReporter)
+        public ThingValidator(ErrorReporter errorReporter, bool requireThingModelForms = true)
         {
             this.errorReporter = errorReporter;
+            this.requireThingModelForms = requireThingModelForms;
         }
 
         public bool TryValidateThing(IResolvingThing resolvingThing, HashSet<SerializationFormat> serializationFormats, bool validateReferences)
@@ -118,17 +120,10 @@ namespace Azure.Iot.Operations.CodeGeneration
                 return false;
             }
 
-            if (!TryValidateCrossFormConsistency(thing.Forms, thing.Actions))
-            {
-                hasError = true;
-            }
-
-            if (!TryValidateCrossFormConsistency(thing.Forms, thing.Properties, resolvingThing, validateReferences))
-            {
-                hasError = true;
-            }
-
-            if (!TryValidateCrossFormConsistency(thing.Forms, thing.Events, resolvingThing, validateReferences))
+            if ((isDescription || this.requireThingModelForms) &&
+                (!TryValidateCrossFormConsistency(thing.Forms, thing.Actions)
+                || !TryValidateCrossFormConsistency(thing.Forms, thing.Properties, resolvingThing, validateReferences)
+                || !TryValidateCrossFormConsistency(thing.Forms, thing.Events, resolvingThing, validateReferences)))
             {
                 hasError = true;
             }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/CommandHandler.cs
@@ -122,41 +122,23 @@ namespace Azure.Iot.Operations.Opc2Wot
                 statusReceiver?.Invoke("Skipping validation of Thing Model references in links because '--integrate' option is not set.", false);
             }
 
+            Dictionary<string, WotThingDocument> documentsByFileName = new(StringComparer.Ordinal);
             foreach (string modelUri in opcUaGraph.GetModelUris())
             {
-                errorLog.ClearRegistrations();
-
                 WotThingCollection thingCollection = new WotThingCollection(opcUaGraph, opcUaGraph.GetOpcUaModelInfo(modelUri), linkRelRuleEngine, options.Integrate, options.InheritVars, options.IncludeTDs);
-
-                string thingText = thingCollection.TransformText();
-
-                string outFileName = $"{SpecMapper.GetSpecNameFromUri(modelUri)}.TM.json";
-                string outFilePath = Path.Combine(options.OutputDir.FullName, outFileName);
-
-                ValidateThing(thingText, errorLog, outFileName, validateReferences: options.Integrate);
-
-                List<string> thingTypes = new();
-                if (thingCollection.ThingDescriptions.Any())
+                foreach (WotThingDocument document in thingCollection.GetDocuments())
                 {
-                    thingTypes.Add("Thing Descriptions");
-                }
-                if (thingCollection.ThingModels.Any())
-                {
-                    thingTypes.Add("Thing Models");
-                }
-                if (thingCollection.DataTypeModels.Any())
-                {
-                    thingTypes.Add("DataType Models");
-                }
-                if (thingCollection.VariableTypeModels.Any())
-                {
-                    thingTypes.Add("VariableType Models");
-                }
-
-                if (thingCollection.ThingDescriptions.Any() || thingCollection.ThingModels.Any() || thingCollection.DataTypeModels.Any() || thingCollection.VariableTypeModels.Any())
-                {
-                    statusReceiver?.Invoke($"Writing {string.Join(" and ", thingTypes)} for '{modelUri}' to '{outFileName}'", false);
-                    File.WriteAllText(outFilePath, thingText);
+                    if (documentsByFileName.TryGetValue(document.FileName, out WotThingDocument? existingDocument))
+                    {
+                        if (existingDocument.Text != document.Text)
+                        {
+                            AddUnlocatableError(ErrorCondition.Duplication, $"Multiple Thing Models would be written to '{document.FileName}' with different content.", errorLog);
+                        }
+                    }
+                    else
+                    {
+                        documentsByFileName.Add(document.FileName, document);
+                    }
                 }
             }
 
@@ -165,40 +147,68 @@ namespace Azure.Iot.Operations.Opc2Wot
                 return errorLog;
             }
 
+            errorLog.ClearRegistrations();
+            ValidateThings(documentsByFileName.Values, errorLog, validateReferences: options.Integrate);
             errorLog.CheckForDuplicatesInThings();
+
+            if (errorLog.HasErrors)
+            {
+                return errorLog;
+            }
+
+            foreach (WotThingDocument document in documentsByFileName.Values.OrderBy(d => d.FileName, StringComparer.Ordinal))
+            {
+                statusReceiver?.Invoke($"Writing Thing document to '{document.FileName}'", false);
+                File.WriteAllText(Path.Combine(options.OutputDir.FullName, document.FileName), document.Text);
+            }
 
             return errorLog;
         }
 
-        private static void ValidateThing(string thingText, ErrorLog errorLog, string outFileName, bool validateReferences)
+        private static void ValidateThings(IEnumerable<WotThingDocument> documents, ErrorLog errorLog, bool validateReferences)
         {
-            byte[] thingBytes = Encoding.UTF8.GetBytes(thingText);
-            ErrorReporter errorReporter = new ErrorReporter(errorLog, outFileName, thingBytes);
-            ThingValidator thingValidator = new ThingValidator(errorReporter);
+            List<(TDThing Thing, ErrorReporter ErrorReporter)> parsedThings = new();
 
-            List<TDThing> things;
-            try
+            foreach (WotThingDocument document in documents)
             {
-                things = TDParser.Parse(thingBytes);
-            }
-            catch (Exception ex)
-            {
-                errorReporter.ReportJsonException(ex);
-                return;
-            }
+                byte[] thingBytes = Encoding.UTF8.GetBytes(document.Text);
+                ErrorReporter errorReporter = new ErrorReporter(errorLog, document.FileName, thingBytes);
 
-            Dictionary<string, TDThing> titleToThingMap = things.ToDictionary(t => t.Title!.Value.Value, t => t);
-
-            foreach (TDThing thing in things)
-            {
-                HashSet<SerializationFormat> serializationFormats = new();
-                if (thingValidator.TryValidateThing(new IntegralResolvingThing(thing, errorReporter, titleToThingMap), serializationFormats, validateReferences))
+                try
                 {
-                    errorReporter.RegisterNameOfThing(thing.Title!.Value.Value, thing.Title!.TokenIndex);
+                    parsedThings.AddRange(TDParser.Parse(thingBytes).Select(thing => (thing, errorReporter)));
+                }
+                catch (Exception ex)
+                {
+                    errorReporter.ReportJsonException(ex);
                 }
             }
 
-            thingValidator.ValidateThingCollection(things, null);
+            Dictionary<string, TDThing> hrefToThingMap = new(StringComparer.Ordinal);
+            foreach ((TDThing thing, _) in parsedThings)
+            {
+                if (thing.Title != null)
+                {
+                    hrefToThingMap.TryAdd($"#{TDValues.HrefTitlePrefix}{thing.Title.Value.Value}", thing);
+                }
+
+                if (thing.Id != null)
+                {
+                    hrefToThingMap.TryAdd(thing.Id.Value.Value, thing);
+                }
+            }
+
+            foreach ((TDThing thing, ErrorReporter errorReporter) in parsedThings)
+            {
+                ThingValidator thingValidator = new ThingValidator(errorReporter, requireThingModelForms: false);
+                HashSet<SerializationFormat> serializationFormats = new();
+                if (thingValidator.TryValidateThing(new IntegralResolvingThing(thing, errorReporter, hrefToThingMap), serializationFormats, validateReferences))
+                {
+                    errorReporter.RegisterNameOfThing(thing.Title!.Value.Value, thing.Title!.TokenIndex);
+                }
+
+                thingValidator.ValidateThingCollection(new List<TDThing> { thing }, null);
+            }
         }
 
         private static void DisplayErrors(ErrorLog errorLog)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/IntegralResolvingThing.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/IntegralResolvingThing.cs
@@ -10,14 +10,12 @@ namespace Azure.Iot.Operations.Opc2Wot
 
     public class IntegralResolvingThing : IResolvingThing
     {
-        private const string HrefPrefix = $"#{TDValues.HrefTitlePrefix}";
-
-        private Dictionary<string, TDThing> titleToThingMap;
+        private Dictionary<string, TDThing> hrefToThingMap;
         private ErrorReporter errorReporter;
 
-        public IntegralResolvingThing(TDThing thing, ErrorReporter errorReporter, Dictionary<string, TDThing> titleToThingMap)
+        public IntegralResolvingThing(TDThing thing, ErrorReporter errorReporter, Dictionary<string, TDThing> hrefToThingMap)
         {
-            this.titleToThingMap = titleToThingMap;
+            this.hrefToThingMap = hrefToThingMap;
             this.errorReporter = errorReporter;
             ParsedThing = new ParsedThing(thing, string.Empty, string.Empty, new SchemaNamer(null), errorReporter, true, true);
         }
@@ -26,11 +24,9 @@ namespace Azure.Iot.Operations.Opc2Wot
 
         public bool TryResolve(string href, [NotNullWhen(true)] out IResolvingThing? resolvingThing)
         {
-            string title = href.StartsWith(HrefPrefix) ? href.Substring(HrefPrefix.Length) : string.Empty;
-
-            if (titleToThingMap.TryGetValue(title, out TDThing? referencedThing))
+            if (hrefToThingMap.TryGetValue(href, out TDThing? referencedThing))
             {
-                resolvingThing = new IntegralResolvingThing(referencedThing, errorReporter, titleToThingMap);
+                resolvingThing = new IntegralResolvingThing(referencedThing, errorReporter, hrefToThingMap);
                 return true;
             }
 

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/OptionContainer.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2Wot/OptionContainer.cs
@@ -13,7 +13,7 @@ namespace Azure.Iot.Operations.Opc2Wot
         /// <summary>Gets or sets one or more glob patterns used to locate OPC UA Nodeset files to process.</summary>
         public required string[] NodeSetsSpec { get; set; }
 
-        /// <summary>Gets or sets the path to a folder for placing files that will each contain a collection of WoT Things.</summary>
+        /// <summary>Gets or sets the path to a folder for placing standalone WoT Thing Model and Thing Description documents.</summary>
         public required DirectoryInfo OutputDir { get; set; }
 
         /// <summary>Gets or sets an indication of whether to integrate all referenced Thing Models into each Thing collection.</summary>

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotThingDocument.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotThingDocument.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+namespace Azure.Iot.Operations.Opc2WotLib
+{
+    using System.Collections.Generic;
+    using System.Text.Encodings.Web;
+    using System.Text.Json;
+    using System.Text.Json.Nodes;
+
+    public record WotThingDocument(string FileName, string Text)
+    {
+        private static readonly string[] OptionalMapNames = { "schemaDefinitions", "actions", "properties", "events" };
+
+        public static WotThingDocument Create(string fileName, string text)
+        {
+            JsonObject document = JsonNode.Parse(text)!.AsObject();
+            if (fileName.EndsWith(".TM.json", System.StringComparison.Ordinal))
+            {
+                RemoveForms(document);
+            }
+
+            foreach (string optionalMapName in OptionalMapNames)
+            {
+                if (document[optionalMapName] is JsonObject map && map.Count == 0)
+                {
+                    document.Remove(optionalMapName);
+                }
+            }
+
+            return new WotThingDocument(
+                fileName,
+                document.ToJsonString(new JsonSerializerOptions
+                {
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    WriteIndented = true,
+                }));
+        }
+
+        private static void RemoveForms(JsonObject document)
+        {
+            document.Remove("forms");
+
+            foreach (string affordanceMapName in new[] { "actions", "properties", "events" })
+            {
+                if (document[affordanceMapName] is not JsonObject affordances)
+                {
+                    continue;
+                }
+
+                foreach (KeyValuePair<string, JsonNode?> affordance in affordances)
+                {
+                    affordance.Value?.AsObject().Remove("forms");
+                }
+            }
+        }
+    }
+}

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
@@ -3,6 +3,7 @@
 
 namespace Azure.Iot.Operations.Opc2WotLib
 {
+    using System;
     using System.Text.RegularExpressions;
 
     public static class WotUtil
@@ -12,6 +13,16 @@ namespace Azure.Iot.Operations.Opc2WotLib
             string legalPrefix = prefix == string.Empty ? string.Empty : Capitalize(Regex.Replace($"{prefix}_", "[^a-zA-Z0-9]+", "_", RegexOptions.CultureInvariant));
             string legalName = Capitalize(Regex.Replace(name, "[^a-zA-Z0-9]+", "_", RegexOptions.CultureInvariant));
             return $"{legalPrefix}{legalName}";
+        }
+
+        public static string GetThingModelId(string modelUri, string thingName)
+        {
+            UriBuilder uriBuilder = new UriBuilder(modelUri)
+            {
+                Fragment = Uri.EscapeDataString(thingName),
+            };
+
+            return uriBuilder.Uri.AbsoluteUri;
         }
 
         private static string Capitalize(string str)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
@@ -9,12 +9,18 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
     public partial class WotDataTypeModel : ITemplateTransform
     {
+        private string modelUri;
+        private string specName;
         private string thingName;
+        private string id;
         private List<KeyValuePair<string, WotDataSchema>> schemaDefinitions;
 
-        public WotDataTypeModel(string specName, IEnumerable<OpcUaDataType> dataTypes)
+        public WotDataTypeModel(string modelUri, string specName, IEnumerable<OpcUaDataType> dataTypes)
         {
+            this.modelUri = modelUri;
+            this.specName = specName;
             this.thingName = WotUtil.LegalizeName("DataTypes", specName);
+            this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
 
             this.schemaDefinitions = dataTypes
                 .Where(dt => !dt.IsDeprecated && !dt.NodeId.IsBuiltInDataType)
@@ -23,9 +29,12 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 .ToList();
         }
 
-        public WotDataTypeModel(string specName, IEnumerable<OpcUaVariableType> variableTypes)
+        public WotDataTypeModel(string modelUri, string specName, IEnumerable<OpcUaVariableType> variableTypes)
         {
+            this.modelUri = modelUri;
+            this.specName = specName;
             this.thingName = WotUtil.LegalizeName("VariableTypes", specName);
+            this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
 
             Dictionary<OpcUaVariableType, string> schemaNames = WotVariableTypeSchema.GetSchemaNames(
                 variableTypes.Where(vt => vt.IsSchemaEligible));
@@ -37,6 +46,30 @@ namespace Azure.Iot.Operations.Opc2WotLib
         }
 
         public bool HasSchemaDefinitions => this.schemaDefinitions.Count > 0;
+
+        public string FileName => $"{this.thingName}.TM.json";
+
+        public IEnumerable<WotThingDocument> GetDocuments()
+        {
+            return this.schemaDefinitions.Select(schemaDefinition =>
+            {
+                string schemaThingName = WotUtil.LegalizeName(schemaDefinition.Key, this.specName);
+                WotDataTypeModel schemaModel = new WotDataTypeModel(
+                    this.modelUri,
+                    schemaThingName,
+                    new List<KeyValuePair<string, WotDataSchema>> { schemaDefinition });
+                return WotThingDocument.Create(schemaModel.FileName, schemaModel.TransformText());
+            });
+        }
+
+        private WotDataTypeModel(string modelUri, string thingName, List<KeyValuePair<string, WotDataSchema>> schemaDefinitions)
+        {
+            this.modelUri = modelUri;
+            this.specName = string.Empty;
+            this.thingName = thingName;
+            this.id = WotUtil.GetThingModelId(modelUri, thingName);
+            this.schemaDefinitions = schemaDefinitions;
+        }
 
         private static WotDataSchema CreateSchema(OpcUaDataType dataType)
         {

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
@@ -13,7 +13,9 @@ namespace Azure.Iot.Operations.Opc2WotLib
         private string specName;
         private string thingName;
         private string id;
+        private string? typeRef;
         private List<KeyValuePair<string, WotDataSchema>> schemaDefinitions;
+        private Dictionary<string, string> schemaTypeRefs;
 
         public WotDataTypeModel(string modelUri, string specName, IEnumerable<OpcUaDataType> dataTypes)
         {
@@ -21,12 +23,16 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName("DataTypes", specName);
             this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
+            this.typeRef = null;
 
-            this.schemaDefinitions = dataTypes
+            List<OpcUaDataType> includedDataTypes = dataTypes
                 .Where(dt => !dt.IsDeprecated && !dt.NodeId.IsBuiltInDataType)
                 .OrderBy(dt => dt.EffectiveName, StringComparer.Ordinal)
+                .ToList();
+            this.schemaDefinitions = includedDataTypes
                 .Select(dt => new KeyValuePair<string, WotDataSchema>(dt.EffectiveName, CreateSchema(dt)))
                 .ToList();
+            this.schemaTypeRefs = includedDataTypes.ToDictionary(dt => dt.EffectiveName, dt => dt.GetTypeRef(), StringComparer.Ordinal);
         }
 
         public WotDataTypeModel(string modelUri, string specName, IEnumerable<OpcUaVariableType> variableTypes)
@@ -35,6 +41,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName("VariableTypes", specName);
             this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
+            this.typeRef = null;
 
             Dictionary<OpcUaVariableType, string> schemaNames = WotVariableTypeSchema.GetSchemaNames(
                 variableTypes.Where(vt => vt.IsSchemaEligible));
@@ -43,6 +50,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 .OrderBy(kvp => kvp.Value, StringComparer.Ordinal)
                 .Select(kvp => new KeyValuePair<string, WotDataSchema>(kvp.Value, WotVariableTypeSchema.Create(kvp.Key)))
                 .ToList();
+            this.schemaTypeRefs = schemaNames.ToDictionary(kvp => kvp.Value, kvp => kvp.Key.GetTypeRef(), StringComparer.Ordinal);
         }
 
         public bool HasSchemaDefinitions => this.schemaDefinitions.Count > 0;
@@ -57,18 +65,21 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 WotDataTypeModel schemaModel = new WotDataTypeModel(
                     this.modelUri,
                     schemaThingName,
+                    this.schemaTypeRefs[schemaDefinition.Key],
                     new List<KeyValuePair<string, WotDataSchema>> { schemaDefinition });
                 return WotThingDocument.Create(schemaModel.FileName, schemaModel.TransformText());
             });
         }
 
-        private WotDataTypeModel(string modelUri, string thingName, List<KeyValuePair<string, WotDataSchema>> schemaDefinitions)
+        private WotDataTypeModel(string modelUri, string thingName, string typeRef, List<KeyValuePair<string, WotDataSchema>> schemaDefinitions)
         {
             this.modelUri = modelUri;
             this.specName = string.Empty;
             this.thingName = thingName;
             this.id = WotUtil.GetThingModelId(modelUri, thingName);
+            this.typeRef = typeRef;
             this.schemaDefinitions = schemaDefinitions;
+            this.schemaTypeRefs = new Dictionary<string, string>(StringComparer.Ordinal);
         }
 
         private static WotDataSchema CreateSchema(OpcUaDataType dataType)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingCollection.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingCollection.cs
@@ -21,21 +21,21 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 Dictionary<string, Dictionary<OpcUaNodeId, OpcUaObjectType>> closure = ModelInfoCloser.ComputeClosure(modelInfo);
                 this.ThingModels = closure.SelectMany(kvp => kvp.Value.Values.Select(ot => new WotThingModel(SpecMapper.GetSpecNameFromUri(kvp.Key), ot, linkRelRuleEngine, isIntegrated: true, inheritVars: inheritVars))).ToList();
                 this.DataTypeModels = opcUaGraph.GetRequiredModelClosure(modelInfo)
-                    .Select(requiredModel => new WotDataTypeModel(SpecMapper.GetSpecNameFromUri(requiredModel.ModelUri), requiredModel.NodeIdToDataTypeMap.Values))
+                    .Select(requiredModel => new WotDataTypeModel(requiredModel.ModelUri, SpecMapper.GetSpecNameFromUri(requiredModel.ModelUri), requiredModel.NodeIdToDataTypeMap.Values))
                     .Where(dtm => dtm.HasSchemaDefinitions)
                     .ToList();
                 this.VariableTypeModels = opcUaGraph.GetRequiredModelClosure(modelInfo)
-                    .Select(requiredModel => new WotDataTypeModel(SpecMapper.GetSpecNameFromUri(requiredModel.ModelUri), requiredModel.NodeIdToVariableTypeMap.Values))
+                    .Select(requiredModel => new WotDataTypeModel(requiredModel.ModelUri, SpecMapper.GetSpecNameFromUri(requiredModel.ModelUri), requiredModel.NodeIdToVariableTypeMap.Values))
                     .Where(vtm => vtm.HasSchemaDefinitions)
                     .ToList();
             }
             else
             {
                 this.ThingModels = modelInfo.NodeIdToObjectTypeMap.Values.Select(ot => new WotThingModel(specName, ot, linkRelRuleEngine, isIntegrated: false, inheritVars: inheritVars)).ToList();
-                this.DataTypeModels = new List<WotDataTypeModel> { new WotDataTypeModel(specName, modelInfo.NodeIdToDataTypeMap.Values) }
+                this.DataTypeModels = new List<WotDataTypeModel> { new WotDataTypeModel(modelInfo.ModelUri, specName, modelInfo.NodeIdToDataTypeMap.Values) }
                     .Where(dtm => dtm.HasSchemaDefinitions)
                     .ToList();
-                this.VariableTypeModels = new List<WotDataTypeModel> { new WotDataTypeModel(specName, modelInfo.NodeIdToVariableTypeMap.Values) }
+                this.VariableTypeModels = new List<WotDataTypeModel> { new WotDataTypeModel(modelInfo.ModelUri, specName, modelInfo.NodeIdToVariableTypeMap.Values) }
                     .Where(vtm => vtm.HasSchemaDefinitions)
                     .ToList();
             }
@@ -48,5 +48,13 @@ namespace Azure.Iot.Operations.Opc2WotLib
         public List<WotDataTypeModel> DataTypeModels { get; }
 
         public List<WotDataTypeModel> VariableTypeModels { get; }
+
+        public IEnumerable<WotThingDocument> GetDocuments()
+        {
+            return this.ThingDescriptions.Select(td => WotThingDocument.Create(td.FileName, td.TransformText()))
+                .Concat(this.ThingModels.Select(tm => WotThingDocument.Create(tm.FileName, tm.TransformText())))
+                .Concat(this.DataTypeModels.SelectMany(dtm => dtm.GetDocuments()))
+                .Concat(this.VariableTypeModels.SelectMany(vtm => vtm.GetDocuments()));
+        }
     }
 }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingDescription.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingDescription.cs
@@ -43,10 +43,13 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.areUnitsInUse = unitfulPropertyNames.Any();
         }
 
+        public string FileName => $"{this.thingName}.TD.json";
+
         private string GetModelRef(OpcUaObject sourceObject, OpcUaObjectType targetObjectType)
         {
             string targetSpecName = SpecMapper.GetSpecNameFromUri(targetObjectType.DefiningModel.ModelUri);
-            return $"#title={WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName)}";
+            string targetThingName = WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName);
+            return WotUtil.GetThingModelId(targetObjectType.DefiningModel.ModelUri, targetThingName);
         }
     }
 }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
@@ -13,6 +13,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         private string specName;
         private string thingName;
+        private string id;
         private string typeRef;
         private bool isIntegrated;
         private bool inheritVars;
@@ -33,6 +34,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName(uaObjectType.DiscriminatedEffectiveName, specName);
+            this.id = WotUtil.GetThingModelId(uaObjectType.DefiningModel.ModelUri, this.thingName);
             this.typeRef = uaObjectType.GetTypeRef();
             this.isIntegrated = isIntegrated;
             this.inheritVars = inheritVars;
@@ -99,6 +101,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.areUnitsInUse = unitfulPropertyNames.Any();
         }
 
+        public string FileName => $"{this.thingName}.TM.json";
+
         private static string? GetVariableTypeSchemaName(OpcUaVariable variable, Dictionary<OpcUaVariableType, string> schemaNames)
         {
             return variable.CanUseVariableTypeSchemaReference &&
@@ -111,9 +115,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
         private string GetModelRef(OpcUaObjectType sourceObjectType, OpcUaObjectType targetObjectType)
         {
             string targetSpecName = SpecMapper.GetSpecNameFromUri(targetObjectType.DefiningModel.ModelUri);
-
-            string fileRef = isIntegrated || ReferenceEquals(sourceObjectType.DefiningModel, targetObjectType.DefiningModel) ? string.Empty : $"./{targetSpecName}.TM.json";
-            return $"{fileRef}#title={WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName)}";
+            string targetThingName = WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName);
+            return WotUtil.GetThingModelId(targetObjectType.DefiningModel.ModelUri, targetThingName);
         }
 
         private LinkInfo GetLinkInfo(OpcUaObjectType sourceObjectType, OpcUaNodeId referenceTypeNodeId, OpcUaObject targetObject, LinkRelRuleEngine linkRelRuleEngine)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.cs
@@ -28,7 +28,9 @@ namespace Azure.Iot.Operations.Opc2WotLib
  // Licensed under the MIT License 
             this.Write("{\r\n  \"@context\": [\r\n    \"https://www.w3.org/2022/wot/td/v1.1\",\r\n    {\r\n      \"dov\":" +
                     " \"http://azure.com/DigitalOperations/vocab#\"\r\n    }\r\n  ],\r\n  \"@type\": \"tm:Thin" +
-                    "gModel\",\r\n  \"title\": \"");
+                    "gModel\",\r\n  \"id\": \"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.id));
+            this.Write("\",\r\n  \"title\": \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.thingName));
             this.Write("\",\r\n  \"links\": [\r\n  ],\r\n  \"schemaDefinitions\": {\r\n");
  int ix1 = 1; foreach (KeyValuePair<string, WotDataSchema> schemaDefinition in this.schemaDefinitions) { 

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.cs
@@ -32,7 +32,13 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.Write(this.ToStringHelper.ToStringWithCulture(this.id));
             this.Write("\",\r\n  \"title\": \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.thingName));
-            this.Write("\",\r\n  \"links\": [\r\n  ],\r\n  \"schemaDefinitions\": {\r\n");
+            this.Write("\",\r\n");
+ if (this.typeRef != null) {
+            this.Write("  \"dov:typeRef\": \"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.typeRef));
+            this.Write("\",\r\n");
+ }
+            this.Write("  \"links\": [\r\n  ],\r\n  \"schemaDefinitions\": {\r\n");
  int ix1 = 1; foreach (KeyValuePair<string, WotDataSchema> schemaDefinition in this.schemaDefinitions) { 
             this.Write("    \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(schemaDefinition.Key));

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.tt
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.tt
@@ -11,6 +11,7 @@
     }
   ],
   "@type": "tm:ThingModel",
+  "id": "<#=this.id#>",
   "title": "<#=this.thingName#>",
   "links": [
   ],

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.tt
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotDataTypeModel.tt
@@ -13,6 +13,9 @@
   "@type": "tm:ThingModel",
   "id": "<#=this.id#>",
   "title": "<#=this.thingName#>",
+<# if (this.typeRef != null) { #>
+  "dov:typeRef": "<#=this.typeRef#>",
+<# } #>
   "links": [
   ],
   "schemaDefinitions": {

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.cs
@@ -31,7 +31,9 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.Write("      \"qudt\": \"http://qudt.org/schema/qudt/\",\r\n");
  } 
             this.Write("      \"dov\": \"http://azure.com/DigitalOperations/vocab#\"\r\n    }\r\n  ],\r\n  \"@type\":" +
-                    " \"tm:ThingModel\",\r\n  \"title\": \"");
+                    " \"tm:ThingModel\",\r\n  \"id\": \"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(this.id));
+            this.Write("\",\r\n  \"title\": \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.thingName));
             this.Write("\",\r\n  \"dov:typeRef\": \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(this.typeRef));

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.tt
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/t4/WotThingModel.tt
@@ -14,6 +14,7 @@
     }
   ],
   "@type": "tm:ThingModel",
+  "id": "<#=this.id#>",
   "title": "<#=this.thingName#>",
   "dov:typeRef": "<#=this.typeRef#>",
 <# if (this.isEvent) { #>

--- a/wot-codegen/src/Azure.Iot.Operations.TDParser/Model/TDThing.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.TDParser/Model/TDThing.cs
@@ -208,12 +208,12 @@ namespace Azure.Iot.Operations.TDParser.Model
                 {
                     yield return item;
                 }
-                if (Id != null)
+            }
+            if (Id != null)
+            {
+                foreach (ITraversable item in Id.Traverse())
                 {
-                    foreach (ITraversable item in Id.Traverse())
-                    {
-                        yield return item;
-                    }
+                    yield return item;
                 }
             }
             if (Description != null)

--- a/wot-codegen/src/Azure.Iot.Operations.TDParser/Model/TDThing.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.TDParser/Model/TDThing.cs
@@ -11,6 +11,7 @@ namespace Azure.Iot.Operations.TDParser.Model
     {
         public const string ContextName = "@context";
         public const string TypeName = "@type";
+        public const string IdName = "id";
         public const string TitleName = TDCommon.TitleName;
         public const string DescriptionName = TDCommon.DescriptionName;
         public const string LinksName = "links";
@@ -37,6 +38,7 @@ namespace Azure.Iot.Operations.TDParser.Model
         {
             ContextName,
             TypeName,
+            IdName,
             TitleName,
             DescriptionName,
             LinksName,
@@ -63,6 +65,8 @@ namespace Azure.Iot.Operations.TDParser.Model
         public ArrayTracker<TDContextSpecifier>? Context { get; set; }
 
         public ValueTracker<StringHolder>? Type { get; set; }
+
+        public ValueTracker<StringHolder>? Id { get; set; }
 
         public ValueTracker<StringHolder>? Title { get; set; }
 
@@ -118,6 +122,7 @@ namespace Azure.Iot.Operations.TDParser.Model
             {
                 return Context == other.Context &&
                        Type == other.Type &&
+                       Id == other.Id &&
                        Title == other.Title &&
                        Description == other.Description &&
                        Links == other.Links &&
@@ -141,7 +146,7 @@ namespace Azure.Iot.Operations.TDParser.Model
 
         public override int GetHashCode()
         {
-            return (Context, Type, Title, Description, Links, SchemaDefinitions, Forms, Optional, Actions, Properties, Events, SecurityDefinitions, Security, IsComposite, IsEvent, TypeRef, Metadata, PropertyGroups, EventGroups, ActionGroups).GetHashCode();
+            return (Context, Type, Id, Title, Description, Links, SchemaDefinitions, Forms, Optional, Actions, Properties, Events, SecurityDefinitions, Security, IsComposite, IsEvent, TypeRef, Metadata, PropertyGroups, EventGroups, ActionGroups).GetHashCode();
         }
 
         public static bool operator ==(TDThing? left, TDThing? right)
@@ -202,6 +207,13 @@ namespace Azure.Iot.Operations.TDParser.Model
                 foreach (ITraversable item in Title.Traverse())
                 {
                     yield return item;
+                }
+                if (Id != null)
+                {
+                    foreach (ITraversable item in Id.Traverse())
+                    {
+                        yield return item;
+                    }
                 }
             }
             if (Description != null)
@@ -349,6 +361,9 @@ namespace Azure.Iot.Operations.TDParser.Model
                         break;
                     case TypeName:
                         thing.Type = ValueTracker<StringHolder>.Deserialize(ref reader, TypeName);
+                        break;
+                    case IdName:
+                        thing.Id = ValueTracker<StringHolder>.Deserialize(ref reader, IdName);
                         break;
                     case TitleName:
                         thing.Title = ValueTracker<StringHolder>.Deserialize(ref reader, TitleName);

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
@@ -519,10 +519,10 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.False(errorLog.HasErrors);
                 Assert.Empty(errorLog.Warnings);
                 FileInfo outputFile = Assert.Single(outputDir.GetFiles("*.TM.json"));
+                Assert.Equal("DataTypeOnly_OnlyEnum.TM.json", outputFile.Name);
                 using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(outputFile.FullName));
-                Assert.True(Assert.Single(doc.RootElement.EnumerateArray().Select(t => t.Clone()))
-                    .GetProperty("schemaDefinitions")
-                    .TryGetProperty("OnlyEnum", out _));
+                Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+                Assert.True(doc.RootElement.GetProperty("schemaDefinitions").TryGetProperty("OnlyEnum", out _));
             }
             finally
             {

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
@@ -522,6 +522,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.Equal("DataTypeOnly_OnlyEnum.TM.json", outputFile.Name);
                 using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(outputFile.FullName));
                 Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+                Assert.EndsWith(".OnlyEnum", doc.RootElement.GetProperty("dov:typeRef").GetString(), StringComparison.Ordinal);
                 Assert.True(doc.RootElement.GetProperty("schemaDefinitions").TryGetProperty("OnlyEnum", out _));
             }
             finally

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
@@ -3,9 +3,17 @@
 
 namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 {
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Text.Json;
+    using Azure.Iot.Operations.CodeGeneration;
+    using Azure.Iot.Operations.Opc2Wot;
     using Azure.Iot.Operations.Opc2WotLib;
+    using Azure.Iot.Operations.TDParser;
+    using Azure.Iot.Operations.TDParser.Model;
     using Xunit;
 
     public class HasAddInLinkTests
@@ -151,7 +159,132 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 .Single(t => t.GetProperty("title").GetString()!.EndsWith("ContainerType", System.StringComparison.Ordinal));
             JsonElement link = Assert.Single(container.GetProperty("links").EnumerateArray().Select(l => l.Clone()));
 
-            Assert.Equal("./ReferencedModel.TM.json#title=ReferencedModel_ModuleType", link.GetProperty("href").GetString());
+            string href = link.GetProperty("href").GetString()!;
+            Assert.True(Uri.TryCreate(href, UriKind.Absolute, out _));
+            Assert.Equal("http://opcfoundation.org/UA/ReferencedModel/#ReferencedModel_ModuleType", href);
+        }
+
+        [Fact]
+        public void CommandHandler_WritesStandaloneThingModelsWithIdBasedReferences()
+        {
+            string sandboxPath = Path.Combine(Path.GetTempPath(), $"Opc2WotThingModelOutputTests_{Guid.NewGuid():N}");
+            DirectoryInfo sandbox = Directory.CreateDirectory(sandboxPath);
+
+            try
+            {
+                string referencingPath = Path.Combine(sandbox.FullName, "Referencing.NodeSet2.xml");
+                string referencedPath = Path.Combine(sandbox.FullName, "Referenced.NodeSet2.xml");
+                File.WriteAllText(referencingPath, ReferencingNodeset);
+                File.WriteAllText(referencedPath, ReferencedNodeset);
+                DirectoryInfo outputDir = new DirectoryInfo(Path.Combine(sandbox.FullName, "out"));
+
+                OptionContainer options = new OptionContainer
+                {
+                    NodeSetsSpec = new[] { referencingPath, referencedPath },
+                    OutputDir = outputDir,
+                    Integrate = false,
+                    InheritVars = false,
+                    IncludeTDs = false,
+                };
+
+                var errorLog = CommandHandler.ConvertSpecs(options, (_, _) => { });
+
+                Assert.False(errorLog.HasErrors);
+                Assert.Equal(
+                    new[] { "ReferenceOrderTest_ContainerType.TM.json", "ReferencedModel_ModuleType.TM.json" },
+                    outputDir.GetFiles("*.TM.json").Select(f => f.Name).OrderBy(n => n, StringComparer.Ordinal));
+
+                using JsonDocument containerDocument = JsonDocument.Parse(
+                    File.ReadAllText(Path.Combine(outputDir.FullName, "ReferenceOrderTest_ContainerType.TM.json")));
+                using JsonDocument moduleDocument = JsonDocument.Parse(
+                    File.ReadAllText(Path.Combine(outputDir.FullName, "ReferencedModel_ModuleType.TM.json")));
+
+                Assert.Equal(JsonValueKind.Object, containerDocument.RootElement.ValueKind);
+                Assert.Equal(JsonValueKind.Object, moduleDocument.RootElement.ValueKind);
+
+                string moduleId = moduleDocument.RootElement.GetProperty("id").GetString()!;
+                string linkHref = Assert.Single(
+                    containerDocument.RootElement.GetProperty("links").EnumerateArray().Select(link => link.Clone()))
+                    .GetProperty("href")
+                    .GetString()!;
+
+                Assert.True(Uri.TryCreate(moduleId, UriKind.Absolute, out _));
+                Assert.Equal(moduleId, linkHref);
+            }
+            finally
+            {
+                sandbox.Delete(recursive: true);
+            }
+        }
+
+        [Fact]
+        public void StandaloneThingModel_PreservesLiteralJsonCharacters()
+        {
+            WotThingDocument document = WotThingDocument.Create(
+                "Test.TM.json",
+                """{"links":[{"dov:refName":"<Node>","type":"application/tm+json"}]}""");
+
+            Assert.Contains("\"dov:refName\": \"<Node>\"", document.Text);
+            Assert.Contains("\"type\": \"application/tm+json\"", document.Text);
+            Assert.DoesNotContain(@"\u003C", document.Text);
+            Assert.DoesNotContain(@"\u002B", document.Text);
+        }
+
+        [Fact]
+        public void StandaloneThingModel_OmitsProtocolForms()
+        {
+            const string thingText = """
+                {
+                  "forms": [{ "op": "readallproperties" }],
+                  "actions": { "Run": { "forms": [{ "op": "invokeaction" }] } },
+                  "properties": { "Status": { "forms": [{ "op": "readproperty" }] } },
+                  "events": { "Changed": { "forms": [{ "op": "subscribeevent" }] } }
+                }
+                """;
+
+            WotThingDocument thingModel = WotThingDocument.Create("Test.TM.json", thingText);
+            WotThingDocument thingDescription = WotThingDocument.Create("Test.TD.json", thingText);
+
+            Assert.DoesNotContain("\"forms\"", thingModel.Text);
+            Assert.Contains("\"forms\"", thingDescription.Text);
+        }
+
+        [Fact]
+        public void ThingValidator_AcceptsAffordancesWithoutFormsInThingModel()
+        {
+            const string thingText = """
+                {
+                  "@context": [
+                    "https://www.w3.org/2022/wot/td/v1.1",
+                    { "dov": "http://azure.com/DigitalOperations/vocab#" }
+                  ],
+                  "@type": "tm:ThingModel",
+                  "title": "FormFreeModel",
+                  "properties": {
+                    "Status": {
+                      "type": "string",
+                      "readOnly": true
+                    }
+                  }
+                }
+                """;
+            byte[] thingBytes = Encoding.UTF8.GetBytes(thingText);
+            ErrorLog errorLog = new(string.Empty);
+            ErrorReporter errorReporter = new(errorLog, "FormFreeModel.TM.json", thingBytes);
+            TDThing thing = Assert.Single(TDParser.Parse(thingBytes));
+            Dictionary<string, TDThing> hrefToThingMap = new()
+            {
+                ["#title=FormFreeModel"] = thing,
+            };
+            ThingValidator validator = new(errorReporter, requireThingModelForms: false);
+
+            bool isValid = validator.TryValidateThing(
+                new IntegralResolvingThing(thing, errorReporter, hrefToThingMap),
+                new HashSet<SerializationFormat>(),
+                validateReferences: false);
+
+            Assert.True(isValid, string.Join(System.Environment.NewLine, errorLog.Errors.Select(error => error.Message)));
+            Assert.False(errorLog.HasErrors);
         }
 
         private static JsonElement GetThingByTitleSuffix(string titleSuffix)

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
@@ -625,6 +625,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
                 JsonElement catalog = doc.RootElement;
                 Assert.Equal("VariableTypeOnly_OnlyType", catalog.GetProperty("title").GetString());
+                Assert.EndsWith(".OnlyType", catalog.GetProperty("dov:typeRef").GetString(), StringComparison.Ordinal);
                 Assert.True(catalog.GetProperty("schemaDefinitions").TryGetProperty("OnlyType", out _));
             }
             finally

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
@@ -620,9 +620,11 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.False(errorLog.HasErrors);
                 Assert.Empty(errorLog.Warnings);
                 FileInfo outputFile = Assert.Single(outputDir.GetFiles("*.TM.json"));
+                Assert.Equal("VariableTypeOnly_OnlyType.TM.json", outputFile.Name);
                 using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(outputFile.FullName));
-                JsonElement catalog = Assert.Single(doc.RootElement.EnumerateArray().Select(t => t.Clone()));
-                Assert.Equal("VariableTypeOnly_VariableTypes", catalog.GetProperty("title").GetString());
+                Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+                JsonElement catalog = doc.RootElement;
+                Assert.Equal("VariableTypeOnly_OnlyType", catalog.GetProperty("title").GetString());
                 Assert.True(catalog.GetProperty("schemaDefinitions").TryGetProperty("OnlyType", out _));
             }
             finally


### PR DESCRIPTION
This pull request refactors the OPC UA NodeSet to WoT Thing Model conversion process to generate standalone Thing Model and Thing Description documents, rather than collections. It introduces a new document abstraction, improves validation and output handling, and updates the documentation and interface to reflect these changes. The most important changes are as follows:

**Standalone Document Generation & Output Handling:**

- Refactored the conversion process to generate and write individual, standalone WoT Thing Model (`.TM.json`) and Thing Description documents, each with a unique file name and absolute `id`. The output directory now contains only these standalone documents, not collections. (`wot-codegen/README.md`, `OptionContainer.cs`, `CommandHandler.cs`, `WotThingDocument.cs`) [[1]](diffhunk://#diff-ef8092acab9bab349bf808b3f466cb7daa2c739c05389c0965536abbf966e641L3-R3) [[2]](diffhunk://#diff-d8057be983ef74c064a93a3eccc9dc4167cf9b5be0211258ecc0cc04fa114896L16-R16) [[3]](diffhunk://#diff-ebe1ea426044a554667ce9d88eb474949e011dca710acb63d431ebc3eda0729fR125-R141) [[4]](diffhunk://#diff-c0ab285afe6b4231c86995bcf3a71290ba6cbd9189ea3975753abd2f8bce0fc2R1-R58)

- Introduced the new `WotThingDocument` abstraction to encapsulate the file name and JSON text for each Thing document, including logic to remove protocol-specific `forms` from Thing Models and to omit empty affordance maps. (`WotThingDocument.cs`)

**Validation Improvements:**

- Updated validation logic to operate on individual Thing documents, using a map keyed by both `id` and `#title` for reference resolution. Validation now occurs after all documents are generated, ensuring cross-document consistency and duplicate detection. (`CommandHandler.cs`, `IntegralResolvingThing.cs`, `ThingValidator.cs`) [[1]](diffhunk://#diff-ebe1ea426044a554667ce9d88eb474949e011dca710acb63d431ebc3eda0729fR125-R141) [[2]](diffhunk://#diff-ebe1ea426044a554667ce9d88eb474949e011dca710acb63d431ebc3eda0729fR150-R211) [[3]](diffhunk://#diff-8b73f1809a1e17e831c4e1ef2306795ce8f5859cea9141a35655db70b1a239fcL13-R18) [[4]](diffhunk://#diff-8b73f1809a1e17e831c4e1ef2306795ce8f5859cea9141a35655db70b1a239fcL29-R29) [[5]](diffhunk://#diff-1311f954a0ba8b51a898d40901c2652dc2c31fcfdd66dcbb71ebffe6aa1c0a0cR24-R31) [[6]](diffhunk://#diff-1311f954a0ba8b51a898d40901c2652dc2c31fcfdd66dcbb71ebffe6aa1c0a0cL121-R126)

- Modified `ThingValidator` to allow optional skipping of `forms` validation for Thing Models, supporting the new document structure. (`ThingValidator.cs`) [[1]](diffhunk://#diff-1311f954a0ba8b51a898d40901c2652dc2c31fcfdd66dcbb71ebffe6aa1c0a0cR24-R31) [[2]](diffhunk://#diff-1311f954a0ba8b51a898d40901c2652dc2c31fcfdd66dcbb71ebffe6aa1c0a0cL121-R126)

**Data Type Model Refactoring:**

- Refactored `WotDataTypeModel` to generate separate Thing Model documents for each schema definition, assigning unique `id` values and file names, and supporting reference resolution. (`WotDataTypeModel.cs`) [[1]](diffhunk://#diff-410f7d1bb50f89c799f8a48239a7bc4ecb84c98c4054a9b3f823058c213a3c23R12-R44) [[2]](diffhunk://#diff-410f7d1bb50f89c799f8a48239a7bc4ecb84c98c4054a9b3f823058c213a3c23R53-R84)

**Documentation and Interface Updates:**

- Updated the `README.md` and code comments to clarify that the tool now produces standalone Thing Model and Thing Description documents, and updated flag descriptions accordingly. (`README.md`, `OptionContainer.cs`) [[1]](diffhunk://#diff-ef8092acab9bab349bf808b3f466cb7daa2c739c05389c0965536abbf966e641L3-R3) [[2]](diffhunk://#diff-ef8092acab9bab349bf808b3f466cb7daa2c739c05389c0965536abbf966e641L42-R42) [[3]](diffhunk://#diff-d8057be983ef74c064a93a3eccc9dc4167cf9b5be0211258ecc0cc04fa114896L16-R16)

**Utility Enhancements:**

- Added a utility method to generate unique Thing Model `id` values based on the model URI and Thing name. (`WotUtil.cs`)

These changes modernize the output and validation pipeline, improving modularity, reference handling, and clarity of the generated WoT artifacts.