### PR TITLE
[Rust][MQTT][Connector] Allow AIO `metriccategory` metadata to be configured via API

### DIFF
--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -105,10 +105,10 @@ pub struct Options {
     #[builder(default = "Duration::from_secs(5)")]
     filemount_debounce_duration: Duration,
 
-    /// Value for the `metriccategory` that is used to categorize the internal traffic between 
-    /// the connector and other AIO services - Broker, Schema Registry, DSS. 
+    /// Value for the `metriccategory` that is used to categorize the internal traffic between
+    /// the connector and other AIO services - Broker, Schema Registry, DSS.
     /// See https://learn.microsoft.com/en-us/azure/iot-operations/reference/observability-metrics-mqtt-broker#category for details.
-    #[builder(default = "\"aiosdk-rust\".to_string()", setter(into))]
+    #[builder(default = "\"aiosdk-rust-connector\".to_string()", setter(into))]
     metric_category: String,
 
     /// Reconnect policy used by the MQTT Session.

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -107,7 +107,7 @@ pub struct Options {
 
     /// Value for the `metriccategory` that is used to categorize the internal traffic between
     /// the connector and other AIO services - Broker, Schema Registry, DSS.
-    /// See https://learn.microsoft.com/en-us/azure/iot-operations/reference/observability-metrics-mqtt-broker#category for details.
+    /// See <https://learn.microsoft.com/en-us/azure/iot-operations/reference/observability-metrics-mqtt-broker#category> for details.
     #[builder(default = "\"aiosdk-rust-connector\".to_string()", setter(into))]
     metric_category: String,
 

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -5,6 +5,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use azure_iot_operations_mqtt::aio::AIOBrokerFeaturesBuilder;
 use azure_iot_operations_mqtt::session::{
     Session, SessionError, SessionManagedClient, SessionOptionsBuilder,
     reconnect_policy::ExponentialBackoffWithJitter, reconnect_policy::ReconnectPolicy,
@@ -104,6 +105,10 @@ pub struct Options {
     #[builder(default = "Duration::from_secs(5)")]
     filemount_debounce_duration: Duration,
 
+    /// Value for the `metriccategory` MQTT CONNECT user property
+    #[builder(default = "\"aiosdk-rust\".to_string()", setter(into))]
+    metric_category: String,
+
     /// Reconnect policy used by the MQTT Session.
     #[builder(default = "Box::new(ExponentialBackoffWithJitter::default())")]
     reconnect_policy: Box<dyn ReconnectPolicy>,
@@ -136,9 +141,14 @@ impl BaseConnector {
         let mqtt_connection_settings = connector_artifacts
             .to_mqtt_connection_settings("0")
             .map_err(|e| e.clone())?;
+        let aio_broker_features = AIOBrokerFeaturesBuilder::default()
+            .metric_category(base_connector_options.metric_category)
+            .build()
+            .map_err(|e| e.to_string())?;
         let session_options = SessionOptionsBuilder::default()
             .connection_settings(mqtt_connection_settings)
             .reconnect_policy(base_connector_options.reconnect_policy)
+            .aio_broker_features(Some(aio_broker_features))
             .build()
             .map_err(|e| e.to_string())?;
         let session = Session::new(session_options).map_err(|e| e.to_string())?;

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -105,7 +105,9 @@ pub struct Options {
     #[builder(default = "Duration::from_secs(5)")]
     filemount_debounce_duration: Duration,
 
-    /// Value for the `metriccategory` MQTT CONNECT user property
+    /// Value for the `metriccategory` that is used to categorize the internal traffic between 
+    /// the connector and other AIO services - Broker, Schema Registry, DSS. 
+    /// See https://learn.microsoft.com/en-us/azure/iot-operations/reference/observability-metrics-mqtt-broker#category for details.
     #[builder(default = "\"aiosdk-rust\".to_string()", setter(into))]
     metric_category: String,
 

--- a/rust/azure_iot_operations_mqtt/src/aio.rs
+++ b/rust/azure_iot_operations_mqtt/src/aio.rs
@@ -13,4 +13,7 @@ pub struct AIOBrokerFeatures {
     /// Indicates if the Session should use AIO persistence
     #[builder(default = "false")]
     pub(crate) persistence: bool,
+    /// Value for the `metriccategory` MQTT CONNECT user property
+    #[builder(default = "\"aiosdk-rust\".to_string()", setter(into))]
+    pub(crate) metric_category: String,
 }

--- a/rust/azure_iot_operations_mqtt/src/session.rs
+++ b/rust/azure_iot_operations_mqtt/src/session.rs
@@ -241,6 +241,11 @@ pub struct Session {
     connect_parameters: AzureMqttConnectParameters,
     /// Client ID of the underlying MQTT client
     client_id: String,
+    /// Metric category of the underlying MQTT client when using AIO broker features
+    // NOTE: This is copied from AIOBrokerFeatures because this is currently the only value from there
+    // that is required in the Session, however, if that changes, this should be replaced with a copy
+    // of the entire AIOBrokerFeatures struct.
+    metric_category: Option<String>,
     /// Receiver dispatcher for incoming publishes
     incoming_pub_dispatcher: Arc<Mutex<IncomingPublishDispatcher>>,
     /// Reconnect policy
@@ -264,15 +269,16 @@ impl Session {
 
         // Add AIO metric and features to user properties when using AIO MQTT broker features
         // CONSIDER: user properties from being supported on SessionOptions or ConnectionSettings
-        let user_properties = if let Some(features) = options.aio_broker_features {
-            let mut user_properties =
-                vec![("metriccategory".to_string(), features.metric_category)];
+        let (user_properties, metric_category) = if let Some(features) = options.aio_broker_features
+        {
+            let metric_category = features.metric_category;
+            let mut user_properties = vec![("metriccategory".to_string(), metric_category.clone())];
             if features.persistence {
                 user_properties.push(("aio-persistence".to_string(), true.to_string()));
             }
-            user_properties
+            (user_properties, Some(metric_category))
         } else {
-            vec![]
+            (vec![], None)
         };
 
         // Create EnhancedAuthPolicy if provided in options or SAT file is provided via ConnectionSettings
@@ -326,6 +332,7 @@ impl Session {
             reauth_handle: None,
             connect_parameters,
             client_id,
+            metric_category,
             incoming_pub_dispatcher,
             reconnect_policy: options.reconnect_policy,
             enhanced_auth_policy,
@@ -353,6 +360,7 @@ impl Session {
     pub fn create_managed_client(&self) -> SessionManagedClient {
         SessionManagedClient {
             client_id: self.client_id.clone(),
+            metric_category: self.metric_category.clone(),
             client: self.client.clone(),
             dispatcher: self.incoming_pub_dispatcher.clone(),
         }

--- a/rust/azure_iot_operations_mqtt/src/session.rs
+++ b/rust/azure_iot_operations_mqtt/src/session.rs
@@ -266,7 +266,7 @@ impl Session {
         // CONSIDER: user properties from being supported on SessionOptions or ConnectionSettings
         let user_properties = if let Some(features) = options.aio_broker_features {
             let mut user_properties =
-                vec![("metriccategory".to_string(), "aiosdk-rust".to_string())];
+                vec![("metriccategory".to_string(), features.metric_category)];
             if features.persistence {
                 user_properties.push(("aio-persistence".to_string(), true.to_string()));
             }

--- a/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
+++ b/rust/azure_iot_operations_mqtt/src/session/managed_client.rs
@@ -23,6 +23,8 @@ use crate::token::{
 pub struct SessionManagedClient {
     // Client ID of the `Session` that manages this client
     pub(crate) client_id: String,
+    // Metric category of the `Session` that manages this client
+    pub(crate) metric_category: Option<String>,
     // PubSub for sending outgoing MQTT messages
     pub(crate) client: crate::azure_mqtt::client::Client,
     /// Manager for receivers
@@ -34,6 +36,12 @@ impl SessionManagedClient {
     #[must_use]
     pub fn client_id(&self) -> &str {
         &self.client_id
+    }
+
+    /// Get the metric category used by this Session, if AIO broker features are enabled
+    #[must_use]
+    pub fn metric_category(&self) -> Option<&str> {
+        self.metric_category.as_deref()
     }
 
     /// Creates a new [`SessionPubReceiver`] that will receive incoming publishes matching the

--- a/rust/azure_iot_operations_mqtt/tests/mock_connection_management.rs
+++ b/rust/azure_iot_operations_mqtt/tests/mock_connection_management.rs
@@ -11,10 +11,7 @@ use futures::FutureExt;
 
 use azure_iot_operations_mqtt::azure_mqtt::mqtt_proto;
 use azure_iot_operations_mqtt::{
-    aio::{
-        AIOBrokerFeaturesBuilder,
-        connection_settings::{MqttConnectionSettings, MqttConnectionSettingsBuilder},
-    },
+    aio::connection_settings::{MqttConnectionSettings, MqttConnectionSettingsBuilder},
     control_packet::AuthenticationInfo,
     error::{SessionErrorKind, SessionExitErrorKind},
     session::{Session, SessionOptionsBuilder},

--- a/rust/azure_iot_operations_mqtt/tests/mock_connection_management.rs
+++ b/rust/azure_iot_operations_mqtt/tests/mock_connection_management.rs
@@ -11,7 +11,10 @@ use futures::FutureExt;
 
 use azure_iot_operations_mqtt::azure_mqtt::mqtt_proto;
 use azure_iot_operations_mqtt::{
-    aio::connection_settings::{MqttConnectionSettings, MqttConnectionSettingsBuilder},
+    aio::{
+        AIOBrokerFeaturesBuilder,
+        connection_settings::{MqttConnectionSettings, MqttConnectionSettingsBuilder},
+    },
     control_packet::AuthenticationInfo,
     error::{SessionErrorKind, SessionExitErrorKind},
     session::{Session, SessionOptionsBuilder},


### PR DESCRIPTION
- API for MQTT and connector crates both allow the configuration of the `metriccategory` metadata that is included in the user properties on MQTT CONNECT.
- This allows for applications to be identified by AIO, e.g. REST Connector