### PR TITLE
Use typeRef-based URNs for generated Thing Model IDs

### DIFF
--- a/wot-codegen/README.md
+++ b/wot-codegen/README.md
@@ -1,6 +1,6 @@
 # OPC UA NodeSet converter
 
-The `Azure.Iot.Operations.Opc2Wot` tool converts OPC UA NodeSet files into standalone W3C WoT Thing Model documents. Each model is written to `<ShortOpcUaName>_<Type>.TM.json`, links between models use the target model's absolute `id`, and protocol-specific `forms` are omitted from Thing Models. The repository provides PowerShell and Bash wrappers for regenerating the OPC UA companion models maintained in the sibling [Azure/smd](https://github.com/Azure/smd) repository.
+The `Azure.Iot.Operations.Opc2Wot` tool converts OPC UA NodeSet files into standalone W3C WoT Thing Model documents. Each model is written to `<ShortOpcUaName>_<Type>.TM.json`, while its absolute `id` is the `dov:typeRef` prefixed with `urn:` (for example, `urn:org.opcfoundation.UA.MTConnect.v2.OptionalStopSubClassType`). Links between models use the target model's absolute `id`, and protocol-specific `forms` are omitted from Thing Models. The repository provides PowerShell and Bash wrappers for regenerating the OPC UA companion models maintained in the sibling [Azure/smd](https://github.com/Azure/smd) repository.
 
 By default, both wrappers expect this sibling repository layout:
 

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaGraph.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaGraph.cs
@@ -105,6 +105,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             ModelUriToModelMap[modelUri] = modelInfo;
 
             Dictionary<string, OpcUaNode> effectiveNameToNodeMap = new();
+            HashSet<string> discriminatedEffectiveNames = new(StringComparer.Ordinal);
 
             foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
             {
@@ -121,7 +122,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
                         break;
                     case "UAObject":
                         OpcUaObject opcUaObject = new OpcUaObject(modelInfo, NsUriToNsInfoMap, node);
-                        SetDiscriminator(opcUaObject, effectiveNameToNodeMap);
+                        SetDiscriminator(opcUaObject, effectiveNameToNodeMap, discriminatedEffectiveNames);
                         if (opcUaObject.HasTypeDefinitionNodeId != null)
                         {
                             modelInfo.TypeDefinitionNodeIds.Add(opcUaObject.HasTypeDefinitionNodeId);
@@ -131,7 +132,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
                         break;
                     case "UAObjectType":
                         OpcUaObjectType opcUaObjectType = new OpcUaObjectType(modelInfo, NsUriToNsInfoMap, node);
-                        SetDiscriminator(opcUaObjectType, effectiveNameToNodeMap);
+                        SetDiscriminator(opcUaObjectType, effectiveNameToNodeMap, discriminatedEffectiveNames);
                         modelInfo.NodeIdToObjectTypeMap[opcUaObjectType.NodeId] = opcUaObjectType;
                         opcUaNode = opcUaObjectType;
                         break;
@@ -190,19 +191,36 @@ namespace Azure.Iot.Operations.Opc2WotLib
             referencesResolved = true;
         }
 
-        private void SetDiscriminator(OpcUaNode newObjectType, Dictionary<string, OpcUaNode> effectiveNameToNodeMap)
+        private void SetDiscriminator(
+            OpcUaNode newObjectType,
+            Dictionary<string, OpcUaNode> effectiveNameToNodeMap,
+            HashSet<string> discriminatedEffectiveNames)
         {
             if (effectiveNameToNodeMap.TryGetValue(newObjectType.EffectiveName, out OpcUaNode? extantObjectType))
             {
                 if (extantObjectType.Discriminator == 0)
                 {
-                    extantObjectType.Discriminator = 1;
+                    discriminatedEffectiveNames.Remove(extantObjectType.DiscriminatedEffectiveName);
+                    SetNextAvailableDiscriminator(extantObjectType, discriminatedEffectiveNames);
                 }
 
-                newObjectType.Discriminator = extantObjectType.Discriminator + 1;
+                SetNextAvailableDiscriminator(newObjectType, discriminatedEffectiveNames);
+            }
+            else if (!discriminatedEffectiveNames.Add(newObjectType.DiscriminatedEffectiveName))
+            {
+                SetNextAvailableDiscriminator(newObjectType, discriminatedEffectiveNames);
             }
 
             effectiveNameToNodeMap[newObjectType.EffectiveName] = newObjectType;
+        }
+
+        private void SetNextAvailableDiscriminator(OpcUaNode node, HashSet<string> discriminatedEffectiveNames)
+        {
+            do
+            {
+                node.Discriminator++;
+            }
+            while (!discriminatedEffectiveNames.Add(node.DiscriminatedEffectiveName));
         }
 
         private void CollateRequiredModels(OpcUaModelInfo modelInfo, List<OpcUaModelInfo> models, HashSet<string> processedModelUris)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaNode.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/OpcUa/OpcUaNode.cs
@@ -101,16 +101,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         public string GetTypeRef()
         {
-            if (this.BrowseNamespace == null)
-            {
-                return $"org.opcfoundation.UA.{this.EffectiveName}";
-            }
-
-            Uri uri = new Uri(this.BrowseNamespace);
-            string reversedHost = string.Join('.', uri.Host.Split('.').Reverse());
-            string path = uri.AbsolutePath.Trim('/').Replace('/', '.');
-            string prefix = string.IsNullOrEmpty(path) ? reversedHost : $"{reversedHost}.{path}";
-            return $"{prefix}.{this.EffectiveName}";
+            return WotUtil.GetTypeRef(this.NodeIdNamespace, this.DiscriminatedEffectiveName);
         }
 
         protected Dictionary<string, OpcUaNamespaceInfo> NsUriToNsInfoMap { get; }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
@@ -4,6 +4,7 @@
 namespace Azure.Iot.Operations.Opc2WotLib
 {
     using System;
+    using System.Linq;
     using System.Text.RegularExpressions;
 
     public static class WotUtil
@@ -15,14 +16,18 @@ namespace Azure.Iot.Operations.Opc2WotLib
             return $"{legalPrefix}{legalName}";
         }
 
-        public static string GetThingModelId(string modelUri, string thingName)
+        public static string GetTypeRef(string namespaceUri, string typeName)
         {
-            UriBuilder uriBuilder = new UriBuilder(modelUri)
-            {
-                Fragment = Uri.EscapeDataString(thingName),
-            };
+            Uri uri = new Uri(namespaceUri);
+            string reversedHost = string.Join('.', uri.Host.Split('.').Reverse());
+            string path = uri.AbsolutePath.Trim('/').Replace('/', '.');
+            string prefix = string.IsNullOrEmpty(path) ? reversedHost : $"{reversedHost}.{path}";
+            return $"{prefix}.{typeName}";
+        }
 
-            return uriBuilder.Uri.AbsoluteUri;
+        public static string GetThingModelId(string typeRef)
+        {
+            return $"urn:{typeRef}";
         }
 
         private static string Capitalize(string str)

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/WotUtil.cs
@@ -4,7 +4,7 @@
 namespace Azure.Iot.Operations.Opc2WotLib
 {
     using System;
-    using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
 
     public static class WotUtil
@@ -18,11 +18,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         public static string GetTypeRef(string namespaceUri, string typeName)
         {
-            Uri uri = new Uri(namespaceUri);
-            string reversedHost = string.Join('.', uri.Host.Split('.').Reverse());
-            string path = uri.AbsolutePath.Trim('/').Replace('/', '.');
-            string prefix = string.IsNullOrEmpty(path) ? reversedHost : $"{reversedHost}.{path}";
-            return $"{prefix}.{typeName}";
+            _ = new Uri(namespaceUri, UriKind.Absolute);
+            return $"{EncodeNamespaceUri(namespaceUri)}.{Uri.EscapeDataString(typeName)}";
         }
 
         public static string GetThingModelId(string typeRef)
@@ -33,6 +30,15 @@ namespace Azure.Iot.Operations.Opc2WotLib
         private static string Capitalize(string str)
         {
             return char.ToUpper(str[0]) + str.Substring(1);
+        }
+
+        private static string EncodeNamespaceUri(string namespaceUri)
+        {
+            // Base64url preserves the complete URI and cannot contain the dot that separates the type name.
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(namespaceUri))
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
         }
     }
 }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotDataTypeModel.cs
@@ -22,7 +22,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.modelUri = modelUri;
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName("DataTypes", specName);
-            this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
+            this.id = WotUtil.GetThingModelId(WotUtil.GetTypeRef(modelUri, "DataTypes"));
             this.typeRef = null;
 
             List<OpcUaDataType> includedDataTypes = dataTypes
@@ -40,7 +40,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.modelUri = modelUri;
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName("VariableTypes", specName);
-            this.id = WotUtil.GetThingModelId(modelUri, this.thingName);
+            this.id = WotUtil.GetThingModelId(WotUtil.GetTypeRef(modelUri, "VariableTypes"));
             this.typeRef = null;
 
             Dictionary<OpcUaVariableType, string> schemaNames = WotVariableTypeSchema.GetSchemaNames(
@@ -76,8 +76,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.modelUri = modelUri;
             this.specName = string.Empty;
             this.thingName = thingName;
-            this.id = WotUtil.GetThingModelId(modelUri, thingName);
             this.typeRef = typeRef;
+            this.id = WotUtil.GetThingModelId(this.typeRef);
             this.schemaDefinitions = schemaDefinitions;
             this.schemaTypeRefs = new Dictionary<string, string>(StringComparer.Ordinal);
         }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingDescription.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingDescription.cs
@@ -25,7 +25,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName(uaObject.DiscriminatedEffectiveName, specName);
             this.typeRef = uaObject.GetTypeRef();
-            this.definingModelRef = uaObject.HasTypeDefinition != null && uaObject.HasTypeDefinition.NodeId.NsIndex != 0 ? GetModelRef(uaObject, uaObject.HasTypeDefinition) : null;
+            this.definingModelRef = uaObject.HasTypeDefinition != null && uaObject.HasTypeDefinition.NodeId.NsIndex != 0 ? GetModelRef(uaObject.HasTypeDefinition) : null;
 
             this.actions = uaObject.Methods.OrderBy(m => m.EffectiveName).Select(m => new WotAction(specName, this.thingName, m, true)).ToList();
             this.properties = uaObject.VariableRecords.OrderBy(r => r.Key).Select(r => new WotProperty(specName, this.thingName, r.Value.UaVariable, r.Key, r.Value.ContainedIn, r.Value.Contains, true)).ToList();
@@ -45,11 +45,9 @@ namespace Azure.Iot.Operations.Opc2WotLib
 
         public string FileName => $"{this.thingName}.TD.json";
 
-        private string GetModelRef(OpcUaObject sourceObject, OpcUaObjectType targetObjectType)
+        private string GetModelRef(OpcUaObjectType targetObjectType)
         {
-            string targetSpecName = SpecMapper.GetSpecNameFromUri(targetObjectType.DefiningModel.ModelUri);
-            string targetThingName = WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName);
-            return WotUtil.GetThingModelId(targetObjectType.DefiningModel.ModelUri, targetThingName);
+            return WotUtil.GetThingModelId(targetObjectType.GetTypeRef());
         }
     }
 }

--- a/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
+++ b/wot-codegen/src/Azure.Iot.Operations.Opc2WotLib/Wot/code/WotThingModel.cs
@@ -34,8 +34,8 @@ namespace Azure.Iot.Operations.Opc2WotLib
         {
             this.specName = specName;
             this.thingName = WotUtil.LegalizeName(uaObjectType.DiscriminatedEffectiveName, specName);
-            this.id = WotUtil.GetThingModelId(uaObjectType.DefiningModel.ModelUri, this.thingName);
             this.typeRef = uaObjectType.GetTypeRef();
+            this.id = WotUtil.GetThingModelId(this.typeRef);
             this.isIntegrated = isIntegrated;
             this.inheritVars = inheritVars;
 
@@ -44,7 +44,7 @@ namespace Azure.Iot.Operations.Opc2WotLib
             this.isComposite = !isTypeDefinition && !this.isEvent && !uaObjectType.IsAbstract;
 
             this.baseModelRefs = uaObjectType.BaseModels
-                .Select(node => GetModelRef(uaObjectType, node))
+                .Select(GetModelRef)
                 .ToHashSet();
             this.linkInfos = uaObjectType.TypeAndObjectOfReferences
                 .Where(t => t.Item1.NsIndex != 0 || t.Item1.IsComponentReference || t.Item1.IsAddInReference)
@@ -112,17 +112,15 @@ namespace Azure.Iot.Operations.Opc2WotLib
                 : null;
         }
 
-        private string GetModelRef(OpcUaObjectType sourceObjectType, OpcUaObjectType targetObjectType)
+        private string GetModelRef(OpcUaObjectType targetObjectType)
         {
-            string targetSpecName = SpecMapper.GetSpecNameFromUri(targetObjectType.DefiningModel.ModelUri);
-            string targetThingName = WotUtil.LegalizeName(targetObjectType.DiscriminatedEffectiveName, targetSpecName);
-            return WotUtil.GetThingModelId(targetObjectType.DefiningModel.ModelUri, targetThingName);
+            return WotUtil.GetThingModelId(targetObjectType.GetTypeRef());
         }
 
         private LinkInfo GetLinkInfo(OpcUaObjectType sourceObjectType, OpcUaNodeId referenceTypeNodeId, OpcUaObject targetObject, LinkRelRuleEngine linkRelRuleEngine)
         {
             OpcUaObjectType targetObjectType = (OpcUaObjectType)targetObject.GetReferencedOpcUaNode(targetObject.HasTypeDefinitionNodeId!);
-            string targetModelRef = GetModelRef(sourceObjectType, targetObjectType);
+            string targetModelRef = GetModelRef(targetObjectType);
 
             if (referenceTypeNodeId.NsIndex != 0)
             {

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
@@ -522,7 +522,9 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.Equal("DataTypeOnly_OnlyEnum.TM.json", outputFile.Name);
                 using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(outputFile.FullName));
                 Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
-                Assert.Equal("urn:org.opcfoundation.UA.DataTypeOnly.OnlyEnum", doc.RootElement.GetProperty("id").GetString());
+                Assert.Equal(
+                    WotUtil.GetThingModelId(WotUtil.GetTypeRef(DataTypeOnlyModelUri, "OnlyEnum")),
+                    doc.RootElement.GetProperty("id").GetString());
                 Assert.Equal("DataTypeOnly_OnlyEnum", doc.RootElement.GetProperty("title").GetString());
                 Assert.EndsWith(".OnlyEnum", doc.RootElement.GetProperty("dov:typeRef").GetString(), StringComparison.Ordinal);
                 Assert.Equal(

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/DataTypeSchemaDefinitionTests.cs
@@ -522,7 +522,12 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 Assert.Equal("DataTypeOnly_OnlyEnum.TM.json", outputFile.Name);
                 using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(outputFile.FullName));
                 Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+                Assert.Equal("urn:org.opcfoundation.UA.DataTypeOnly.OnlyEnum", doc.RootElement.GetProperty("id").GetString());
+                Assert.Equal("DataTypeOnly_OnlyEnum", doc.RootElement.GetProperty("title").GetString());
                 Assert.EndsWith(".OnlyEnum", doc.RootElement.GetProperty("dov:typeRef").GetString(), StringComparison.Ordinal);
+                Assert.Equal(
+                    $"urn:{doc.RootElement.GetProperty("dov:typeRef").GetString()}",
+                    doc.RootElement.GetProperty("id").GetString());
                 Assert.True(doc.RootElement.GetProperty("schemaDefinitions").TryGetProperty("OnlyEnum", out _));
             }
             finally

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
@@ -112,6 +112,22 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             </UANodeSet>
             """;
 
+        private const string DuplicateTypeNameNodeset = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+              <NamespaceUris>
+                <Uri>http://opcfoundation.org/UA/DuplicateTypeName/</Uri>
+              </NamespaceUris>
+              <Models>
+                <Model ModelUri="http://opcfoundation.org/UA/DuplicateTypeName/" Version="1.0.0" />
+              </Models>
+              <Aliases>
+              </Aliases>
+              <UAObjectType NodeId="ns=1;i=1" BrowseName="ModuleType" />
+              <UAObjectType NodeId="ns=1;i=2" BrowseName="ModuleType" />
+            </UANodeSet>
+            """;
+
         [Fact]
         public void HasAddInReference_IsPreservedAsWotLink()
         {
@@ -161,7 +177,39 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 
             string href = link.GetProperty("href").GetString()!;
             Assert.True(Uri.TryCreate(href, UriKind.Absolute, out _));
-            Assert.Equal("http://opcfoundation.org/UA/ReferencedModel/#ReferencedModel_ModuleType", href);
+            Assert.Equal("urn:org.opcfoundation.UA.ReferencedModel.ModuleType", href);
+        }
+
+        [Fact]
+        public void DuplicateTypeNames_HaveMatchingUniqueIdsAndTypeRefs()
+        {
+            OpcUaGraph graph = new OpcUaGraph();
+            graph.AddNodeset(DuplicateTypeNameNodeset);
+
+            WotThingCollection collection = new WotThingCollection(
+                graph,
+                graph.GetOpcUaModelInfo("http://opcfoundation.org/UA/DuplicateTypeName/"),
+                new LinkRelRuleEngine(),
+                integrate: false,
+                inheritVars: false,
+                includeTDs: false);
+
+            using JsonDocument doc = JsonDocument.Parse(collection.TransformText());
+            JsonElement[] models = doc.RootElement.EnumerateArray()
+                .OrderBy(model => model.GetProperty("title").GetString(), StringComparer.Ordinal)
+                .Select(model => model.Clone())
+                .ToArray();
+
+            Assert.Equal(
+                new[]
+                {
+                    "org.opcfoundation.UA.DuplicateTypeName.ModuleType_1",
+                    "org.opcfoundation.UA.DuplicateTypeName.ModuleType_2",
+                },
+                models.Select(model => model.GetProperty("dov:typeRef").GetString()));
+            Assert.Equal(
+                models.Select(model => $"urn:{model.GetProperty("dov:typeRef").GetString()}"),
+                models.Select(model => model.GetProperty("id").GetString()));
         }
 
         [Fact]
@@ -209,6 +257,11 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                     .GetString()!;
 
                 Assert.True(Uri.TryCreate(moduleId, UriKind.Absolute, out _));
+                Assert.Equal("urn:org.opcfoundation.UA.ReferencedModel.ModuleType", moduleId);
+                Assert.Equal("ReferencedModel_ModuleType", moduleDocument.RootElement.GetProperty("title").GetString());
+                Assert.Equal(
+                    $"urn:{moduleDocument.RootElement.GetProperty("dov:typeRef").GetString()}",
+                    moduleId);
                 Assert.Equal(moduleId, linkHref);
             }
             finally

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/HasAddInLinkTests.cs
@@ -125,6 +125,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
               </Aliases>
               <UAObjectType NodeId="ns=1;i=1" BrowseName="ModuleType" />
               <UAObjectType NodeId="ns=1;i=2" BrowseName="ModuleType" />
+              <UAObjectType NodeId="ns=1;i=3" BrowseName="ModuleType_2" />
             </UANodeSet>
             """;
 
@@ -141,7 +142,9 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             string rel = addInLink.Value.GetProperty("rel").GetString()!;
             Assert.StartsWith("dov:", rel);
             string href = addInLink.Value.GetProperty("href").GetString()!;
-            Assert.Contains("IdentificationType", href);
+            Assert.Equal(
+                WotUtil.GetThingModelId(WotUtil.GetTypeRef(ModelUri, "IdentificationType")),
+                href);
         }
 
         [Fact]
@@ -177,7 +180,9 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 
             string href = link.GetProperty("href").GetString()!;
             Assert.True(Uri.TryCreate(href, UriKind.Absolute, out _));
-            Assert.Equal("urn:org.opcfoundation.UA.ReferencedModel.ModuleType", href);
+            Assert.Equal(
+                WotUtil.GetThingModelId(WotUtil.GetTypeRef("http://opcfoundation.org/UA/ReferencedModel/", "ModuleType")),
+                href);
         }
 
         [Fact]
@@ -200,13 +205,8 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                 .Select(model => model.Clone())
                 .ToArray();
 
-            Assert.Equal(
-                new[]
-                {
-                    "org.opcfoundation.UA.DuplicateTypeName.ModuleType_1",
-                    "org.opcfoundation.UA.DuplicateTypeName.ModuleType_2",
-                },
-                models.Select(model => model.GetProperty("dov:typeRef").GetString()));
+            Assert.Equal(3, models.Length);
+            Assert.Equal(3, models.Select(model => model.GetProperty("dov:typeRef").GetString()).Distinct().Count());
             Assert.Equal(
                 models.Select(model => $"urn:{model.GetProperty("dov:typeRef").GetString()}"),
                 models.Select(model => model.GetProperty("id").GetString()));
@@ -257,7 +257,9 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
                     .GetString()!;
 
                 Assert.True(Uri.TryCreate(moduleId, UriKind.Absolute, out _));
-                Assert.Equal("urn:org.opcfoundation.UA.ReferencedModel.ModuleType", moduleId);
+                Assert.Equal(
+                    WotUtil.GetThingModelId(WotUtil.GetTypeRef("http://opcfoundation.org/UA/ReferencedModel/", "ModuleType")),
+                    moduleId);
                 Assert.Equal("ReferencedModel_ModuleType", moduleDocument.RootElement.GetProperty("title").GetString());
                 Assert.Equal(
                     $"urn:{moduleDocument.RootElement.GetProperty("dov:typeRef").GetString()}",

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/VariableTypeSchemaDefinitionTests.cs
@@ -351,7 +351,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             JsonElement schemas = thing.GetProperty("schemaDefinitions");
 
             Assert.True(schemas.TryGetProperty("UIElementType", out JsonElement uiElementType));
-            Assert.Equal("org.opcfoundation.UA.VariableTypeTest.UIElementType", uiElementType.GetProperty("dov:typeRef").GetString());
+            Assert.Equal(WotUtil.GetTypeRef(ModelUri, "UIElementType"), uiElementType.GetProperty("dov:typeRef").GetString());
             Assert.Equal("string", uiElementType.GetProperty("type").GetString());
 
             JsonElement properties = thing.GetProperty("properties");
@@ -374,7 +374,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             JsonElement twoStateDiscreteType = schemas.GetProperty("TwoStateDiscreteType");
             Assert.Equal("boolean", twoStateDiscreteType.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.TwoStateDiscreteType",
+                WotUtil.GetTypeRef(OpcUaGraph.OpcUaCoreModelUri, "TwoStateDiscreteType"),
                 twoStateDiscreteType.GetProperty("dov:typeRef").GetString());
 
             JsonElement specialized = properties.GetProperty("SpecializedUIElement");
@@ -391,14 +391,14 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             Assert.False(structuredProperty.TryGetProperty("tm:ref", out _));
             Assert.Equal("object", structuredProperty.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                WotUtil.GetTypeRef(ModelUri, "StructuredValueType"),
                 structuredProperty.GetProperty("dov:typeRef").GetString());
 
             JsonElement enumProperty = properties.GetProperty("EnumProperty");
             Assert.False(enumProperty.TryGetProperty("tm:ref", out _));
             Assert.Equal("integer", enumProperty.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.ValueKind",
+                WotUtil.GetTypeRef(ModelUri, "ValueKind"),
                 enumProperty.GetProperty("dov:typeRef").GetString());
 
             JsonElement structuredArrayProperty = properties.GetProperty("StructuredArrayProperty");
@@ -406,13 +406,13 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             Assert.False(structuredArrayProperty.TryGetProperty("dov:typeRef", out _));
             Assert.Equal("array", structuredArrayProperty.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                WotUtil.GetTypeRef(ModelUri, "StructuredValueType"),
                 structuredArrayProperty.GetProperty("items").GetProperty("dov:typeRef").GetString());
 
             JsonElement events = thing.GetProperty("events");
             Assert.Equal("#/schemaDefinitions/UIElementType", events.GetProperty("UIElement").GetProperty("data").GetProperty("tm:ref").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.StructuredValueType",
+                WotUtil.GetTypeRef(ModelUri, "StructuredValueType"),
                 events.GetProperty("StructuredProperty").GetProperty("data").GetProperty("dov:typeRef").GetString());
             Assert.False(
                 events.GetProperty("BuiltIn").GetProperty("data").TryGetProperty("dov:typeRef", out _));
@@ -426,12 +426,12 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
             JsonElement directArray = schemas.GetProperty("SampleArrayType");
             Assert.Equal("array", directArray.GetProperty("type").GetString());
             Assert.Equal("string", directArray.GetProperty("items").GetProperty("type").GetString());
-            Assert.Equal("org.opcfoundation.UA.VariableTypeTest.SampleArrayType", directArray.GetProperty("dov:typeRef").GetString());
+            Assert.Equal(WotUtil.GetTypeRef(ModelUri, "SampleArrayType"), directArray.GetProperty("dov:typeRef").GetString());
 
             JsonElement inheritedArray = schemas.GetProperty("DerivedSampleArrayType");
             Assert.Equal("array", inheritedArray.GetProperty("type").GetString());
             Assert.Equal("string", inheritedArray.GetProperty("items").GetProperty("type").GetString());
-            Assert.Equal("org.opcfoundation.UA.VariableTypeTest.DerivedSampleArrayType", inheritedArray.GetProperty("dov:typeRef").GetString());
+            Assert.Equal(WotUtil.GetTypeRef(ModelUri, "DerivedSampleArrayType"), inheritedArray.GetProperty("dov:typeRef").GetString());
         }
 
         [Fact]
@@ -442,12 +442,12 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 
             Assert.Equal("string", subtypeProperty.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.AbstractWeightType",
+                WotUtil.GetTypeRef(ModelUri, "AbstractWeightType"),
                 subtypeProperty.GetProperty("dov:typeRef").GetString());
 
             JsonElement subtypeEventData = thing.GetProperty("events").GetProperty("SubtypeProperty").GetProperty("data");
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.AbstractWeightType",
+                WotUtil.GetTypeRef(ModelUri, "AbstractWeightType"),
                 subtypeEventData.GetProperty("dov:typeRef").GetString());
         }
 
@@ -488,7 +488,7 @@ namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
 
             Assert.Equal("string", property.GetProperty("type").GetString());
             Assert.Equal(
-                "org.opcfoundation.UA.VariableTypeTest.UIElementType",
+                WotUtil.GetTypeRef(ModelUri, "UIElementType"),
                 property.GetProperty("dov:typeRef").GetString());
         }
 

--- a/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/WotUtilTests.cs
+++ b/wot-codegen/test/Azure.Iot.Operations.Opc2WotLib.UnitTests/WotUtilTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+namespace Azure.Iot.Operations.Opc2WotLib.UnitTests
+{
+    using System;
+    using Azure.Iot.Operations.Opc2WotLib;
+    using Xunit;
+
+    public class WotUtilTests
+    {
+        [Theory]
+        [InlineData("http://example.test:4840/UA/", "http://example.test:4841/UA/")]
+        [InlineData("http://example.test/UA", "http://example.test/UA/")]
+        [InlineData("http://example.test/UA/?version=1", "http://example.test/UA/?version=2")]
+        [InlineData("http://example.test/UA/#one", "http://example.test/UA/#two")]
+        public void GetTypeRef_DistinguishesCompleteNamespaceUris(string firstNamespaceUri, string secondNamespaceUri)
+        {
+            Assert.NotEqual(
+                WotUtil.GetTypeRef(firstNamespaceUri, "Thing"),
+                WotUtil.GetTypeRef(secondNamespaceUri, "Thing"));
+        }
+
+        [Fact]
+        public void GetThingModelId_EncodesUnsafeTypeReferenceCharacters()
+        {
+            string typeRef = WotUtil.GetTypeRef("http://example.test/UA/", "Thing%#");
+            string id = WotUtil.GetThingModelId(typeRef);
+
+            Assert.DoesNotContain('#', typeRef);
+            Assert.Contains("%25%23", typeRef);
+            Assert.True(Uri.TryCreate(id, UriKind.Absolute, out Uri? uri));
+            Assert.Equal(id, uri.AbsoluteUri);
+        }
+    }
+}


### PR DESCRIPTION
Generate each Thing Model ID as `urn:<dov:typeRef>` and update all cross-model links to reference the new URNs.

Derive type references from the complete OPC UA NodeId namespace URI using lossless base64url encoding, and URI-escape type names so generated identifiers remain globally unique and valid. Allocate collision-safe discriminators for duplicate and suffix-like type names.