### PR TITLE
Add typed Edge Registry APIs for listing schemas, thing descriptions, and thing models in the Rust and .NET SDKs.

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
@@ -48,6 +48,19 @@ public sealed partial class EdgeRegistryClient : ISchemaRegistryClient
     }
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<Models.ResourceXId>> ListSchemasAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => ListResourcesAsync(
+            GroupQuery.WithinGroupType(Generated.Constants.SchemaGroupType, groups),
+            Generated.Constants.SchemaResourceType,
+            label,
+            timeout,
+            cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<Models.SchemaVersionXid>> ListSchemaVersionsAsync(GroupSelector groups, string? schemaId = null, string? documentHash = null, Models.Label? label = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
@@ -49,6 +49,19 @@ public sealed partial class EdgeRegistryClient : IThingDescriptionClient
     }
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<Models.ResourceXId>> ListThingDescriptionsAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => ListResourcesAsync(
+            GroupQuery.WithinGroupType(Generated.Constants.ThingDescriptionGroupType, groups),
+            Generated.Constants.ThingDescriptionResourceType,
+            label,
+            timeout,
+            cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<Models.ThingDescriptionVersionXid>> ListThingDescriptionVersionsAsync(GroupSelector groups, string? thingDescriptionId = null, string? documentHash = null, Models.Label? label = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
@@ -48,6 +48,19 @@ public sealed partial class EdgeRegistryClient : IThingModelClient
     }
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<Models.ResourceXId>> ListThingModelsAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+        => ListResourcesAsync(
+            GroupQuery.WithinGroupType(Generated.Constants.ThingModelGroupType, groups),
+            Generated.Constants.ThingModelResourceType,
+            label,
+            timeout,
+            cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<Models.ThingModelVersionXid>> ListThingModelVersionsAsync(GroupSelector groups, string? thingModelId = null, string? documentHash = null, Models.Label? label = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
@@ -44,6 +44,18 @@ public interface ISchemaRegistryClient
     /// <returns>A task whose result is the requested <see cref="Models.SchemaVersion"/>.</returns>
     Task<Models.SchemaVersion> GetSchemaVersionAsync(GroupId groupId, string schemaId, GetSchemaVersionId versionId, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
+    /// <summary>Lists the XIDs of Schemas matching the query, optionally filtered by a single label.</summary>
+    /// <param name="groups">The Schema Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
+    /// <param name="label">When set, restricts the results to Schemas carrying this label.</param>
+    /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task whose result is the XIDs of the matching Schemas.</returns>
+    Task<IReadOnlyList<Models.ResourceXId>> ListSchemasAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Lists the XIDs of Schema Versions matching the query, optionally filtered by Schema id and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
     /// <param name="schemaId">When set, restricts the results to this Schema.</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
@@ -45,6 +45,18 @@ public interface IThingDescriptionClient
     /// <returns>A task whose result is the requested <see cref="Models.ThingDescriptionVersion"/>.</returns>
     Task<Models.ThingDescriptionVersion> GetThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, GetThingDescriptionVersionId versionId, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
+    /// <summary>Lists the XIDs of Thing Descriptions matching the query, optionally filtered by a single label.</summary>
+    /// <param name="groups">The Thing Description Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
+    /// <param name="label">When set, restricts the results to Thing Descriptions carrying this label.</param>
+    /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task whose result is the XIDs of the matching Thing Descriptions.</returns>
+    Task<IReadOnlyList<Models.ResourceXId>> ListThingDescriptionsAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Lists the XIDs of Thing Description Versions matching the query, optionally filtered by Thing Description id and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
     /// <param name="thingDescriptionId">When set, restricts the results to this Thing Description.</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
@@ -45,6 +45,18 @@ public interface IThingModelClient
     /// <returns>A task whose result is the requested <see cref="Models.ThingModelVersion"/>.</returns>
     Task<Models.ThingModelVersion> GetThingModelVersionAsync(GroupId groupId, string thingModelId, GetThingModelVersionId versionId, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
+    /// <summary>Lists the XIDs of Thing Models matching the query, optionally filtered by a single label.</summary>
+    /// <param name="groups">The Thing Model Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
+    /// <param name="label">When set, restricts the results to Thing Models carrying this label.</param>
+    /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task whose result is the XIDs of the matching Thing Models.</returns>
+    Task<IReadOnlyList<Models.ResourceXId>> ListThingModelsAsync(
+        GroupSelector groups,
+        Models.Label? label = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Lists the XIDs of Thing Model Versions matching the query, optionally filtered by Thing Model id and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupSelector"/> for the available scopes.</param>
     /// <param name="thingModelId">When set, restricts the results to this Thing Model.</param>

--- a/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/EdgeRegistryClientIntegrationTests.cs
+++ b/dotnet/test/Azure.Iot.Operations.Services.IntegrationTests/EdgeRegistryClientIntegrationTests.cs
@@ -3,6 +3,7 @@
 
 namespace Azure.Iot.Operations.Services.IntegrationTest;
 
+using System.Globalization;
 using Azure.Iot.Operations.Mqtt.Session;
 using Azure.Iot.Operations.Protocol;
 using Azure.Iot.Operations.Services.EdgeRegistry;
@@ -216,6 +217,40 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task ListResourcesAllGroupsStaysWithinGroupType()
+    {
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        ApplicationContext applicationContext = new();
+        await using IEdgeRegistryClient client = new EdgeRegistryClient(applicationContext, mqttClient);
+
+        const string otherGroupType = "othergroups";
+        string groupId = NewId("grp");
+        string otherGroupId = NewId("grp");
+        string resourceId = NewId("res");
+        string otherResourceId = NewId("res");
+
+        try
+        {
+            await client.CreateResourceAsync(GroupType, groupId, ResourceType, resourceId, MakeMeta(), [], CreateVersionId.ServerAssigned, MakeVersionAttributes("v1"));
+            await client.CreateResourceAsync(otherGroupType, otherGroupId, ResourceType, otherResourceId, MakeMeta(), [], CreateVersionId.ServerAssigned, MakeVersionAttributes("v1"));
+
+            IReadOnlyList<ResourceXId> resources = await client.ListResourcesAsync(
+                GroupQuery.WithinGroupType(GroupType, GroupSelector.All),
+                resourceType: ResourceType);
+
+            Assert.Contains(resources, resource => resource.ResourceId == resourceId);
+            Assert.DoesNotContain(resources, resource => resource.ResourceId == otherResourceId);
+        }
+        finally
+        {
+            await client.DeleteGroupAsync(GroupType, groupId);
+            await client.DeleteGroupAsync(otherGroupType, otherGroupId);
+        }
+
+        await client.StopAsync();
+    }
+
+    [Fact]
     public async Task ThrowsObjectDisposedExceptionWhenDisposed()
     {
         await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
@@ -249,8 +284,9 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
         await using IEdgeRegistryClient client = new EdgeRegistryClient(applicationContext, mqttClient);
 
         string schemaId = NewId("schema");
+        Label schemaLabel = MakeResourceLabel(schemaId);
 
-        SchemaVersion created = await client.CreateSchemaVersionAsync(GroupId.CloudDefault, schemaId, [], MakeSchemaVersionAttributes());
+        SchemaVersion created = await client.CreateSchemaVersionAsync(GroupId.CloudDefault, schemaId, [schemaLabel], MakeSchemaVersionAttributes());
         output.WriteLine($"created schema version {created.VersionId} for {created.ResourceId}");
         Assert.Equal(schemaId, created.ResourceId);
         Assert.True(created.IsDefault);
@@ -259,15 +295,87 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
         Assert.Equal(created.VersionId, fetched.VersionId);
 
         // The newest Version becomes the Schema's default.
-        SchemaVersion second = await client.CreateSchemaVersionAsync(GroupId.CloudDefault, schemaId, [], MakeSchemaVersionAttributes());
+        SchemaVersion second = await client.CreateSchemaVersionAsync(GroupId.CloudDefault, schemaId, [schemaLabel], MakeSchemaVersionAttributes());
         Assert.True(second.IsDefault);
         Assert.NotEqual(created.VersionId, second.VersionId);
+
+        CoreResourceEntity coreSchema = await client.GetResourceAsync(GroupType, GroupId.CloudDefault, ResourceType, schemaId);
+        Assert.Equal(second.VersionId.ToString(CultureInfo.InvariantCulture), coreSchema.DefaultVersion.VersionId);
+
+        IReadOnlyList<VersionXId> coreVersions = await client.ListVersionsAsync(
+            GroupQuery.WithinGroupType(GroupType, GroupSelector.Default),
+            resourceType: ResourceType,
+            resourceId: schemaId);
+        Assert.Contains(coreVersions, version => version.VersionId == created.VersionId.ToString(CultureInfo.InvariantCulture));
+        Assert.Contains(coreVersions, version => version.VersionId == second.VersionId.ToString(CultureInfo.InvariantCulture));
 
         IReadOnlyList<SchemaVersionXid> versions = await client.ListSchemaVersionsAsync(GroupSelector.Default, schemaId);
         Assert.True(versions.Count >= 2);
         Assert.All(versions, v => Assert.Equal(schemaId, v.ResourceId));
 
+        IReadOnlyList<ResourceXId> schemas = await client.ListSchemasAsync(GroupSelector.Default, schemaLabel);
+        ResourceXId schema = Assert.Single(schemas);
+        Assert.Equal(schemaId, schema.ResourceId);
+
         await client.DeleteSchemaVersionAsync(GroupId.CloudDefault, schemaId, second.VersionId);
+
+        coreSchema = await client.GetResourceAsync(GroupType, GroupId.CloudDefault, ResourceType, schemaId);
+        Assert.Equal(created.VersionId.ToString(CultureInfo.InvariantCulture), coreSchema.DefaultVersion.VersionId);
+
+        await client.StopAsync();
+    }
+
+    [Fact]
+    public async Task SchemaListSelectorsMapAllAndSpecificGroups()
+    {
+        await using MqttSessionClient mqttClient = await ClientFactory.CreateAndConnectClientAsyncFromEnvAsync();
+        ApplicationContext applicationContext = new();
+        await using IEdgeRegistryClient client = new EdgeRegistryClient(applicationContext, mqttClient);
+
+        string firstGroupId = NewId("grp");
+        string secondGroupId = NewId("grp");
+        string firstSchemaId = NewId("schema");
+        string secondSchemaId = NewId("schema");
+        Label selectorLabel = MakeResourceLabel(NewId("selector"));
+        SchemaVersion? firstVersion = null;
+        SchemaVersion? secondVersion = null;
+
+        try
+        {
+            firstVersion = await client.CreateSchemaVersionAsync(GroupId.Specific(firstGroupId), firstSchemaId, [selectorLabel], MakeSchemaVersionAttributes());
+            secondVersion = await client.CreateSchemaVersionAsync(GroupId.Specific(secondGroupId), secondSchemaId, [selectorLabel], MakeSchemaVersionAttributes());
+
+            IReadOnlyList<ResourceXId> allSchemas = await client.ListSchemasAsync(GroupSelector.All, selectorLabel);
+            Assert.Contains(allSchemas, schema => schema.ResourceId == firstSchemaId);
+            Assert.Contains(allSchemas, schema => schema.ResourceId == secondSchemaId);
+
+            IReadOnlyList<ResourceXId> firstGroupSchemas = await client.ListSchemasAsync(GroupSelector.Specific(firstGroupId), selectorLabel);
+            Assert.Contains(firstGroupSchemas, schema => schema.ResourceId == firstSchemaId);
+            Assert.DoesNotContain(firstGroupSchemas, schema => schema.ResourceId == secondSchemaId);
+
+            IReadOnlyList<SchemaVersionXid> allVersions = await client.ListSchemaVersionsAsync(GroupSelector.All);
+            Assert.Contains(allVersions, version => version.ResourceId == firstSchemaId && version.VersionId == firstVersion.VersionId);
+            Assert.Contains(allVersions, version => version.ResourceId == secondSchemaId && version.VersionId == secondVersion.VersionId);
+
+            IReadOnlyList<SchemaVersionXid> firstGroupVersions = await client.ListSchemaVersionsAsync(GroupSelector.Specific(firstGroupId));
+            Assert.Contains(firstGroupVersions, version => version.ResourceId == firstSchemaId);
+            Assert.DoesNotContain(firstGroupVersions, version => version.ResourceId == secondSchemaId);
+        }
+        finally
+        {
+            if (firstVersion is not null)
+            {
+                await client.DeleteSchemaVersionAsync(GroupId.Specific(firstGroupId), firstSchemaId, firstVersion.VersionId);
+            }
+
+            if (secondVersion is not null)
+            {
+                await client.DeleteSchemaVersionAsync(GroupId.Specific(secondGroupId), secondSchemaId, secondVersion.VersionId);
+            }
+
+            await client.DeleteGroupAsync(GroupType, firstGroupId);
+            await client.DeleteGroupAsync(GroupType, secondGroupId);
+        }
 
         await client.StopAsync();
     }
@@ -280,20 +388,25 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
         await using IEdgeRegistryClient client = new EdgeRegistryClient(applicationContext, mqttClient);
 
         string thingDescriptionId = NewId("td");
+        Label thingDescriptionLabel = MakeResourceLabel(thingDescriptionId);
 
-        ThingDescriptionVersion created = await client.CreateThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, [], MakeThingDescriptionVersionAttributes());
+        ThingDescriptionVersion created = await client.CreateThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, [thingDescriptionLabel], MakeThingDescriptionVersionAttributes());
         Assert.Equal(thingDescriptionId, created.ResourceId);
         Assert.True(created.IsDefault);
 
         ThingDescriptionVersion fetched = await client.GetThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, GetThingDescriptionVersionId.ResourceDefault);
         Assert.Equal(created.VersionId, fetched.VersionId);
 
-        ThingDescriptionVersion second = await client.CreateThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, [], MakeThingDescriptionVersionAttributes());
+        ThingDescriptionVersion second = await client.CreateThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, [thingDescriptionLabel], MakeThingDescriptionVersionAttributes());
         Assert.True(second.IsDefault);
 
         IReadOnlyList<ThingDescriptionVersionXid> versions = await client.ListThingDescriptionVersionsAsync(GroupSelector.Default, thingDescriptionId);
         Assert.True(versions.Count >= 2);
         Assert.All(versions, v => Assert.Equal(thingDescriptionId, v.ResourceId));
+
+        IReadOnlyList<ResourceXId> thingDescriptions = await client.ListThingDescriptionsAsync(GroupSelector.Default, thingDescriptionLabel);
+        ResourceXId thingDescription = Assert.Single(thingDescriptions);
+        Assert.Equal(thingDescriptionId, thingDescription.ResourceId);
 
         await client.DeleteThingDescriptionVersionAsync(GroupId.CloudDefault, thingDescriptionId, second.VersionId);
 
@@ -308,20 +421,25 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
         await using IEdgeRegistryClient client = new EdgeRegistryClient(applicationContext, mqttClient);
 
         string thingModelId = NewId("tm");
+        Label thingModelLabel = MakeResourceLabel(thingModelId);
 
-        ThingModelVersion created = await client.CreateThingModelVersionAsync(GroupId.CloudDefault, thingModelId, [], MakeThingModelVersionAttributes());
+        ThingModelVersion created = await client.CreateThingModelVersionAsync(GroupId.CloudDefault, thingModelId, [thingModelLabel], MakeThingModelVersionAttributes());
         Assert.Equal(thingModelId, created.ResourceId);
         Assert.True(created.IsDefault);
 
         ThingModelVersion fetched = await client.GetThingModelVersionAsync(GroupId.CloudDefault, thingModelId, GetThingModelVersionId.ResourceDefault);
         Assert.Equal(created.VersionId, fetched.VersionId);
 
-        ThingModelVersion second = await client.CreateThingModelVersionAsync(GroupId.CloudDefault, thingModelId, [], MakeThingModelVersionAttributes());
+        ThingModelVersion second = await client.CreateThingModelVersionAsync(GroupId.CloudDefault, thingModelId, [thingModelLabel], MakeThingModelVersionAttributes());
         Assert.True(second.IsDefault);
 
         IReadOnlyList<ThingModelVersionXid> versions = await client.ListThingModelVersionsAsync(GroupSelector.Default, thingModelId);
         Assert.True(versions.Count >= 2);
         Assert.All(versions, v => Assert.Equal(thingModelId, v.ResourceId));
+
+        IReadOnlyList<ResourceXId> thingModels = await client.ListThingModelsAsync(GroupSelector.Default, thingModelLabel);
+        ResourceXId thingModel = Assert.Single(thingModels);
+        Assert.Equal(thingModelId, thingModel.ResourceId);
 
         await client.DeleteThingModelVersionAsync(GroupId.CloudDefault, thingModelId, second.VersionId);
 
@@ -329,6 +447,8 @@ public class EdgeRegistryClientIntegrationTests(ITestOutputHelper output)
     }
 
     private static string NewId(string prefix) => $"it-{prefix}-{Guid.NewGuid():N}";
+
+    private static Label MakeResourceLabel(string value) => new() { Key = "managed-by", Value = value };
 
     private static CoreGroupAttributes MakeGroupAttributes() => new()
     {

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistrySchemaExtensionService.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistrySchemaExtensionService.cs
@@ -21,10 +21,12 @@ internal sealed class EdgeRegistrySchemaExtensionService : EdgeRegistrySchemaExt
     private const string SchemaIdToken = "ex:schemaId";
 
     private readonly ExtensionVersionStore<CreateSchemaVersionAttributes> _store = new(a => a.Labels, a => a.Document);
+    private readonly EdgeRegistryService _coreService;
 
-    public EdgeRegistrySchemaExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient)
+    public EdgeRegistrySchemaExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient, EdgeRegistryService coreService)
         : base(applicationContext, mqttClient)
     {
+        _coreService = coreService;
     }
 
     public override Task<ExtendedResponse<CreateSchemaVersionOutputArguments>> CreateSchemaVersionAsync(CreateSchemaVersionInputArguments request, CommandRequestMetadata requestMetadata, CancellationToken cancellationToken)
@@ -32,6 +34,14 @@ internal sealed class EdgeRegistrySchemaExtensionService : EdgeRegistrySchemaExt
         string schemaId = TopicToken(requestMetadata, SchemaIdToken);
         string groupId = request.GroupId ?? DefaultGroupId;
         var version = _store.CreateVersion(groupId, schemaId, request.SchemaLabels, request);
+        _coreService.UpsertExtensionVersion(
+            GroupType,
+            groupId,
+            ResourceType,
+            schemaId,
+            request.SchemaLabels,
+            version.VersionId.ToString(CultureInfo.InvariantCulture),
+            ToCoreVersionAttributes(request.Name, request.Description, request.Documentation, request.Icon, request.Labels, request.Ancestor, request.ContentType, request.Format, request.Document, request.Extensions));
         return Task.FromResult(Ok(ToEntity(groupId, schemaId, version)));
     }
 
@@ -72,7 +82,11 @@ internal sealed class EdgeRegistrySchemaExtensionService : EdgeRegistrySchemaExt
         string schemaId = TopicToken(requestMetadata, SchemaIdToken);
         ulong versionId = ulong.Parse(TopicToken(requestMetadata, VersionIdToken), CultureInfo.InvariantCulture);
         string groupId = request.GroupId ?? DefaultGroupId;
-        _store.DeleteVersion(groupId, schemaId, versionId, request.Options.ExpectedEpoch);
+        if (_store.DeleteVersion(groupId, schemaId, versionId, request.Options.ExpectedEpoch))
+        {
+            _coreService.DeleteExtensionVersion(GroupType, groupId, ResourceType, schemaId, versionId.ToString(CultureInfo.InvariantCulture));
+        }
+
         return Task.FromResult(Ok(new EmptyJson()));
     }
 

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryService.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryService.cs
@@ -186,6 +186,57 @@ internal sealed class EdgeRegistryService : EdgeRegistry.Service
         }
     }
 
+    internal void UpsertExtensionVersion(string groupType, string groupId, string resourceType, string resourceId, IReadOnlyList<Label> labels, string versionId, VersionAttributes versionAttributes)
+    {
+        lock (_gate)
+        {
+            DateTime now = DateTime.UtcNow;
+            StoredGroup group = GetOrCreateGroup(groupType, groupId, now);
+
+            if (!group.Resources.TryGetValue((resourceType, resourceId), out StoredResource? resource))
+            {
+                ResourceMetaAttributes meta = new() { Labels = CloneLabels(labels), Extensions = new Dictionary<string, byte[]>() };
+                resource = new StoredResource(resourceType, resourceId, meta, new Dictionary<string, byte[]>(), now);
+                group.Resources[(resourceType, resourceId)] = resource;
+            }
+            else
+            {
+                resource.Meta.Labels = CloneLabels(labels);
+                resource.ModifiedAt = now;
+                resource.MetaEpoch++;
+            }
+
+            resource.Versions.RemoveAll(v => v.VersionId == versionId);
+            resource.Versions.Add(new StoredVersion(versionId, versionAttributes, now));
+            resource.DefaultVersionId = versionId;
+            group.ModifiedAt = now;
+        }
+    }
+
+    internal void DeleteExtensionVersion(string groupType, string groupId, string resourceType, string resourceId, string versionId)
+    {
+        lock (_gate)
+        {
+            if (!_groups.TryGetValue((groupType, groupId), out StoredGroup? group)
+                || !group.Resources.TryGetValue((resourceType, resourceId), out StoredResource? resource)
+                || resource.Versions.RemoveAll(v => v.VersionId == versionId) == 0)
+            {
+                return;
+            }
+
+            if (resource.Versions.Count == 0)
+            {
+                group.Resources.Remove((resourceType, resourceId));
+            }
+            else if (resource.DefaultVersionId == versionId)
+            {
+                resource.DefaultVersionId = resource.Versions[^1].VersionId;
+            }
+
+            group.ModifiedAt = DateTime.UtcNow;
+        }
+    }
+
     // TODO: should return an error if the item isn't found or the expected epoch doesn't match.
     public override Task<ExtendedResponse<EmptyJson>> DeleteResourceAsync(DeleteResourceInputArguments request, CommandRequestMetadata requestMetadata, CancellationToken cancellationToken)
     {
@@ -372,7 +423,9 @@ internal sealed class EdgeRegistryService : EdgeRegistry.Service
     {
         if (allGroups)
         {
-            return _groups.Values;
+            return groupType is null
+                ? _groups.Values
+                : _groups.Values.Where(g => g.GroupType == groupType);
         }
 
         string effectiveGroupId = groupId ?? DefaultGroupId;
@@ -482,7 +535,7 @@ internal sealed class EdgeRegistryService : EdgeRegistry.Service
         return counts;
     }
 
-    private static List<Label> CloneLabels(List<Label> labels)
+    private static List<Label> CloneLabels(IEnumerable<Label> labels)
         => labels.Select(l => new Label { Key = l.Key, Value = l.Value }).ToList();
 
     private static Dictionary<string, byte[]> CloneExtensions(Dictionary<string, byte[]> extensions)

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryThingDescriptionExtensionService.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryThingDescriptionExtensionService.cs
@@ -21,10 +21,12 @@ internal sealed class EdgeRegistryThingDescriptionExtensionService : EdgeRegistr
     private const string ThingDescriptionIdToken = "ex:thingDescriptionId";
 
     private readonly ExtensionVersionStore<CreateThingDescriptionVersionAttributes> _store = new(a => a.Labels, a => a.Document);
+    private readonly EdgeRegistryService _coreService;
 
-    public EdgeRegistryThingDescriptionExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient)
+    public EdgeRegistryThingDescriptionExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient, EdgeRegistryService coreService)
         : base(applicationContext, mqttClient)
     {
+        _coreService = coreService;
     }
 
     public override Task<ExtendedResponse<CreateThingDescriptionVersionOutputArguments>> CreateThingDescriptionVersionAsync(CreateThingDescriptionVersionInputArguments request, CommandRequestMetadata requestMetadata, CancellationToken cancellationToken)
@@ -32,6 +34,14 @@ internal sealed class EdgeRegistryThingDescriptionExtensionService : EdgeRegistr
         string thingDescriptionId = TopicToken(requestMetadata, ThingDescriptionIdToken);
         string groupId = request.GroupId ?? DefaultGroupId;
         var version = _store.CreateVersion(groupId, thingDescriptionId, request.ThingDescriptionLabels, request);
+        _coreService.UpsertExtensionVersion(
+            GroupType,
+            groupId,
+            ResourceType,
+            thingDescriptionId,
+            request.ThingDescriptionLabels,
+            version.VersionId.ToString(CultureInfo.InvariantCulture),
+            ToCoreVersionAttributes(request.Name, request.Description, request.Documentation, request.Icon, request.Labels, request.Ancestor, request.ContentType, request.Format, request.Document, request.Extensions));
         return Task.FromResult(Ok(ToEntity(groupId, thingDescriptionId, version)));
     }
 
@@ -72,7 +82,11 @@ internal sealed class EdgeRegistryThingDescriptionExtensionService : EdgeRegistr
         string thingDescriptionId = TopicToken(requestMetadata, ThingDescriptionIdToken);
         ulong versionId = ulong.Parse(TopicToken(requestMetadata, VersionIdToken), CultureInfo.InvariantCulture);
         string groupId = request.GroupId ?? DefaultGroupId;
-        _store.DeleteVersion(groupId, thingDescriptionId, versionId, request.Options.ExpectedEpoch);
+        if (_store.DeleteVersion(groupId, thingDescriptionId, versionId, request.Options.ExpectedEpoch))
+        {
+            _coreService.DeleteExtensionVersion(GroupType, groupId, ResourceType, thingDescriptionId, versionId.ToString(CultureInfo.InvariantCulture));
+        }
+
         return Task.FromResult(Ok(new EmptyJson()));
     }
 

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryThingModelExtensionService.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/EdgeRegistryThingModelExtensionService.cs
@@ -21,10 +21,12 @@ internal sealed class EdgeRegistryThingModelExtensionService : EdgeRegistryThing
     private const string ThingModelIdToken = "ex:thingModelId";
 
     private readonly ExtensionVersionStore<CreateThingModelVersionAttributes> _store = new(a => a.Labels, a => a.Document);
+    private readonly EdgeRegistryService _coreService;
 
-    public EdgeRegistryThingModelExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient)
+    public EdgeRegistryThingModelExtensionService(ApplicationContext applicationContext, MqttSessionClient mqttClient, EdgeRegistryService coreService)
         : base(applicationContext, mqttClient)
     {
+        _coreService = coreService;
     }
 
     public override Task<ExtendedResponse<CreateThingModelVersionOutputArguments>> CreateThingModelVersionAsync(CreateThingModelVersionInputArguments request, CommandRequestMetadata requestMetadata, CancellationToken cancellationToken)
@@ -32,6 +34,14 @@ internal sealed class EdgeRegistryThingModelExtensionService : EdgeRegistryThing
         string thingModelId = TopicToken(requestMetadata, ThingModelIdToken);
         string groupId = request.GroupId ?? DefaultGroupId;
         var version = _store.CreateVersion(groupId, thingModelId, request.ThingModelLabels, request);
+        _coreService.UpsertExtensionVersion(
+            GroupType,
+            groupId,
+            ResourceType,
+            thingModelId,
+            request.ThingModelLabels,
+            version.VersionId.ToString(CultureInfo.InvariantCulture),
+            ToCoreVersionAttributes(request.Name, request.Description, request.Documentation, request.Icon, request.Labels, request.Ancestor, request.ContentType, request.Format, request.Document, request.Extensions));
         return Task.FromResult(Ok(ToEntity(groupId, thingModelId, version)));
     }
 
@@ -72,7 +82,11 @@ internal sealed class EdgeRegistryThingModelExtensionService : EdgeRegistryThing
         string thingModelId = TopicToken(requestMetadata, ThingModelIdToken);
         ulong versionId = ulong.Parse(TopicToken(requestMetadata, VersionIdToken), CultureInfo.InvariantCulture);
         string groupId = request.GroupId ?? DefaultGroupId;
-        _store.DeleteVersion(groupId, thingModelId, versionId, request.Options.ExpectedEpoch);
+        if (_store.DeleteVersion(groupId, thingModelId, versionId, request.Options.ExpectedEpoch))
+        {
+            _coreService.DeleteExtensionVersion(GroupType, groupId, ResourceType, thingModelId, versionId.ToString(CultureInfo.InvariantCulture));
+        }
+
         return Task.FromResult(Ok(new EmptyJson()));
     }
 

--- a/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/ExtensionVersionStore.cs
+++ b/eng/test/edge-registry/src/Azure.Iot.Operations.Services.EdgeRegistry.Host/ExtensionVersionStore.cs
@@ -95,18 +95,27 @@ internal sealed class ExtensionVersionStore<TAttributes>(Func<TAttributes, List<
     }
 
     // TODO: for correct behavior, this should return an error if the item isn't found or the expected epoch doesn't match.
-    public void DeleteVersion(string groupId, string resourceId, ulong versionId, ulong? expectedEpoch)
+    public bool DeleteVersion(string groupId, string resourceId, ulong versionId, ulong? expectedEpoch)
     {
         lock (_gate)
         {
-            if (_resources.TryGetValue((groupId, resourceId), out StoredResource? resource))
+            if (!_resources.TryGetValue((groupId, resourceId), out StoredResource? resource))
             {
-                resource.Versions.RemoveAll(v => v.VersionId == versionId && (expectedEpoch is null || v.Epoch == expectedEpoch));
-                if (resource.DefaultVersionId == versionId)
-                {
-                    resource.DefaultVersionId = resource.Versions.Count > 0 ? resource.Versions[^1].VersionId : 0;
-                }
+                return false;
             }
+
+            int removed = resource.Versions.RemoveAll(v => v.VersionId == versionId && (expectedEpoch is null || v.Epoch == expectedEpoch));
+            if (removed == 0)
+            {
+                return false;
+            }
+
+            if (resource.DefaultVersionId == versionId)
+            {
+                resource.DefaultVersionId = resource.Versions.Count > 0 ? resource.Versions[^1].VersionId : 0;
+            }
+
+            return true;
         }
     }
 
@@ -148,6 +157,30 @@ internal static class ExtensionStub
 {
     public const string DefaultGroupId = "default";
     public const string VersionIdToken = "ex:versionId";
+
+    public static VersionAttributes ToCoreVersionAttributes(
+        string? name,
+        string? description,
+        string? documentation,
+        string? icon,
+        IReadOnlyList<Label> labels,
+        ulong? ancestor,
+        string? contentType,
+        string format,
+        byte[] document,
+        Dictionary<string, byte[]> extensions) => new()
+        {
+            Name = name,
+            Description = description,
+            Documentation = documentation,
+            Icon = icon,
+            Labels = labels.Select(l => new Label { Key = l.Key, Value = l.Value }).ToList(),
+            Ancestor = ancestor?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ContentType = contentType,
+            Format = format,
+            Document = document.ToArray(),
+            Extensions = new Dictionary<string, byte[]>(extensions),
+        };
 
     public static string TopicToken(CommandRequestMetadata metadata, string token)
         => metadata.TopicTokens.TryGetValue(token, out string? value)

--- a/rust/azure_iot_operations_services/Cargo.toml
+++ b/rust/azure_iot_operations_services/Cargo.toml
@@ -101,5 +101,9 @@ name = "schema_registry_client"
 required-features = ["schema_registry"]
 
 [[example]]
+name = "edge_registry_client"
+required-features = ["edge_registry"]
+
+[[example]]
 name = "lock_client"
 required-features = ["leased_lock"]

--- a/rust/azure_iot_operations_services/examples/edge_registry_client.rs
+++ b/rust/azure_iot_operations_services/examples/edge_registry_client.rs
@@ -1,0 +1,327 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::error::Error;
+use std::future::Future;
+use std::io;
+use std::time::Duration;
+
+use azure_iot_operations_mqtt::aio::connection_settings::MqttConnectionSettingsBuilder;
+use azure_iot_operations_mqtt::control_packet::{
+    PublishProperties, QoS, RetainOptions, SubscribeProperties, TopicFilter, TopicName,
+};
+use azure_iot_operations_mqtt::session::{
+    Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
+};
+use azure_iot_operations_protocol::application::ApplicationContextBuilder;
+use azure_iot_operations_protocol::common::aio_protocol_error::AIOProtocolErrorKind;
+use azure_iot_operations_services::edge_registry::models::{
+    SchemaFormat, SchemaVersionAttributesBuilder, ThingDescriptionFormat,
+    ThingDescriptionVersionAttributesBuilder, ThingModelFormat, ThingModelVersionAttributesBuilder,
+};
+use azure_iot_operations_services::edge_registry::{
+    self, Client, GetVersionId, GroupId, GroupSelection, Label,
+};
+use bytes::Bytes;
+use env_logger::Builder;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const LIST_RETRY_ATTEMPTS: u32 = 30;
+const LIST_RETRY_DELAY: Duration = Duration::from_secs(1);
+const SCHEMA_V1: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"}}}"#;
+const SCHEMA_V2: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"},"humidity":{"type":"number"}}}"#;
+const THING_DESCRIPTION: &str = r#"{"@context":"https://www.w3.org/2022/wot/td/v1.1","id":"urn:sample:thing-description","title":"Sample Thing Description","securityDefinitions":{"nosec_sc":{"scheme":"nosec"}},"security":["nosec_sc"]}"#;
+const THING_MODEL: &str = r#"{"@context":"https://www.w3.org/2022/wot/td/v1.1","@type":"tm:ThingModel","id":"urn:sample:thing-model","title":"Sample Thing Model"}"#;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .format_timestamp(None)
+        .filter_module("azure_mqtt", log::LevelFilter::Warn)
+        .init();
+
+    let connection_settings = MqttConnectionSettingsBuilder::from_environment()?.build()?;
+    let session_options = SessionOptionsBuilder::default()
+        .connection_settings(connection_settings)
+        .build()?;
+    let session = Session::new(session_options)?;
+
+    let application_context = ApplicationContextBuilder::default().build()?;
+    let mqtt_client = session.create_managed_client();
+    let client = edge_registry::Client::new(application_context, &mqtt_client);
+
+    let (program_result, session_result) = tokio::join!(
+        run_program(client, mqtt_client, session.create_exit_handle()),
+        session.run(),
+    );
+    session_result?;
+    program_result
+}
+
+async fn run_program(
+    client: Client,
+    mqtt_client: SessionManagedClient,
+    exit_handle: SessionExitHandle,
+) -> Result<(), Box<dyn Error>> {
+    let operation_result = async {
+        resource_list_demo(&client).await?;
+        graph_round_trip_if_configured(&mqtt_client).await
+    }
+    .await;
+    let shutdown_result = client.shutdown().await;
+
+    if exit_handle.try_exit().is_err() {
+        exit_handle.force_exit();
+    }
+
+    operation_result?;
+    shutdown_result?;
+    Ok(())
+}
+
+async fn graph_round_trip_if_configured(
+    client: &SessionManagedClient,
+) -> Result<(), Box<dyn Error>> {
+    let Ok(input_topic) = std::env::var("EDGE_REGISTRY_E2E_INPUT_TOPIC") else {
+        return Ok(());
+    };
+    let output_topic = std::env::var("EDGE_REGISTRY_E2E_OUTPUT_TOPIC")?;
+    let payload = std::env::var("EDGE_REGISTRY_E2E_PAYLOAD")?;
+
+    let output_filter = TopicFilter::new(output_topic)?;
+    let mut receiver = client.create_filtered_pub_receiver(output_filter.clone());
+    client
+        .subscribe(
+            output_filter,
+            QoS::AtLeastOnce,
+            false,
+            RetainOptions::default(),
+            SubscribeProperties::default(),
+        )
+        .await?
+        .await?;
+
+    client
+        .publish_qos1(
+            TopicName::new(input_topic)?,
+            false,
+            payload.clone(),
+            PublishProperties::default(),
+        )
+        .await?
+        .await?;
+
+    let output = tokio::time::timeout(Duration::from_secs(60), receiver.recv())
+        .await?
+        .ok_or_else(|| io::Error::other("graph output subscription closed"))?;
+    if output.payload.as_ref() != payload.as_bytes() {
+        return Err(io::Error::other("graph output payload did not match input").into());
+    }
+
+    log::info!("EDGE_REGISTRY_RESOURCE_LIST_ROUND_TRIP_PASSED");
+    Ok(())
+}
+
+fn label(key: &str, value: &str) -> Label {
+    Label {
+        key: key.to_string(),
+        value: value.to_string(),
+    }
+}
+
+fn is_retryable_list_error(error: &edge_registry::Error) -> bool {
+    match error.kind() {
+        edge_registry::ErrorKind::AIOProtocolError(protocol_error) => matches!(
+            protocol_error.kind,
+            AIOProtocolErrorKind::Timeout | AIOProtocolErrorKind::ClientError
+        ),
+        edge_registry::ErrorKind::ServiceError(service_error) => {
+            matches!(service_error.code, 408 | 429 | 500..=599)
+        }
+        _ => false,
+    }
+}
+
+async fn retry_list<T, F, Fut, P>(
+    mut operation: F,
+    mut is_complete: P,
+    incomplete_message: &'static str,
+) -> Result<T, Box<dyn Error>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, edge_registry::Error>>,
+    P: FnMut(&T) -> bool,
+{
+    for attempt in 1..=LIST_RETRY_ATTEMPTS {
+        match operation().await {
+            Ok(value) if is_complete(&value) => return Ok(value),
+            Ok(_) if attempt == LIST_RETRY_ATTEMPTS => {
+                return Err(io::Error::other(incomplete_message).into());
+            }
+            Ok(_) => {
+                log::warn!(
+                    "List request returned incomplete registry state (attempt {attempt}/{LIST_RETRY_ATTEMPTS})"
+                );
+                tokio::time::sleep(LIST_RETRY_DELAY).await;
+            }
+            Err(error) if attempt < LIST_RETRY_ATTEMPTS && is_retryable_list_error(&error) => {
+                log::warn!(
+                    "List request failed during registry reconciliation (attempt {attempt}/{LIST_RETRY_ATTEMPTS}): {error}"
+                );
+                tokio::time::sleep(LIST_RETRY_DELAY).await;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    unreachable!("the retry loop always returns on its final attempt")
+}
+
+async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
+    let schema_id = "sample-schema".to_string();
+    let schema_label = label("managed-by", "sample");
+
+    let first = client
+        .create_schema_version(
+            GroupId::CloudDefault,
+            schema_id.clone(),
+            vec![schema_label.clone()],
+            SchemaVersionAttributesBuilder::default()
+                .format(SchemaFormat::JsonSchemaDraft07)
+                .labels(vec![label("revision", "1")])
+                .document(Bytes::from_static(SCHEMA_V1.as_bytes()))
+                .build()
+                .expect("required attributes are set"),
+            TIMEOUT,
+        )
+        .await?;
+
+    let fetched = client
+        .get_schema_version(
+            GroupId::CloudDefault,
+            schema_id.clone(),
+            GetVersionId::Specified(first.version_id),
+            TIMEOUT,
+        )
+        .await?;
+    if fetched.version_id != first.version_id {
+        return Err(io::Error::other("fetched Schema Version did not match").into());
+    }
+
+    let second = client
+        .create_schema_version(
+            GroupId::CloudDefault,
+            schema_id.clone(),
+            vec![schema_label.clone()],
+            SchemaVersionAttributesBuilder::default()
+                .format(SchemaFormat::JsonSchemaDraft07)
+                .labels(vec![label("revision", "2")])
+                .document(Bytes::from_static(SCHEMA_V2.as_bytes()))
+                .build()
+                .expect("required attributes are set"),
+            TIMEOUT,
+        )
+        .await?;
+
+    retry_list(
+        || {
+            client.list_schema_versions(
+                GroupSelection::Default,
+                Some(schema_id.clone()),
+                None,
+                None,
+                TIMEOUT,
+            )
+        },
+        |versions| {
+            versions
+                .iter()
+                .any(|xid| xid.version_id == first.version_id)
+                && versions
+                    .iter()
+                    .any(|xid| xid.version_id == second.version_id)
+        },
+        "created Schema Versions were not listed",
+    )
+    .await?;
+
+    retry_list(
+        || client.list_schemas(GroupSelection::Default, Some(schema_label.clone()), TIMEOUT),
+        |schemas| schemas.iter().any(|xid| xid.resource_id == schema_id),
+        "labeled Schema was not listed",
+    )
+    .await?;
+
+    log::info!(
+        "Listed Schema {schema_id} with Versions {} and {}",
+        first.version_id,
+        second.version_id
+    );
+
+    let thing_description_id = "sample-thing-description".to_string();
+    let thing_description_label = label("managed-by", "sample");
+    client
+        .create_thing_description_version(
+            GroupId::CloudDefault,
+            thing_description_id.clone(),
+            vec![thing_description_label.clone()],
+            ThingDescriptionVersionAttributesBuilder::default()
+                .format(ThingDescriptionFormat::JsonLd11)
+                .document(Bytes::from_static(THING_DESCRIPTION.as_bytes()))
+                .build()
+                .expect("required attributes are set"),
+            TIMEOUT,
+        )
+        .await?;
+    retry_list(
+        || {
+            client.list_thing_descriptions(
+                GroupSelection::Default,
+                Some(thing_description_label.clone()),
+                TIMEOUT,
+            )
+        },
+        |thing_descriptions| {
+            thing_descriptions
+                .iter()
+                .any(|xid| xid.resource_id == thing_description_id)
+        },
+        "labeled Thing Description was not listed",
+    )
+    .await?;
+
+    let thing_model_id = "sample-thing-model".to_string();
+    let thing_model_label = label("managed-by", "sample");
+    client
+        .create_thing_model_version(
+            GroupId::CloudDefault,
+            thing_model_id.clone(),
+            vec![thing_model_label.clone()],
+            ThingModelVersionAttributesBuilder::default()
+                .format(ThingModelFormat::JsonLd11)
+                .document(Bytes::from_static(THING_MODEL.as_bytes()))
+                .build()
+                .expect("required attributes are set"),
+            TIMEOUT,
+        )
+        .await?;
+    retry_list(
+        || {
+            client.list_thing_models(
+                GroupSelection::Default,
+                Some(thing_model_label.clone()),
+                TIMEOUT,
+            )
+        },
+        |thing_models| {
+            thing_models
+                .iter()
+                .any(|xid| xid.resource_id == thing_model_id)
+        },
+        "labeled Thing Model was not listed",
+    )
+    .await?;
+
+    log::info!("Listed Thing Description {thing_description_id} and Thing Model {thing_model_id}");
+    Ok(())
+}

--- a/rust/azure_iot_operations_services/examples/edge_registry_client.rs
+++ b/rust/azure_iot_operations_services/examples/edge_registry_client.rs
@@ -2,19 +2,11 @@
 // Licensed under the MIT License.
 
 use std::error::Error;
-use std::future::Future;
-use std::io;
 use std::time::Duration;
 
 use azure_iot_operations_mqtt::aio::connection_settings::MqttConnectionSettingsBuilder;
-use azure_iot_operations_mqtt::control_packet::{
-    PublishProperties, QoS, RetainOptions, SubscribeProperties, TopicFilter, TopicName,
-};
-use azure_iot_operations_mqtt::session::{
-    Session, SessionExitHandle, SessionManagedClient, SessionOptionsBuilder,
-};
+use azure_iot_operations_mqtt::session::{Session, SessionExitHandle, SessionOptionsBuilder};
 use azure_iot_operations_protocol::application::ApplicationContextBuilder;
-use azure_iot_operations_protocol::common::aio_protocol_error::AIOProtocolErrorKind;
 use azure_iot_operations_services::edge_registry::models::{
     SchemaFormat, SchemaVersionAttributesBuilder, ThingDescriptionFormat,
     ThingDescriptionVersionAttributesBuilder, ThingModelFormat, ThingModelVersionAttributesBuilder,
@@ -26,8 +18,6 @@ use bytes::Bytes;
 use env_logger::Builder;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
-const LIST_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
-const LIST_RETRY_DELAY: Duration = Duration::from_secs(1);
 const SCHEMA_V1: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"}}}"#;
 const SCHEMA_V2: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"},"humidity":{"type":"number"}}}"#;
 const THING_DESCRIPTION: &str = r#"{"@context":"https://www.w3.org/2022/wot/td/v1.1","id":"urn:sample:thing-description","title":"Sample Thing Description","securityDefinitions":{"nosec_sc":{"scheme":"nosec"}},"security":["nosec_sc"]}"#;
@@ -52,23 +42,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = edge_registry::Client::new(application_context, &mqtt_client);
 
     let (program_result, session_result) = tokio::join!(
-        run_program(client, mqtt_client, session.create_exit_handle()),
+        run_program(client, session.create_exit_handle()),
         session.run(),
     );
     session_result?;
     program_result
 }
 
-async fn run_program(
-    client: Client,
-    mqtt_client: SessionManagedClient,
-    exit_handle: SessionExitHandle,
-) -> Result<(), Box<dyn Error>> {
-    let operation_result = async {
-        resource_list_demo(&client).await?;
-        graph_round_trip_if_configured(&mqtt_client).await
-    }
-    .await;
+async fn run_program(client: Client, exit_handle: SessionExitHandle) -> Result<(), Box<dyn Error>> {
+    let operation_result = resource_list_demo(&client).await;
     let shutdown_result = client.shutdown().await;
 
     if exit_handle.try_exit().is_err() {
@@ -80,110 +62,10 @@ async fn run_program(
     Ok(())
 }
 
-async fn graph_round_trip_if_configured(
-    client: &SessionManagedClient,
-) -> Result<(), Box<dyn Error>> {
-    let Ok(input_topic) = std::env::var("EDGE_REGISTRY_E2E_INPUT_TOPIC") else {
-        return Ok(());
-    };
-    let output_topic = std::env::var("EDGE_REGISTRY_E2E_OUTPUT_TOPIC")?;
-    let payload = std::env::var("EDGE_REGISTRY_E2E_PAYLOAD")?;
-
-    let output_filter = TopicFilter::new(output_topic)?;
-    let mut receiver = client.create_filtered_pub_receiver(output_filter.clone());
-    client
-        .subscribe(
-            output_filter,
-            QoS::AtLeastOnce,
-            false,
-            RetainOptions::default(),
-            SubscribeProperties::default(),
-        )
-        .await?
-        .await?;
-
-    client
-        .publish_qos1(
-            TopicName::new(input_topic)?,
-            false,
-            payload.clone(),
-            PublishProperties::default(),
-        )
-        .await?
-        .await?;
-
-    let output = tokio::time::timeout(Duration::from_secs(60), receiver.recv())
-        .await?
-        .ok_or_else(|| io::Error::other("graph output subscription closed"))?;
-    if output.payload.as_ref() != payload.as_bytes() {
-        return Err(io::Error::other("graph output payload did not match input").into());
-    }
-
-    log::info!("EDGE_REGISTRY_RESOURCE_LIST_ROUND_TRIP_PASSED");
-    Ok(())
-}
-
 fn label(key: &str, value: &str) -> Label {
     Label {
         key: key.to_string(),
         value: value.to_string(),
-    }
-}
-
-fn is_retryable_list_error(error: &edge_registry::Error) -> bool {
-    match error.kind() {
-        edge_registry::ErrorKind::AIOProtocolError(protocol_error) => matches!(
-            protocol_error.kind,
-            AIOProtocolErrorKind::Timeout | AIOProtocolErrorKind::ClientError
-        ),
-        edge_registry::ErrorKind::ServiceError(service_error) => {
-            matches!(service_error.code, 408 | 429 | 500..=599)
-        }
-        _ => false,
-    }
-}
-
-async fn retry_list<T, F, Fut, P>(
-    mut operation: F,
-    mut is_complete: P,
-    incomplete_message: &'static str,
-    retry_timeout: Duration,
-) -> Result<T, Box<dyn Error>>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, edge_registry::Error>>,
-    P: FnMut(&T) -> bool,
-{
-    let mut attempt = 1;
-    let result = tokio::time::timeout(retry_timeout, async {
-        loop {
-            match operation().await {
-                Ok(value) if is_complete(&value) => return Ok(value),
-                Ok(_) => {
-                    log::warn!(
-                        "List request returned incomplete registry state (attempt {attempt})"
-                    );
-                }
-                Err(error) if is_retryable_list_error(&error) => {
-                    log::warn!(
-                        "List request failed during registry reconciliation (attempt {attempt}): {error}"
-                    );
-                }
-                Err(error) => return Err(error),
-            }
-
-            attempt += 1;
-            tokio::time::sleep(LIST_RETRY_DELAY).await;
-        }
-    })
-    .await;
-
-    match result {
-        Ok(Ok(value)) => Ok(value),
-        Ok(Err(error)) => Err(error.into()),
-        Err(_) => {
-            Err(io::Error::other(format!("{incomplete_message} within {retry_timeout:?}")).into())
-        }
     }
 }
 
@@ -214,11 +96,9 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
             TIMEOUT,
         )
         .await?;
-    if fetched.version_id != first.version_id {
-        return Err(io::Error::other("fetched Schema Version did not match").into());
-    }
+    log::info!("Fetched Schema Version: {fetched:?}");
 
-    let second = client
+    client
         .create_schema_version(
             GroupId::CloudDefault,
             schema_id.clone(),
@@ -233,42 +113,25 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
         )
         .await?;
 
-    retry_list(
-        || {
-            client.list_schema_versions(
-                GroupSelection::Default,
-                Some(schema_id.clone()),
-                None,
-                None,
-                TIMEOUT,
-            )
-        },
-        |versions| {
-            versions
-                .iter()
-                .any(|xid| xid.version_id == first.version_id)
-                && versions
-                    .iter()
-                    .any(|xid| xid.version_id == second.version_id)
-        },
-        "created Schema Versions were not listed",
-        LIST_RETRY_TIMEOUT,
-    )
-    .await?;
+    let schema_versions = client
+        .list_schema_versions(
+            GroupSelection::Default,
+            Some(schema_id.clone()),
+            None,
+            None,
+            TIMEOUT,
+        )
+        .await?;
+    for schema_version in schema_versions {
+        log::info!("Schema Version: {schema_version:?}");
+    }
 
-    retry_list(
-        || client.list_schemas(GroupSelection::Default, Some(schema_label.clone()), TIMEOUT),
-        |schemas| schemas.iter().any(|xid| xid.resource_id == schema_id),
-        "labeled Schema was not listed",
-        LIST_RETRY_TIMEOUT,
-    )
-    .await?;
-
-    log::info!(
-        "Listed Schema {schema_id} with Versions {} and {}",
-        first.version_id,
-        second.version_id
-    );
+    let schemas = client
+        .list_schemas(GroupSelection::Default, Some(schema_label), TIMEOUT)
+        .await?;
+    for schema in schemas {
+        log::info!("Schema: {schema:?}");
+    }
 
     let thing_description_id = "sample-thing-description".to_string();
     let thing_description_label = label("managed-by", "sample");
@@ -285,23 +148,17 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
             TIMEOUT,
         )
         .await?;
-    retry_list(
-        || {
-            client.list_thing_descriptions(
-                GroupSelection::Default,
-                Some(thing_description_label.clone()),
-                TIMEOUT,
-            )
-        },
-        |thing_descriptions| {
-            thing_descriptions
-                .iter()
-                .any(|xid| xid.resource_id == thing_description_id)
-        },
-        "labeled Thing Description was not listed",
-        LIST_RETRY_TIMEOUT,
-    )
-    .await?;
+
+    let thing_descriptions = client
+        .list_thing_descriptions(
+            GroupSelection::Default,
+            Some(thing_description_label),
+            TIMEOUT,
+        )
+        .await?;
+    for thing_description in thing_descriptions {
+        log::info!("Thing Description: {thing_description:?}");
+    }
 
     let thing_model_id = "sample-thing-model".to_string();
     let thing_model_label = label("managed-by", "sample");
@@ -318,45 +175,13 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
             TIMEOUT,
         )
         .await?;
-    retry_list(
-        || {
-            client.list_thing_models(
-                GroupSelection::Default,
-                Some(thing_model_label.clone()),
-                TIMEOUT,
-            )
-        },
-        |thing_models| {
-            thing_models
-                .iter()
-                .any(|xid| xid.resource_id == thing_model_id)
-        },
-        "labeled Thing Model was not listed",
-        LIST_RETRY_TIMEOUT,
-    )
-    .await?;
 
-    log::info!("Listed Thing Description {thing_description_id} and Thing Model {thing_model_id}");
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn retry_list_stops_at_overall_timeout() {
-        let result = retry_list(
-            || async { Ok::<bool, edge_registry::Error>(false) },
-            |is_complete| *is_complete,
-            "resource was not listed",
-            Duration::from_millis(20),
-        )
-        .await;
-
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "resource was not listed within 20ms"
-        );
+    let thing_models = client
+        .list_thing_models(GroupSelection::Default, Some(thing_model_label), TIMEOUT)
+        .await?;
+    for thing_model in thing_models {
+        log::info!("Thing Model: {thing_model:?}");
     }
+
+    Ok(())
 }

--- a/rust/azure_iot_operations_services/examples/edge_registry_client.rs
+++ b/rust/azure_iot_operations_services/examples/edge_registry_client.rs
@@ -26,7 +26,7 @@ use bytes::Bytes;
 use env_logger::Builder;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
-const LIST_RETRY_ATTEMPTS: u32 = 30;
+const LIST_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
 const LIST_RETRY_DELAY: Duration = Duration::from_secs(1);
 const SCHEMA_V1: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"}}}"#;
 const SCHEMA_V2: &str = r#"{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"temperature":{"type":"number"},"humidity":{"type":"number"}}}"#;
@@ -147,34 +147,44 @@ async fn retry_list<T, F, Fut, P>(
     mut operation: F,
     mut is_complete: P,
     incomplete_message: &'static str,
+    retry_timeout: Duration,
 ) -> Result<T, Box<dyn Error>>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, edge_registry::Error>>,
     P: FnMut(&T) -> bool,
 {
-    for attempt in 1..=LIST_RETRY_ATTEMPTS {
-        match operation().await {
-            Ok(value) if is_complete(&value) => return Ok(value),
-            Ok(_) if attempt == LIST_RETRY_ATTEMPTS => {
-                return Err(io::Error::other(incomplete_message).into());
+    let mut attempt = 1;
+    let result = tokio::time::timeout(retry_timeout, async {
+        loop {
+            match operation().await {
+                Ok(value) if is_complete(&value) => return Ok(value),
+                Ok(_) => {
+                    log::warn!(
+                        "List request returned incomplete registry state (attempt {attempt})"
+                    );
+                }
+                Err(error) if is_retryable_list_error(&error) => {
+                    log::warn!(
+                        "List request failed during registry reconciliation (attempt {attempt}): {error}"
+                    );
+                }
+                Err(error) => return Err(error),
             }
-            Ok(_) => {
-                log::warn!(
-                    "List request returned incomplete registry state (attempt {attempt}/{LIST_RETRY_ATTEMPTS})"
-                );
-                tokio::time::sleep(LIST_RETRY_DELAY).await;
-            }
-            Err(error) if attempt < LIST_RETRY_ATTEMPTS && is_retryable_list_error(&error) => {
-                log::warn!(
-                    "List request failed during registry reconciliation (attempt {attempt}/{LIST_RETRY_ATTEMPTS}): {error}"
-                );
-                tokio::time::sleep(LIST_RETRY_DELAY).await;
-            }
-            Err(error) => return Err(error.into()),
+
+            attempt += 1;
+            tokio::time::sleep(LIST_RETRY_DELAY).await;
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(error.into()),
+        Err(_) => {
+            Err(io::Error::other(format!("{incomplete_message} within {retry_timeout:?}")).into())
         }
     }
-    unreachable!("the retry loop always returns on its final attempt")
 }
 
 async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
@@ -242,6 +252,7 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
                     .any(|xid| xid.version_id == second.version_id)
         },
         "created Schema Versions were not listed",
+        LIST_RETRY_TIMEOUT,
     )
     .await?;
 
@@ -249,6 +260,7 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
         || client.list_schemas(GroupSelection::Default, Some(schema_label.clone()), TIMEOUT),
         |schemas| schemas.iter().any(|xid| xid.resource_id == schema_id),
         "labeled Schema was not listed",
+        LIST_RETRY_TIMEOUT,
     )
     .await?;
 
@@ -287,6 +299,7 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
                 .any(|xid| xid.resource_id == thing_description_id)
         },
         "labeled Thing Description was not listed",
+        LIST_RETRY_TIMEOUT,
     )
     .await?;
 
@@ -319,9 +332,31 @@ async fn resource_list_demo(client: &Client) -> Result<(), Box<dyn Error>> {
                 .any(|xid| xid.resource_id == thing_model_id)
         },
         "labeled Thing Model was not listed",
+        LIST_RETRY_TIMEOUT,
     )
     .await?;
 
     log::info!("Listed Thing Description {thing_description_id} and Thing Model {thing_model_id}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_list_stops_at_overall_timeout() {
+        let result = retry_list(
+            || async { Ok::<bool, edge_registry::Error>(false) },
+            |is_complete| *is_complete,
+            "resource was not listed",
+            Duration::from_millis(20),
+        )
+        .await;
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "resource was not listed within 20ms"
+        );
+    }
 }

--- a/rust/azure_iot_operations_services/src/edge_registry/client.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/client.rs
@@ -881,6 +881,37 @@ impl Client {
 
     // ~~~~~~~~~~~~~~~~~ Schema extension APIs ~~~~~~~~~~~~~~~~~~~~~
 
+    /// List the XIDs of the xRegistry Schemas matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Schema Groups to list across: [`All`](GroupSelection::All), the
+    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Schemas carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Schemas matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_schemas(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: SCHEMA_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(SCHEMA_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
+    }
+
     /// Create a new xRegistry Schema Version entity under the specified Schema. The parent Schema is
     /// implicitly created if it doesn't already exist.
     ///
@@ -981,37 +1012,6 @@ impl Client {
             .map_err(ErrorKind::from)?
             .map_err(ErrorKind::from)?;
         Ok(response.payload.into())
-    }
-
-    /// List the XIDs of the xRegistry Schemas matching the provided constraints.
-    ///
-    /// # Arguments
-    /// * `groups` - Which Schema Groups to list across: [`All`](GroupSelection::All), the
-    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
-    ///   [`GroupId`](GroupSelection::GroupId).
-    /// * `label` - If provided, only Schemas carrying this [`Label`] are listed.
-    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
-    ///
-    /// Returns the [`ResourceXId`]s of the Schemas matching the constraints.
-    ///
-    /// # Errors
-    /// See [`Client::list_resources`].
-    pub async fn list_schemas(
-        &self,
-        groups: GroupSelection,
-        label: Option<Label>,
-        timeout: Duration,
-    ) -> Result<Vec<ResourceXId>, Error> {
-        self.list_resources(
-            GroupQuery::GroupType {
-                group_type: SCHEMA_GROUP_TYPE.to_string(),
-                groups,
-            },
-            Some(SCHEMA_RESOURCE_TYPE.to_string()),
-            label,
-            timeout,
-        )
-        .await
     }
 
     /// List the XIDs of the xRegistry Schema Versions matching the provided constraints.
@@ -1125,6 +1125,37 @@ impl Client {
 
     // ~~~~~~~~~~~~~~~~~ Thing Description extension APIs ~~~~~~~~~~~~~~~~~~~~~
 
+    /// List the XIDs of the xRegistry Thing Descriptions matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Thing Description Groups to list across: [`All`](GroupSelection::All),
+    ///   the [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Thing Descriptions carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Thing Descriptions matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_thing_descriptions(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: THING_DESCRIPTION_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(THING_DESCRIPTION_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
+    }
+
     /// Create a new xRegistry Thing Description Version entity under the specified Thing Description. The
     /// parent Thing Description is implicitly created if it doesn't already exist.
     ///
@@ -1225,37 +1256,6 @@ impl Client {
             .map_err(ErrorKind::from)?
             .map_err(ErrorKind::from)?;
         Ok(response.payload.into())
-    }
-
-    /// List the XIDs of the xRegistry Thing Descriptions matching the provided constraints.
-    ///
-    /// # Arguments
-    /// * `groups` - Which Thing Description Groups to list across: [`All`](GroupSelection::All),
-    ///   the [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
-    ///   [`GroupId`](GroupSelection::GroupId).
-    /// * `label` - If provided, only Thing Descriptions carrying this [`Label`] are listed.
-    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
-    ///
-    /// Returns the [`ResourceXId`]s of the Thing Descriptions matching the constraints.
-    ///
-    /// # Errors
-    /// See [`Client::list_resources`].
-    pub async fn list_thing_descriptions(
-        &self,
-        groups: GroupSelection,
-        label: Option<Label>,
-        timeout: Duration,
-    ) -> Result<Vec<ResourceXId>, Error> {
-        self.list_resources(
-            GroupQuery::GroupType {
-                group_type: THING_DESCRIPTION_GROUP_TYPE.to_string(),
-                groups,
-            },
-            Some(THING_DESCRIPTION_RESOURCE_TYPE.to_string()),
-            label,
-            timeout,
-        )
-        .await
     }
 
     /// List the XIDs of xRegistry Thing Description Versions matching the provided constraints.
@@ -1369,6 +1369,37 @@ impl Client {
 
     // ~~~~~~~~~~~~~~~~~ Thing Model extension APIs ~~~~~~~~~~~~~~~~~~~~~
 
+    /// List the XIDs of the xRegistry Thing Models matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Thing Model Groups to list across: [`All`](GroupSelection::All), the
+    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Thing Models carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Thing Models matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_thing_models(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: THING_MODEL_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(THING_MODEL_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
+    }
+
     /// Create a new xRegistry Thing Model Version entity under the specified Thing Model. The parent
     /// Thing Model is implicitly created if it doesn't already exist.
     ///
@@ -1469,37 +1500,6 @@ impl Client {
             .map_err(ErrorKind::from)?
             .map_err(ErrorKind::from)?;
         Ok(response.payload.into())
-    }
-
-    /// List the XIDs of the xRegistry Thing Models matching the provided constraints.
-    ///
-    /// # Arguments
-    /// * `groups` - Which Thing Model Groups to list across: [`All`](GroupSelection::All), the
-    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
-    ///   [`GroupId`](GroupSelection::GroupId).
-    /// * `label` - If provided, only Thing Models carrying this [`Label`] are listed.
-    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
-    ///
-    /// Returns the [`ResourceXId`]s of the Thing Models matching the constraints.
-    ///
-    /// # Errors
-    /// See [`Client::list_resources`].
-    pub async fn list_thing_models(
-        &self,
-        groups: GroupSelection,
-        label: Option<Label>,
-        timeout: Duration,
-    ) -> Result<Vec<ResourceXId>, Error> {
-        self.list_resources(
-            GroupQuery::GroupType {
-                group_type: THING_MODEL_GROUP_TYPE.to_string(),
-                groups,
-            },
-            Some(THING_MODEL_RESOURCE_TYPE.to_string()),
-            label,
-            timeout,
-        )
-        .await
     }
 
     /// List the XIDs of xRegistry Thing Model Versions matching the provided constraints.

--- a/rust/azure_iot_operations_services/src/edge_registry/client.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/client.rs
@@ -983,6 +983,37 @@ impl Client {
         Ok(response.payload.into())
     }
 
+    /// List the XIDs of the xRegistry Schemas matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Schema Groups to list across: [`All`](GroupSelection::All), the
+    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Schemas carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Schemas matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_schemas(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: SCHEMA_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(SCHEMA_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
+    }
+
     /// List the XIDs of the xRegistry Schema Versions matching the provided constraints.
     ///
     /// # Arguments
@@ -1196,6 +1227,37 @@ impl Client {
         Ok(response.payload.into())
     }
 
+    /// List the XIDs of the xRegistry Thing Descriptions matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Thing Description Groups to list across: [`All`](GroupSelection::All),
+    ///   the [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Thing Descriptions carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Thing Descriptions matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_thing_descriptions(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: THING_DESCRIPTION_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(THING_DESCRIPTION_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
+    }
+
     /// List the XIDs of xRegistry Thing Description Versions matching the provided constraints.
     ///
     /// # Arguments
@@ -1407,6 +1469,37 @@ impl Client {
             .map_err(ErrorKind::from)?
             .map_err(ErrorKind::from)?;
         Ok(response.payload.into())
+    }
+
+    /// List the XIDs of the xRegistry Thing Models matching the provided constraints.
+    ///
+    /// # Arguments
+    /// * `groups` - Which Thing Model Groups to list across: [`All`](GroupSelection::All), the
+    ///   [`Default`](GroupSelection::Default) (cloud default) Group, or a specific
+    ///   [`GroupId`](GroupSelection::GroupId).
+    /// * `label` - If provided, only Thing Models carrying this [`Label`] are listed.
+    /// * `timeout` - The duration until the client stops waiting for a response to the request, it is rounded up to the nearest second.
+    ///
+    /// Returns the [`ResourceXId`]s of the Thing Models matching the constraints.
+    ///
+    /// # Errors
+    /// See [`Client::list_resources`].
+    pub async fn list_thing_models(
+        &self,
+        groups: GroupSelection,
+        label: Option<Label>,
+        timeout: Duration,
+    ) -> Result<Vec<ResourceXId>, Error> {
+        self.list_resources(
+            GroupQuery::GroupType {
+                group_type: THING_MODEL_GROUP_TYPE.to_string(),
+                groups,
+            },
+            Some(THING_MODEL_RESOURCE_TYPE.to_string()),
+            label,
+            timeout,
+        )
+        .await
     }
 
     /// List the XIDs of xRegistry Thing Model Versions matching the provided constraints.


### PR DESCRIPTION
Add typed Edge Registry APIs for listing schemas, thing descriptions, and thing models in the Rust and .NET SDKs.


## Changes

- Add `list_schemas` / `ListSchemasAsync`.
- Add `list_thing_descriptions` / `ListThingDescriptionsAsync`.
- Add `list_thing_models` / `ListThingModelsAsync`.
- Support default, all, and specific group selection.
- Support resource label filtering.
- Add .NET integration coverage for the new APIs.
- Add a Rust Edge Registry example with retry handling for eventual consistency.

## Testing

### Local integration

- Ran the Rust SDK sample against a local MQTT broker and Edge Registry test host.
- Ran three .NET Edge Registry integration tests against the same host.
- Built and tested TinyKube and Azure-NBC using local SDK path dependencies.

### Standalone WASM end-to-end test