### PR TITLE
[Rust][Services][Connector][EdgeRegistry] Move Connector SDK to be able to report schemas through Edge Registry

### DIFF
--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -31,6 +31,7 @@ tokio-retry2 = { version = "0.5.7", features = ["jitter"] }
 tokio-util.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 env_logger.workspace = true
 temp-env = { workspace = true, features = ["async_closure"] }
 tempfile.workspace = true

--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -14,7 +14,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "schema_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "edge_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 chrono = { workspace = true, features = ["clock"] }
 derive_builder.workspace = true

--- a/rust/azure_iot_operations_connector/Cargo.toml
+++ b/rust/azure_iot_operations_connector/Cargo.toml
@@ -14,7 +14,7 @@ publish = true
 
 [dependencies]
 azure_iot_operations_protocol = { version = "1.0", path = "../azure_iot_operations_protocol" }
-azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "edge_registry", "azure_device_registry"]  }
+azure_iot_operations_services = { version = "1.4.0-beta2", path = "../azure_iot_operations_services", features = ["state_store", "edge_registry", "schema_registry", "azure_device_registry"]  }
 azure_iot_operations_mqtt = { version = "1.1", path = "../azure_iot_operations_mqtt" }
 chrono = { workspace = true, features = ["clock"] }
 derive_builder.workspace = true

--- a/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
+++ b/rust/azure_iot_operations_connector/examples/base_connector_sample.rs
@@ -392,10 +392,10 @@ async fn run_dataset(
                 let sample_data = mock_received_data(count);
 
                 let current_message_schema =
-                    derived_json::create_schema(&sample_data).ok();
+                    derived_json::create_xregistry_schema(&sample_data, data_operation_client.data_operation_ref()).ok();
                 // Report schema only if there isn't already one
                 match data_operation_client
-                    .report_message_schema_if_modified(|current_schema_reference| {
+                    .report_xregistry_message_schema_if_modified(|current_schema_reference| {
                         // Only report schema if there isn't already one, or if schema has changed
                         if local_schema_reference.is_none()
                             || current_schema_reference.is_none()

--- a/rust/azure_iot_operations_connector/src/base_connector.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector.rs
@@ -12,7 +12,7 @@ use azure_iot_operations_mqtt::session::{
 use azure_iot_operations_protocol::application::ApplicationContext;
 use azure_iot_operations_services::{
     azure_device_registry::{self, health_reporter::ReportInterval},
-    schema_registry, state_store,
+    edge_registry, schema_registry, state_store,
 };
 use derive_builder::Builder;
 use managed_azure_device_registry::DeviceEndpointClientCreationObservation;
@@ -50,6 +50,8 @@ pub(crate) struct ConnectorContext {
     debounce_duration: Duration,
     /// Timeout for Azure Device Registry operations
     pub(crate) azure_device_registry_timeout: Duration,
+    /// Timeout for Edge Registry operations
+    pub(crate) edge_registry_timeout: Duration,
     /// Timeout for Schema Registry operations
     pub(crate) schema_registry_timeout: Duration,
     /// Timeout for State Store operations
@@ -60,6 +62,7 @@ pub(crate) struct ConnectorContext {
     azure_device_registry_client: azure_device_registry::Client,
     pub(crate) state_store_client: Arc<state_store::Client>,
     schema_registry_client: schema_registry::Client,
+    edge_registry_client: edge_registry::Client,
     /// Channel for signaling that the connector requires a restart
     pub(crate) connector_restart_tx: mpsc::Sender<String>,
 }
@@ -87,6 +90,9 @@ pub struct Options {
     /// Timeout for Azure Device Registry operations
     #[builder(default = "Duration::from_secs(10)")]
     azure_device_registry_timeout: Duration,
+    /// Timeout for Edge Registry operations
+    #[builder(default = "Duration::from_secs(30)")]
+    edge_registry_timeout: Duration,
     // NOTE (2025-09-12): Schema Registry has an issue with scale causing throttling,
     // so this value has been set very high. This is probably not ideal.
     /// Timeout for Schema Registry operations
@@ -156,7 +162,13 @@ impl BaseConnector {
         )
         .map_err(|e| e.to_string())?;
 
-        // Create Schema Registry Client
+        // Create Edge Registry Client
+        let edge_registry_client = edge_registry::Client::new(
+            application_context.clone(),
+            &session.create_managed_client(),
+        );
+
+        // Create legacy Schema Registry Client
         let schema_registry_client = schema_registry::Client::new(
             application_context.clone(),
             &session.create_managed_client(),
@@ -177,6 +189,7 @@ impl BaseConnector {
             connector_context: Arc::new(ConnectorContext {
                 debounce_duration: base_connector_options.filemount_debounce_duration,
                 azure_device_registry_timeout: base_connector_options.azure_device_registry_timeout,
+                edge_registry_timeout: base_connector_options.edge_registry_timeout,
                 schema_registry_timeout: base_connector_options.schema_registry_timeout,
                 state_store_timeout: base_connector_options.state_store_timeout,
                 health_report_interval: base_connector_options.health_report_interval,
@@ -185,6 +198,7 @@ impl BaseConnector {
                 connector_artifacts,
                 azure_device_registry_client,
                 schema_registry_client,
+                edge_registry_client,
                 state_store_client: Arc::new(state_store_client),
                 connector_restart_tx,
             }),

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -2932,7 +2932,7 @@ impl DataOperationClient {
     /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
     ///
     /// # Errors
-    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ValidationError`](edge_registry::ErrorKind::ValidationError)
     /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
     ///
     /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)
@@ -4130,7 +4130,7 @@ impl ManagementActionClient {
     /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
     ///
     /// # Errors
-    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ValidationError`](edge_registry::ErrorKind::ValidationError)
     /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
     ///
     /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)
@@ -4173,7 +4173,7 @@ impl ManagementActionClient {
     /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
     ///
     /// # Errors
-    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ValidationError`](edge_registry::ErrorKind::ValidationError)
     /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
     ///
     /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)

--- a/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
+++ b/rust/azure_iot_operations_connector/src/base_connector/managed_azure_device_registry.rs
@@ -17,6 +17,7 @@ use azure_iot_operations_services::{
         health_reporter::HealthReporterSender,
         models::{self as adr_models, Asset, DeviceRef},
     },
+    edge_registry::{self, models::VersionXId},
     schema_registry,
 };
 use chrono::{DateTime, Utc};
@@ -31,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     AdrConfigError, Data, DataOperationKind, DataOperationName, DataOperationRef,
-    ManagementActionRef, MessageSchema, MessageSchemaReference,
+    ManagementActionRef, MessageSchema, MessageSchemaReference, XRegistryMessageSchema,
     base_connector::ConnectorContext,
     deployment_artifacts::{
         self,
@@ -2152,12 +2153,23 @@ pub enum AssetComponentClient {
     ),
 }
 
-/// Errors that can be returned when reporting a message schema for an asset component
+/// Errors that can be returned when reporting a message schema to the Schema Registry for an asset component
 #[derive(Error, Debug)]
 pub enum MessageSchemaError {
     /// An error occurred while putting the Schema in the Schema Registry
     #[error(transparent)]
     PutSchemaError(#[from] schema_registry::Error),
+    /// An error occurred while reporting the Schema to the Azure Device Registry Service.
+    #[error(transparent)]
+    AzureDeviceRegistryError(#[from] azure_device_registry::Error),
+}
+
+/// Errors that can be returned when reporting a message schema to the edge registry for an asset component
+#[derive(Error, Debug)]
+pub enum XRegistryMessageSchemaError {
+    /// An error occurred while putting the Schema in the Edge Registry
+    #[error(transparent)]
+    CreateSchemaError(#[from] edge_registry::Error),
     /// An error occurred while reporting the Schema to the Azure Device Registry Service.
     #[error(transparent)]
     AzureDeviceRegistryError(#[from] azure_device_registry::Error),
@@ -2867,7 +2879,10 @@ impl DataOperationClient {
         Ok(SchemaModifyResult::Reported(new_message_schema_reference))
     }
 
-    /// Used to conditionally report the message schema of a data operation
+    /// Used to conditionally report the message schema of a data operation to the Schema Registry and Azure Device Registry.
+    ///
+    /// NOTE: If your deployment of AIO has the Edge Registry Service, `report_xregistry_message_schema_if_modified`
+    /// should be used instead.
     ///
     /// The `modify` function is called with the current message schema reference (if any) and should return:
     /// - `Some(new_message_schema)` if the schema should be updated and reported
@@ -2901,6 +2916,59 @@ impl DataOperationClient {
     ) -> Result<SchemaModifyResult, MessageSchemaError>
     where
         F: Fn(Option<&MessageSchemaReference>) -> Option<MessageSchema>,
+    {
+        self.internal_report_message_schema_if_modified(modify, Self::put_message_schema)
+            .await
+    }
+
+    /// Used to conditionally report the message schema of a data operation to the Edge Registry and Azure Device Registry.
+    ///
+    /// The `modify` function is called with the current message schema reference (if any) and should return:
+    /// - `Some(new_xregistry_message_schema)` if the schema should be updated and reported
+    /// - `None` if no update is needed
+    ///
+    /// # Returns
+    /// - [`SchemaModifyResult::Reported`] if the schema was updated and successfully reported, containing the reported [`MessageSchemaReference`]
+    /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
+    ///
+    /// # Errors
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)
+    /// if there is an error returned by the Edge Registry Service. This error will be retried 10
+    /// times with exponential backoff and jitter if it is an internal error and only returned if
+    /// it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if
+    /// there are any underlying errors from the AIO RPC protocol. This error will be retried
+    /// 10 times with exponential backoff and jitter and only returned if it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::ServiceError`](azure_device_registry::ErrorKind::ServiceError) if
+    /// an error is returned by the Azure Device Registry service.
+    ///
+    /// # Panics
+    /// If the asset specification mutex has been poisoned, which should not be possible
+    pub async fn report_xregistry_message_schema_if_modified<F>(
+        &mut self,
+        modify: F,
+    ) -> Result<SchemaModifyResult, XRegistryMessageSchemaError>
+    where
+        F: Fn(Option<&MessageSchemaReference>) -> Option<XRegistryMessageSchema>,
+    {
+        self.internal_report_message_schema_if_modified(modify, Self::put_xregistry_message_schema)
+            .await
+    }
+
+    async fn internal_report_message_schema_if_modified<F, RegF, RegErr, MS, MSErr>(
+        &mut self,
+        modify: F,
+        put_schema: RegF,
+    ) -> Result<SchemaModifyResult, MSErr>
+    where
+        F: Fn(Option<&MessageSchemaReference>) -> Option<MS>,
+        RegF: AsyncFn(&Self, &MS) -> Result<MessageSchemaReference, RegErr>,
+        MSErr: From<RegErr> + From<azure_device_registry::Error>,
     {
         // Get the current version of the asset specification
         let cached_version = self.asset_specification.read().unwrap().version;
@@ -2964,7 +3032,28 @@ impl DataOperationClient {
         };
 
         // First put the schema in the schema registry
-        let message_schema_reference = Retry::spawn(
+        let message_schema_reference = put_schema(self, &new_message_schema).await?;
+
+        Self::internal_report_message_schema_reference(
+            &self.connector_context,
+            &self.asset_ref,
+            &self.data_operation_ref,
+            &mut self.forwarder,
+            asset_status_to_report,
+            &mut status_write_guard,
+            &message_schema_reference,
+            "DataOperationClient::report_message_schema_if_modified",
+        )
+        .await?;
+
+        Ok(SchemaModifyResult::Reported(message_schema_reference))
+    }
+
+    async fn put_message_schema(
+        &self,
+        new_message_schema: &MessageSchema,
+    ) -> Result<MessageSchemaReference, schema_registry::Error> {
+        Retry::spawn(
             RETRY_STRATEGY.map(tokio_retry2::strategy::jitter),
             async || -> Result<schema_registry::Schema, RetryError<schema_registry::Error>> {
                 self.connector_context
@@ -3010,21 +3099,65 @@ impl DataOperationClient {
             name: schema.name,
             version: schema.version,
             registry_namespace: schema.namespace,
-        })?;
+        })
+    }
 
-        Self::internal_report_message_schema_reference(
-            &self.connector_context,
-            &self.asset_ref,
-            &self.data_operation_ref,
-            &mut self.forwarder,
-            asset_status_to_report,
-            &mut status_write_guard,
-            &message_schema_reference,
-            "DataOperationClient::report_message_schema_if_modified",
+    async fn put_xregistry_message_schema(
+        &self,
+        new_message_schema: &XRegistryMessageSchema,
+    ) -> Result<MessageSchemaReference, edge_registry::Error> {
+        let schema_version_entity = Retry::spawn(
+            RETRY_STRATEGY.map(tokio_retry2::strategy::jitter),
+            async || -> Result<edge_registry::models::SchemaVersionEntity, RetryError<edge_registry::Error>> {
+                self.connector_context
+                    .edge_registry_client
+                    .create_schema_version(
+                        new_message_schema.group_id.clone(),
+                        new_message_schema.schema_id.clone(),
+                        new_message_schema.schema_labels.clone(),
+                        new_message_schema.version.clone(),
+                        self.connector_context.edge_registry_timeout,
+                    )
+                    .await
+                    .map_err(|e| {
+                        match e.kind() {
+                            // network/retriable
+                            edge_registry::ErrorKind::AIOProtocolError(_) => {
+                                log::warn!(
+                                    "Reporting message schema failed for {:?}. Retrying: {e}",
+                                    self.data_operation_ref
+                                );
+                                RetryError::transient(e)
+                            }
+                            edge_registry::ErrorKind::ServiceError(service_error) => {
+                                if let 500 =
+                                    service_error.code
+                                {
+                                    log::warn!(
+                                        "Reporting message schema failed for {:?}. Retrying: {e}",
+                                        self.data_operation_ref
+                                    );
+                                    RetryError::transient(e)
+                                } else {
+                                    RetryError::permanent(e)
+                                }
+                            }
+                            // indicates an error in the provided message schema or an unknown error, return to caller so they can fix
+                            // edge_registry::ErrorKind::ValidationError(_) |
+                            _ => {
+                                RetryError::permanent(e)
+                            }
+                        }
+                    })
+            },
         )
         .await?;
-
-        Ok(SchemaModifyResult::Reported(message_schema_reference))
+        Ok(MessageSchemaReference {
+            name: schema_version_entity.resource_id,
+            version: schema_version_entity.version_id.to_string(),
+            registry_namespace: VersionXId::<String>::try_from(schema_version_entity.xid.as_str())?
+                .group_id,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3037,7 +3170,7 @@ impl DataOperationClient {
         status_write_guard: &mut adr_models::AssetStatus,
         message_schema_reference: &MessageSchemaReference,
         log_identifier: &str,
-    ) -> Result<(), MessageSchemaError> {
+    ) -> Result<(), azure_device_registry::Error> {
         // Use the provided asset_status_to_report instead of creating a new one
         let mut new_status = asset_status_to_report;
 
@@ -3894,7 +4027,10 @@ impl ManagementActionClient {
             .await
     }
 
-    /// Used to conditionally report the request message schema of a management action
+    /// Used to conditionally report the request message schema of a management action to the Schema Registry and Azure Device Registry.
+    ///
+    /// NOTE: If your deployment of AIO has the Edge Registry Service, `report_request_xregistry_message_schema_if_modified`
+    /// should be used instead.
     ///
     /// The `modify` function is called with the current message schema reference (if any) and should return:
     /// - `Some(new_message_schema)` if the schema should be updated and reported
@@ -3929,11 +4065,18 @@ impl ManagementActionClient {
     where
         F: Fn(Option<&MessageSchemaReference>) -> Option<MessageSchema>,
     {
-        self.report_message_schema_if_modified(ActionSchema::Request, modify)
-            .await
+        self.report_message_schema_if_modified(
+            ActionSchema::Request,
+            modify,
+            Self::put_message_schema,
+        )
+        .await
     }
 
-    /// Used to conditionally report the response message schema of a management action
+    /// Used to conditionally report the response message schema of a management action to the Schema Registry and Azure Device Registry.
+    ///
+    /// NOTE: If your deployment of AIO has the Edge Registry Service, `report_response_xregistry_message_schema_if_modified`
+    /// should be used instead.
     ///
     /// The `modify` function is called with the current message schema reference (if any) and should return:
     /// - `Some(new_message_schema)` if the schema should be updated and reported
@@ -3968,8 +4111,98 @@ impl ManagementActionClient {
     where
         F: Fn(Option<&MessageSchemaReference>) -> Option<MessageSchema>,
     {
-        self.report_message_schema_if_modified(ActionSchema::Response, modify)
-            .await
+        self.report_message_schema_if_modified(
+            ActionSchema::Response,
+            modify,
+            Self::put_message_schema,
+        )
+        .await
+    }
+
+    /// Used to conditionally report the request message schema of a management action to the Edge Registry and Azure Device Registry.
+    ///
+    /// The `modify` function is called with the current message schema reference (if any) and should return:
+    /// - `Some(new_xregistry_message_schema)` if the schema should be updated and reported
+    /// - `None` if no update is needed
+    ///
+    /// # Returns
+    /// - [`SchemaModifyResult::Reported`] if the schema was updated and successfully reported, containing the reported [`MessageSchemaReference`]
+    /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
+    ///
+    /// # Errors
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)
+    /// if there is an error returned by the Edge Registry Service. This error will be retried 10
+    /// times with exponential backoff and jitter if it is an internal error and only returned if
+    /// it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if
+    /// there are any underlying errors from the AIO RPC protocol. This error will be retried
+    /// 10 times with exponential backoff and jitter and only returned if it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::ServiceError`](azure_device_registry::ErrorKind::ServiceError) if
+    /// an error is returned by the Azure Device Registry service.
+    ///
+    /// # Panics
+    /// If the asset specification mutex has been poisoned, which should not be possible
+    pub async fn report_request_xregistry_message_schema_if_modified<F>(
+        &mut self,
+        modify: F,
+    ) -> Result<SchemaModifyResult, XRegistryMessageSchemaError>
+    where
+        F: Fn(Option<&MessageSchemaReference>) -> Option<XRegistryMessageSchema>,
+    {
+        self.report_message_schema_if_modified(
+            ActionSchema::Request,
+            modify,
+            Self::put_xregistry_message_schema,
+        )
+        .await
+    }
+
+    /// Used to conditionally report the response message schema of a management action to the Edge Registry and Azure Device Registry.
+    ///
+    /// The `modify` function is called with the current message schema reference (if any) and should return:
+    /// - `Some(new_xregistry_message_schema)` if the schema should be updated and reported
+    /// - `None` if no update is needed
+    ///
+    /// # Returns
+    /// - [`SchemaModifyResult::Reported`] if the schema was updated and successfully reported, containing the reported [`MessageSchemaReference`]
+    /// - [`SchemaModifyResult::NotModified`] if no modification was needed or the version changed during processing
+    ///
+    /// # Errors
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::InvalidRequestArgument`](edge_registry::ErrorKind::ValidationError)
+    /// if the document of the [`XRegistryMessageSchema`] is empty or there is an error building the request
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`EdgeRegistryError::ServiceError`](edge_registry::ErrorKind::ServiceError)
+    /// if there is an error returned by the Edge Registry Service. This error will be retried 10
+    /// times with exponential backoff and jitter if it is an internal error and only returned if
+    /// it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::AIOProtocolError`](azure_device_registry::ErrorKind::AIOProtocolError) if
+    /// there are any underlying errors from the AIO RPC protocol. This error will be retried
+    /// 10 times with exponential backoff and jitter and only returned if it still is failing.
+    ///
+    /// [`XRegistryMessageSchemaError`] of kind [`AzureDeviceRegistryError::ServiceError`](azure_device_registry::ErrorKind::ServiceError) if
+    /// an error is returned by the Azure Device Registry service.
+    ///
+    /// # Panics
+    /// If the asset specification mutex has been poisoned, which should not be possible
+    pub async fn report_response_xregistry_message_schema_if_modified<F>(
+        &mut self,
+        modify: F,
+    ) -> Result<SchemaModifyResult, XRegistryMessageSchemaError>
+    where
+        F: Fn(Option<&MessageSchemaReference>) -> Option<XRegistryMessageSchema>,
+    {
+        self.report_message_schema_if_modified(
+            ActionSchema::Response,
+            modify,
+            Self::put_xregistry_message_schema,
+        )
+        .await
     }
 
     /// Used to receive notifications about the Management Action from the Azure Device Registry Service.
@@ -4354,13 +4587,16 @@ impl ManagementActionClient {
         Ok(SchemaModifyResult::Reported(new_message_schema_reference))
     }
 
-    async fn report_message_schema_if_modified<F>(
+    async fn report_message_schema_if_modified<F, RegF, RegErr, MS, MSErr>(
         &mut self,
         schema_side: ActionSchema,
         modify: F,
-    ) -> Result<SchemaModifyResult, MessageSchemaError>
+        put_schema: RegF,
+    ) -> Result<SchemaModifyResult, MSErr>
     where
-        F: Fn(Option<&MessageSchemaReference>) -> Option<MessageSchema>,
+        F: Fn(Option<&MessageSchemaReference>) -> Option<MS>,
+        RegF: AsyncFn(&Self, &ActionSchema, &MS) -> Result<MessageSchemaReference, RegErr>,
+        MSErr: From<RegErr> + From<azure_device_registry::Error>,
     {
         // Get the current version of the asset specification
         let cached_version = self.asset_specification.read().unwrap().version;
@@ -4426,7 +4662,30 @@ impl ManagementActionClient {
         };
 
         // First put the schema in the schema registry
-        let message_schema_reference = Retry::spawn(
+        let message_schema_reference = put_schema(self, &schema_side, &new_message_schema).await?;
+
+        Self::internal_report_message_schema_reference(
+            &self.connector_context,
+            &self.asset_ref,
+            &self.management_action_ref,
+            // &mut self.forwarder,
+            asset_status_to_report,
+            &mut status_write_guard,
+            &message_schema_reference,
+            &schema_side,
+            &format!("ManagementActionClient::report_{schema_side:?}_message_schema_if_modified"),
+        )
+        .await?;
+
+        Ok(SchemaModifyResult::Reported(message_schema_reference))
+    }
+
+    async fn put_message_schema(
+        &self,
+        schema_side: &ActionSchema,
+        new_message_schema: &MessageSchema,
+    ) -> Result<MessageSchemaReference, schema_registry::Error> {
+        Retry::spawn(
             RETRY_STRATEGY.map(tokio_retry2::strategy::jitter),
             async || -> Result<schema_registry::Schema, RetryError<schema_registry::Error>> {
                 self.connector_context
@@ -4472,22 +4731,66 @@ impl ManagementActionClient {
             name: schema.name,
             version: schema.version,
             registry_namespace: schema.namespace,
-        })?;
+        })
+    }
 
-        Self::internal_report_message_schema_reference(
-            &self.connector_context,
-            &self.asset_ref,
-            &self.management_action_ref,
-            // &mut self.forwarder,
-            asset_status_to_report,
-            &mut status_write_guard,
-            &message_schema_reference,
-            &schema_side,
-            &format!("ManagementActionClient::report_{schema_side:?}_message_schema_if_modified"),
+    async fn put_xregistry_message_schema(
+        &self,
+        schema_side: &ActionSchema,
+        new_message_schema: &XRegistryMessageSchema,
+    ) -> Result<MessageSchemaReference, edge_registry::Error> {
+        let schema_version_entity = Retry::spawn(
+            RETRY_STRATEGY.map(tokio_retry2::strategy::jitter),
+            async || -> Result<edge_registry::models::SchemaVersionEntity, RetryError<edge_registry::Error>> {
+                self.connector_context
+                    .edge_registry_client
+                    .create_schema_version(
+                        new_message_schema.group_id.clone(),
+                        new_message_schema.schema_id.clone(),
+                        new_message_schema.schema_labels.clone(),
+                        new_message_schema.version.clone(),
+                        self.connector_context.edge_registry_timeout,
+                    )
+                    .await
+                    .map_err(|e| {
+                        match e.kind() {
+                            // network/retriable
+                            edge_registry::ErrorKind::AIOProtocolError(_) => {
+                                log::warn!(
+                                    "Reporting {schema_side:?} message schema failed for {:?}. Retrying: {e}",
+                                    self.management_action_ref
+                                );
+                                RetryError::transient(e)
+                            }
+                            edge_registry::ErrorKind::ServiceError(service_error) => {
+                                if let 500 =
+                                    service_error.code
+                                {
+                                    log::warn!(
+                                        "Reporting {schema_side:?} message schema failed for {:?}. Retrying: {e}",
+                                        self.management_action_ref
+                                    );
+                                    RetryError::transient(e)
+                                } else {
+                                    RetryError::permanent(e)
+                                }
+                            }
+                            // indicates an error in the provided message schema or an unknown error, return to caller so they can fix
+                            // edge_registry::ErrorKind::ValidationError(_) |
+                            _ => {
+                                RetryError::permanent(e)
+                            }
+                        }
+                    })
+            },
         )
         .await?;
-
-        Ok(SchemaModifyResult::Reported(message_schema_reference))
+        Ok(MessageSchemaReference {
+            name: schema_version_entity.resource_id,
+            version: schema_version_entity.version_id.to_string(),
+            registry_namespace: VersionXId::<String>::try_from(schema_version_entity.xid.as_str())?
+                .group_id,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4500,7 +4803,7 @@ impl ManagementActionClient {
         message_schema_reference: &MessageSchemaReference,
         schema_side: &ActionSchema,
         log_identifier: &str,
-    ) -> Result<(), MessageSchemaError> {
+    ) -> Result<(), azure_device_registry::Error> {
         // Use the provided asset_status_to_report instead of creating a new one
         let mut new_status = asset_status_to_report;
 

--- a/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
+++ b/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
@@ -99,6 +99,10 @@ fn create_output_schema(data: &Data) -> Result<MessageSchema, SchemaGenerationEr
 ///
 /// # Errors
 /// Returns a [`XRegistrySchemaGenerationError`] if there is an error during the transformation or schema generation.
+///
+/// # Panics
+/// Panics if the schema id generated from `default_schema_id` is an empty string. Not possible because this at minimum
+/// returns `:::`
 pub fn create_xregistry_schema(
     data: &Data,
     data_operation_ref: &DataOperationRef,
@@ -128,7 +132,7 @@ pub fn create_xregistry_schema(
 ///   information is available to derive the type of the field.
 ///
 /// # Errors
-/// Returns a [`SchemaGenerationError`] if there is an error during the transformation or schema generation.
+/// Returns a [`XRegistrySchemaGenerationError`] if there is an error during the transformation or schema generation.
 pub fn create_schema_version_attributes(
     data: &Data,
 ) -> Result<SchemaVersionAttributes, XRegistrySchemaGenerationError> {

--- a/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
+++ b/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
@@ -182,6 +182,9 @@ fn create_output_schema_string(data: &Data) -> Result<String, serde_json::Error>
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::DataOperationName;
+    use azure_iot_operations_services::edge_registry::Label;
+    use bytes::Bytes;
     use test_case::test_case;
 
     struct SchemaGenerationTestCase {
@@ -376,5 +379,136 @@ mod test {
 
         let r = create_schema(&input_data);
         assert!(r.is_err());
+    }
+
+    fn data_operation_ref() -> DataOperationRef {
+        DataOperationRef {
+            data_operation_name: DataOperationName::Dataset {
+                name: "test_data_operation_name".to_string(),
+            },
+            asset_name: "test_asset_name".to_string(),
+            device_name: "test_device_name".to_string(),
+            inbound_endpoint_name: "test_inbound_endpoint_name".to_string(),
+        }
+    }
+
+    /// Helper function to compare two `SchemaVersionAttributes` structs for equality.
+    /// This is necessary over the PartialEq/Eq trait because when using JSON, we can
+    /// end up with different ordering of the keys in the JSON object, which prevents
+    /// us from being able to make accurate comparisons of the `content` field.
+    fn schema_version_attributes_eq(
+        schema1: &SchemaVersionAttributes,
+        schema2: &SchemaVersionAttributes,
+    ) -> bool {
+        // Make new structs with the content set to empty strings to normalize our SchemaVersionAttributes
+        // under comparison since we can't directly compare the content accurately.
+        let schema1_no_content = SchemaVersionAttributes {
+            document: Bytes::new(),
+            ..schema1.clone()
+        };
+        let schema2_no_content = SchemaVersionAttributes {
+            document: Bytes::new(),
+            ..schema2.clone()
+        };
+
+        // Compare the content of the schemas
+        let schema1_json_content: Value = serde_json::from_slice(&schema1.document).unwrap();
+        let schema2_json_content: Value = serde_json::from_slice(&schema2.document).unwrap();
+
+        schema1_no_content == schema2_no_content && schema1_json_content == schema2_json_content
+    }
+
+    /// Helper function to compare two `XRegistryMessageSchema` structs for equality.
+    /// This is necessary over the PartialEq/Eq trait because when using JSON, we can
+    /// end up with different ordering of the keys in the JSON object, which prevents
+    /// us from being able to make accurate comparisons of the `content` field.
+    fn xregistry_message_schema_eq(
+        schema1: &XRegistryMessageSchema,
+        schema2: &XRegistryMessageSchema,
+    ) -> bool {
+        if !schema_version_attributes_eq(&schema1.version, &schema2.version) {
+            return false;
+        }
+        assert_eq!(schema1.group_id, schema2.group_id);
+        assert_eq!(schema1.schema_id, schema2.schema_id);
+        assert_eq!(schema1.schema_labels, schema2.schema_labels);
+
+        true
+    }
+
+    // /// Helper function to compare two raw schemas for equality.
+    // /// This is necessary over the PartialEq/Eq trait because when using JSON, we can
+    // /// end up with different ordering of the keys in the JSON object, which prevents
+    // /// us from being able to make accurate comparisons of the `content` field.
+    // fn output_schema_eq(schema1: &str, schema2: &str) -> bool {
+    //     // Compare the content of the schemas
+    //     let schema1_json_content: Value = serde_json::from_str(schema1).unwrap();
+    //     let schema2_json_content: Value = serde_json::from_str(schema2).unwrap();
+
+    //     schema1_json_content == schema2_json_content
+    // }
+
+    #[test_case(&valid_testcase_1(); "1:1 transformation")]
+    #[test_case(&valid_testcase_3(); "Overlapping transformation")]
+    fn valid_create_xregistry_schema(test_case: &SchemaGenerationTestCase) {
+        let input_data = Data {
+            payload: serde_json::to_vec(&test_case.input_json).unwrap(),
+            content_type: "application/json".to_string(),
+            custom_user_data: vec![],
+            timestamp: None,
+        };
+
+        // We expect the output message schema to contain the expected output JSON schema
+        // and have the correct format and schema type
+        let expected_schema_version_attributes = SchemaVersionAttributesBuilder::default()
+            .document(
+                serde_json::to_string(&test_case.expected_output_json_schema)
+                    .unwrap()
+                    .into(),
+            )
+            .format(SchemaFormat::JsonSchemaDraft07)
+            .build()
+            .unwrap();
+        let expected_output_message_schema = XRegistryMessageSchemaBuilder::default()
+            .version(expected_schema_version_attributes.clone())
+            .schema_id("10f3506100271610521098abccf13ad4e9dfd15e8dd17f9a9ade247863a65d74".to_string())
+            .schema_labels(vec![Label {
+                key: "originalid".to_string(),
+                value: "test_device_name:test_inbound_endpoint_name:test_asset_name:dataset:test_data_operation_name".to_string(),
+            }])
+            .build()
+            .unwrap();
+
+        let output_schema_version_attributes =
+            create_schema_version_attributes(&input_data).unwrap();
+        let output_message_schema =
+            create_xregistry_schema(&input_data, &data_operation_ref()).unwrap();
+
+        assert!(schema_version_attributes_eq(
+            &output_schema_version_attributes,
+            &expected_schema_version_attributes
+        ));
+
+        assert!(xregistry_message_schema_eq(
+            &output_message_schema,
+            &expected_output_message_schema
+        ));
+    }
+
+    #[test_case("not json".as_bytes(); "Not JSON")]
+    #[test_case(&[0x9c, 0xe5, 0x78]; "Not UTF8")]
+    fn invalid_xregistry_data_payload(invalid_payload: &[u8]) {
+        let input_data = Data {
+            payload: invalid_payload.into(),
+            content_type: "application/json".to_string(),
+            custom_user_data: vec![],
+            timestamp: None,
+        };
+
+        let r = create_schema_version_attributes(&input_data);
+        assert!(r.is_err());
+
+        let r2 = create_xregistry_schema(&input_data, &data_operation_ref());
+        assert!(r2.is_err());
     }
 }

--- a/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
+++ b/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
@@ -3,10 +3,18 @@
 
 //! Processor for generating [`MessageSchema`] for the JSON payload defined in a [`Data`].
 
+use azure_iot_operations_services::edge_registry::models::{
+    SchemaFormat, SchemaVersionAttributes, SchemaVersionAttributesBuilder,
+    SchemaVersionAttributesBuilderError,
+};
 use azure_iot_operations_services::schema_registry::{Format, SchemaType};
 use serde_json::{self, Value};
 
-use crate::{Data, MessageSchema, MessageSchemaBuilder, MessageSchemaBuilderError};
+use crate::{
+    Data, DataOperationRef, MessageSchema, MessageSchemaBuilder, MessageSchemaBuilderError,
+    XRegistryMessageSchema, XRegistryMessageSchemaBuilder, XRegistryMessageSchemaBuilderError,
+    default_schema_id,
+};
 
 /// An error that occurred during the schema generation of data.
 #[derive(Debug, thiserror::Error)]
@@ -25,6 +33,24 @@ enum SchemaGenerationErrorRepr {
     Schema(#[from] MessageSchemaBuilderError),
 }
 
+/// An error that occurred during the schema generation of data.
+#[derive(Debug, thiserror::Error)]
+#[error("{repr}")]
+pub struct XRegistrySchemaGenerationError {
+    #[source]
+    repr: XRegistrySchemaGenerationErrorRepr,
+}
+
+/// Inner representation of a [`XRegistrySchemaGenerationError`].
+#[derive(Debug, thiserror::Error)]
+enum XRegistrySchemaGenerationErrorRepr {
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Schema(#[from] SchemaVersionAttributesBuilderError),
+    #[error(transparent)]
+    MessageSchema(#[from] XRegistryMessageSchemaBuilderError),
+}
 /// Returns a new [`MessageSchema`] that describes it.
 ///
 /// # Limitations
@@ -50,6 +76,90 @@ pub fn create_schema(data: &Data) -> Result<MessageSchema, SchemaGenerationError
 /// Returns an error if the transformation or schema generation cannot be made.
 /// Input data will not be modified.
 fn create_output_schema(data: &Data) -> Result<MessageSchema, SchemaGenerationErrorRepr> {
+    // Create a MessageSchema from the output JSON schema
+    let output_message_schema = MessageSchemaBuilder::default()
+        .schema_content(create_output_schema_string(data)?)
+        .format(Format::JsonSchemaDraft07)
+        .schema_type(SchemaType::MessageSchema)
+        .build()?;
+
+    Ok(output_message_schema)
+}
+
+/// Returns a new [`XRegistryMessageSchema`] that describes it, generating a generic schema id.
+///
+/// # Limitations
+/// - Cannot correctly interpret enums as it derives the schema only from JSON payload provided.
+/// - Similarly, optionality of fields cannot be inferred correctly in the schema.
+/// - Fields that are set to `null` in the input JSON will be set to `true` in the schema, as no
+///   information is available to derive the type of the field.
+///
+/// # Errors
+/// Returns a [`XRegistrySchemaGenerationError`] if there is an error during the transformation or schema generation.
+pub fn create_xregistry_schema(
+    data: &Data,
+    data_operation_ref: &DataOperationRef,
+) -> Result<XRegistryMessageSchema, XRegistrySchemaGenerationError> {
+    // NOTE: We delegate to a function here that modifies the data in place so that the entire
+    // `data` struct does not need to be reallocated, while also being able to return it as part
+    // of an error if necessary.
+    let schema_version_attributes = create_schema_version_attributes(data)?;
+    let desired_schema_id = default_schema_id(data_operation_ref);
+    let schema_labels = vec![];
+    // TODO: run derive_resource_id once it's available
+    let actual_schema_id = desired_schema_id; // derive_resource_id(desired_schema_id, &mut schema_labels);
+    XRegistryMessageSchemaBuilder::default()
+        .schema_id(actual_schema_id)
+        .version(schema_version_attributes)
+        .schema_labels(schema_labels)
+        .build()
+        .map_err(|e| XRegistrySchemaGenerationError { repr: e.into() })
+}
+
+/// Returns a new [`SchemaVersionAttributes`] that describes it, leaving the caller to determine the schema id,
+/// group id, and schema labels.
+///
+/// # Limitations
+/// - Cannot correctly interpret enums as it derives the schema only from JSON payload provided.
+/// - Similarly, optionality of fields cannot be inferred correctly in the schema.
+/// - Fields that are set to `null` in the input JSON will be set to `true` in the schema, as no
+///   information is available to derive the type of the field.
+///
+/// # Errors
+/// Returns a [`SchemaGenerationError`] if there is an error during the transformation or schema generation.
+pub fn create_schema_version_attributes(
+    data: &Data,
+) -> Result<SchemaVersionAttributes, XRegistrySchemaGenerationError> {
+    // NOTE: We delegate to a function here that modifies the data in place so that the entire
+    // `data` struct does not need to be reallocated, while also being able to return it as part
+    // of an error if necessary.
+    match create_output_schema_version_attributes(data) {
+        Ok(message_schema) => Ok(message_schema),
+        Err(e) => Err(XRegistrySchemaGenerationError { repr: e }),
+    }
+}
+
+/// Generates a new [`SchemaVersionAttributes`] that describes the data.
+///
+/// Returns an error if the transformation or schema generation cannot be made.
+/// Input data will not be modified.
+fn create_output_schema_version_attributes(
+    data: &Data,
+) -> Result<SchemaVersionAttributes, XRegistrySchemaGenerationErrorRepr> {
+    // Create a SchemaVersionAttributes from the output JSON schema
+    let schema_version_attributes = SchemaVersionAttributesBuilder::default()
+        .document(create_output_schema_string(data)?.into())
+        .format(SchemaFormat::JsonSchemaDraft07)
+        .build()?;
+
+    Ok(schema_version_attributes)
+}
+
+/// Generates a new Schema document that describes the data.
+///
+/// Returns an error if the transformation or schema generation cannot be made.
+/// Input data will not be modified.
+fn create_output_schema_string(data: &Data) -> Result<String, serde_json::Error> {
     // Parse the input JSON from bytes
     let output_json: Value = serde_json::from_slice(&data.payload)?;
 
@@ -59,14 +169,8 @@ fn create_output_schema(data: &Data) -> Result<MessageSchema, SchemaGenerationEr
         metadata.examples = vec![];
     }
 
-    // Create a MessageSchema from the output JSON schema
-    let output_message_schema = MessageSchemaBuilder::default()
-        .schema_content(serde_json::to_string(&output_root_schema)?)
-        .format(Format::JsonSchemaDraft07)
-        .schema_type(SchemaType::MessageSchema)
-        .build()?;
-
-    Ok(output_message_schema)
+    // Create the output JSON schema
+    serde_json::to_string(&output_root_schema)
 }
 
 #[cfg(test)]

--- a/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
+++ b/rust/azure_iot_operations_connector/src/data_processor/derived_json.rs
@@ -3,9 +3,12 @@
 
 //! Processor for generating [`MessageSchema`] for the JSON payload defined in a [`Data`].
 
-use azure_iot_operations_services::edge_registry::models::{
-    SchemaFormat, SchemaVersionAttributes, SchemaVersionAttributesBuilder,
-    SchemaVersionAttributesBuilderError,
+use azure_iot_operations_services::edge_registry::{
+    derive_resource_id,
+    models::{
+        SchemaFormat, SchemaVersionAttributes, SchemaVersionAttributesBuilder,
+        SchemaVersionAttributesBuilderError,
+    },
 };
 use azure_iot_operations_services::schema_registry::{Format, SchemaType};
 use serde_json::{self, Value};
@@ -105,9 +108,8 @@ pub fn create_xregistry_schema(
     // of an error if necessary.
     let schema_version_attributes = create_schema_version_attributes(data)?;
     let desired_schema_id = default_schema_id(data_operation_ref);
-    let schema_labels = vec![];
-    // TODO: run derive_resource_id once it's available
-    let actual_schema_id = desired_schema_id; // derive_resource_id(desired_schema_id, &mut schema_labels);
+    let (actual_schema_id, schema_labels) = derive_resource_id(desired_schema_id, vec![])
+        .expect("default_schema_id can't return an empty String");
     XRegistryMessageSchemaBuilder::default()
         .schema_id(actual_schema_id)
         .version(schema_version_attributes)

--- a/rust/azure_iot_operations_connector/src/lib.rs
+++ b/rust/azure_iot_operations_connector/src/lib.rs
@@ -7,9 +7,12 @@
 
 use std::fmt::Display;
 
+use derive_builder::Builder;
+
 use azure_iot_operations_protocol::common::hybrid_logical_clock::HybridLogicalClock;
 use azure_iot_operations_services::{
     azure_device_registry,
+    edge_registry::{GroupId, Label, models::SchemaVersionAttributes},
     schema_registry::{PutSchemaRequest, PutSchemaRequestBuilder, PutSchemaRequestBuilderError},
 };
 
@@ -33,6 +36,43 @@ pub type AdrConfigError = azure_device_registry::ConfigError;
 pub type MessageSchemaBuilder = PutSchemaRequestBuilder;
 /// Error type for [`MessageSchemaBuilder`]
 pub type MessageSchemaBuilderError = PutSchemaRequestBuilderError;
+
+/// Message Schema to send to the Edge Registry Service in the xRegistry format
+#[derive(Debug, Clone, Builder, PartialEq, Eq)]
+pub struct XRegistryMessageSchema {
+    /// The groupId to store the schema under. Defaults to `GroupId::CloudDefault`.
+    #[builder(default = "GroupId::CloudDefault")]
+    group_id: GroupId,
+    /// The schemaId to store the version under. Should be validated with
+    /// [`derive_resource_id`](azure_iot_operations_services::edge_registry::derive_resource_id) to ensure it is a valid resource id.
+    schema_id: String,
+    /// Queryable key/value pairs to be added to the parent Schema.
+    #[builder(default)]
+    schema_labels: Vec<Label>,
+    /// The Attributes used to create the Schema Version
+    version: SchemaVersionAttributes,
+}
+
+/// Creates a schema id that will be unique for the given data operation.
+/// Must be validated with [`derive_resource_id`](azure_iot_operations_services::edge_registry::derive_resource_id)
+/// turn it into a valid resource id.
+#[must_use]
+pub fn default_schema_id(data_operation_ref: &DataOperationRef) -> String {
+    let data_operation_name = match &data_operation_ref.data_operation_name {
+        DataOperationName::Dataset { name } => format!("dataset:{name}"),
+        DataOperationName::Event {
+            name,
+            event_group_name,
+        } => format!("event:{event_group_name}:{name}"),
+        DataOperationName::Stream { name } => format!("stream:{name}"),
+    };
+    format!(
+        "{}:{}:{}:{data_operation_name}",
+        data_operation_ref.device_name,
+        data_operation_ref.inbound_endpoint_name,
+        data_operation_ref.asset_name,
+    )
+}
 
 /// Struct format for data sent to the destination
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/azure_iot_operations_services/src/edge_registry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry.rs
@@ -137,7 +137,7 @@ impl From<rpc_command::invoker::RequestBuilderError> for ErrorKind {
 // ~~~~~~~~~~~~~~~~~~~SDK Created Helper Structs~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Identifies a Group within its Group type for a request.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum GroupId {
     /// Use the cloud default Group Id of the Group type.
     #[default]
@@ -226,7 +226,7 @@ pub enum GroupSelection {
 }
 
 /// A label key/value pair used to filter list queries.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Label {
     /// The label key.
     pub key: String,

--- a/rust/azure_iot_operations_services/src/edge_registry/models/schema.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/models/schema.rs
@@ -146,7 +146,7 @@ impl From<String> for SchemaFormat {
 }
 
 /// Attributes needed to create a Schema Version.
-#[derive(Debug, Clone, Builder)]
+#[derive(Debug, Clone, Builder, PartialEq, Eq)]
 pub struct SchemaVersionAttributes {
     /// Human-readable name.
     #[builder(default = "None")]

--- a/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
+++ b/rust/azure_iot_operations_services/src/edge_registry/models/xregistry.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 
-use crate::edge_registry::Label;
 use crate::edge_registry::edge_registry_gen::common_types::b64::{self};
-use crate::edge_registry::edge_registry_gen::edge_registry::client as client_gen;
+use crate::edge_registry::edge_registry_gen::edge_registry::client::{self as client_gen};
 use crate::edge_registry::models::{
     extensions_from_gen, extensions_to_gen, labels_from_gen, labels_to_gen,
 };
+use crate::edge_registry::{Error, ErrorKind, Label};
 
 // ~~~~~~~~~~~~~~~~~~~Shared value types~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -161,6 +161,41 @@ impl From<client_gen::VersionXid> for VersionXId<String> {
             resource_type: value.resource_type,
             resource_id: value.resource_id,
             version_id: value.version_id,
+        }
+    }
+}
+
+impl TryFrom<&str> for VersionXId<String> {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let trimmed = s.trim_start_matches('/');
+        let parts: Vec<&str> = trimmed.split('/').collect();
+
+        // Reject non-root XIDs that contain empty path segments (e.g. "/a//b", "/schemagroups/").
+        let parts_slice = parts.as_slice();
+        if parts_slice != [""] && parts.iter().any(|p| p.is_empty()) {
+            return Err(ErrorKind::ValidationError(format!(
+                "Invalid Version XID format (empty path segment): {s}"
+            ))
+            .into());
+        }
+        match parts_slice {
+            [
+                group_type,
+                group_id,
+                resource_type,
+                resource_id,
+                "versions",
+                version_id,
+            ] => Ok(VersionXId {
+                group_type: (*group_type).to_string(),
+                group_id: (*group_id).to_string(),
+                resource_type: (*resource_type).to_string(),
+                resource_id: (*resource_id).to_string(),
+                version_id: (*version_id).to_string(),
+            }),
+            _ => Err(ErrorKind::ValidationError(format!("Invalid Version XID format: {s}")).into()),
         }
     }
 }


### PR DESCRIPTION
This PR:
- adds a parallel surface for all schema registry calls to opt-in to using the new Edge Registry APIs
- NO BREAKING CHANGES
- adds some pre-requisite changes in the service sdk
- ~~pending #1472 for proper schema id handling~~