### PR TITLE
[.NET][MQTT][Connector] Allow AIO metriccategory metadata to be configured via API

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -70,6 +70,7 @@
     ],
     "words": [
         "aarch64",
+        "aiosdk",
         "Akri",
         "avrogen",
         "azurecr",

--- a/dotnet/src/Azure.Iot.Operations.Connector/MqttSessionClientProvider.cs
+++ b/dotnet/src/Azure.Iot.Operations.Connector/MqttSessionClientProvider.cs
@@ -11,6 +11,11 @@ namespace Azure.Iot.Operations.Connector
 {
     public static class MqttSessionClientProvider
     {
+        /// <summary>
+        /// Categorizes the internal traffic between the connector and other AIO services.
+        /// </summary>
+        private const string ConnectorMetricCategory = "aiosdk-dotnet-connector";
+
         public static Func<IServiceProvider, IMqttClient> Factory = service =>
         {
             IConfiguration? config = service.GetService<IConfiguration>();
@@ -24,6 +29,7 @@ namespace Azure.Iot.Operations.Connector
             {
                 EnableMqttLogging = mqttDiag,
                 RetryOnFirstConnect = true,
+                MetricCategory = ConnectorMetricCategory,
             };
 
 

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
@@ -87,7 +87,7 @@ public class OrderedAckMqttClient : IMqttPubSubClient, IMqttClient
 
         if (_clientOptions.EnableAIOBrokerFeatures)
         {
-            mqttNetOptions.UserProperties.Add(new("metriccategory", System.Text.Encoding.UTF8.GetBytes("aiosdk-dotnet")));
+            mqttNetOptions.UserProperties.Add(new("metriccategory", System.Text.Encoding.UTF8.GetBytes(_clientOptions.MetricCategory)));
         }
 
         MqttClientConnectResult? result =  MqttNetConverter.ToGeneric(await UnderlyingMqttClient.ConnectAsync(mqttNetOptions, cancellationToken).ConfigureAwait(false));

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClient.cs
@@ -87,6 +87,11 @@ public class OrderedAckMqttClient : IMqttPubSubClient, IMqttClient
 
         if (_clientOptions.EnableAIOBrokerFeatures)
         {
+            if (string.IsNullOrWhiteSpace(_clientOptions.MetricCategory))
+            {
+                throw new ArgumentException($"{nameof(OrderedAckMqttClientOptions.MetricCategory)} must be a non-empty value when {nameof(OrderedAckMqttClientOptions.EnableAIOBrokerFeatures)} is enabled.");
+            }
+
             mqttNetOptions.UserProperties.Add(new("metriccategory", System.Text.Encoding.UTF8.GetBytes(_clientOptions.MetricCategory)));
         }
 

--- a/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClientOptions.cs
+++ b/dotnet/src/Azure.Iot.Operations.Mqtt/OrderedAckMqttClientOptions.cs
@@ -15,5 +15,14 @@ namespace Azure.Iot.Operations.Mqtt
         /// Sets whether or not to use AIO broker-specific features. By default, this is true.
         /// </summary>
         public bool EnableAIOBrokerFeatures { get; set; } = true;
+
+        /// <summary>
+        /// The value of the <c>metriccategory</c> MQTT CONNECT user property, which categorizes this
+        /// client's traffic to AIO services. Only sent when <see cref="EnableAIOBrokerFeatures"/> is true.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://learn.microsoft.com/azure/iot-operations/reference/observability-metrics-mqtt-broker#category"/> for details.
+        /// </remarks>
+        public string MetricCategory { get; set; } = "aiosdk-dotnet";
     }
 }


### PR DESCRIPTION
Mirrors Rust #1466. The metriccategory CONNECT user property is now taken from OrderedAckMqttClientOptions.MetricCategory (default aiosdk-dotnet) instead of being hardcoded, and the connector's session client reports aiosdk-dotnet-connector.