### PR TITLE
[.NET][Services][EdgeRegistry] Add persistence user property to write  requests

### DIFF
--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
@@ -9,11 +9,6 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public class CreateOptions
 {
     /// <summary>
-    /// The default options, which persist the created entity.
-    /// </summary>
-    public static CreateOptions Default => new();
-
-    /// <summary>
     /// Whether the Edge Registry should persist the created entity to disk. Defaults to <c>true</c>.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/CreateOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Operations.Services.EdgeRegistry;
+
+/// <summary>
+/// Options that control the behavior of a create operation.
+/// </summary>
+public class CreateOptions
+{
+    /// <summary>
+    /// The default options, which persist the created entity.
+    /// </summary>
+    public static CreateOptions Default => new();
+
+    /// <summary>
+    /// Whether the Edge Registry should persist the created entity to disk. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Persistence requires a broker deployed with persistence enabled; it is otherwise ignored. An
+    /// entity that has been persisted can't later be made non-persistent.
+    /// </remarks>
+    public bool Persist { get; set; } = true;
+}

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Core.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Core.cs
@@ -43,7 +43,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -53,6 +53,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateGroupAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: GroupTopicTokens(groupType),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);
@@ -95,7 +96,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -111,6 +112,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateResourceAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ResourceTopicTokens(groupType, resourceType, resourceId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);
@@ -181,7 +183,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
     }
 
     /// <inheritdoc/>
-    public async Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -196,6 +198,7 @@ public sealed partial class EdgeRegistryClient : ICoreClient
 
         var output = await _coreStub.CreateVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ResourceTopicTokens(groupType, resourceType, resourceId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.Schema.cs
@@ -10,7 +10,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : ISchemaRegistryClient
 {
     /// <inheritdoc/>
-    public async Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -19,6 +19,7 @@ public sealed partial class EdgeRegistryClient : ISchemaRegistryClient
 
         var output = await _schemaStub.CreateSchemaVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(SchemaIdTopicToken, schemaId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingDescription.cs
@@ -11,7 +11,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : IThingDescriptionClient
 {
     /// <inheritdoc/>
-    public async Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -20,6 +20,7 @@ public sealed partial class EdgeRegistryClient : IThingDescriptionClient
 
         var output = await _thingDescriptionStub.CreateThingDescriptionVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(ThingDescriptionIdTopicToken, thingDescriptionId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.ThingModel.cs
@@ -10,7 +10,7 @@ namespace Azure.Iot.Operations.Services.EdgeRegistry;
 public sealed partial class EdgeRegistryClient : IThingModelClient
 {
     /// <inheritdoc/>
-    public async Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    public async Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -19,6 +19,7 @@ public sealed partial class EdgeRegistryClient : IThingModelClient
 
         var output = await _thingModelStub.CreateThingModelVersionAsync(
             request,
+            PersistenceMetadata(options),
             additionalTopicTokenMap: ExtensionResourceTopicTokens(ThingModelIdTopicToken, thingModelId),
             commandTimeout: timeout ?? s_defaultCommandTimeout,
             cancellationToken: cancellationToken);

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Azure.Iot.Operations.Protocol;
+using Azure.Iot.Operations.Protocol.RPC;
 
 namespace Azure.Iot.Operations.Services.EdgeRegistry;
 
@@ -30,6 +31,9 @@ public sealed partial class EdgeRegistryClient : IEdgeRegistryClient
     private const string SchemaIdTopicToken = "schemaId";
     private const string ThingDescriptionIdTopicToken = "thingDescriptionId";
     private const string ThingModelIdTopicToken = "thingModelId";
+
+    /// <summary>The user property that asks the Edge Registry to persist the entity being written.</summary>
+    private const string PersistUserProperty = "aio-persistence";
 
     private static readonly TimeSpan s_defaultCommandTimeout = TimeSpan.FromSeconds(10);
 
@@ -85,6 +89,20 @@ public sealed partial class EdgeRegistryClient : IEdgeRegistryClient
         Dictionary<string, string> tokens = ExtensionResourceTopicTokens(resourceIdToken, resourceId);
         tokens[VersionIdTopicToken] = versionId.ToString(CultureInfo.InvariantCulture);
         return tokens;
+    }
+
+    /// <summary>Builds the request metadata for a create request, signalling persistence when requested.</summary>
+    private static CommandRequestMetadata PersistenceMetadata(CreateOptions? options)
+    {
+        CommandRequestMetadata requestMetadata = new();
+
+        // Only sent when true, since sending "false" is equivalent to omitting the property.
+        if ((options ?? CreateOptions.Default).Persist)
+        {
+            requestMetadata.UserData.TryAdd(PersistUserProperty, "true");
+        }
+
+        return requestMetadata;
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/EdgeRegistryClient.cs
@@ -97,7 +97,7 @@ public sealed partial class EdgeRegistryClient : IEdgeRegistryClient
         CommandRequestMetadata requestMetadata = new();
 
         // Only sent when true, since sending "false" is equivalent to omitting the property.
-        if ((options ?? CreateOptions.Default).Persist)
+        if (options is null || options.Persist)
         {
             requestMetadata.UserData.TryAdd(PersistUserProperty, "true");
         }

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
@@ -60,10 +60,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="groupType">The Group type (the xRegistry Group collection name).</param>
     /// <param name="groupId">The Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>
     /// <param name="attributes">The attributes of the Group to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreGroupEntity"/>.</returns>
-    Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreGroupEntity> CreateGroupAsync(string groupType, GroupId groupId, Models.CoreGroupAttributes attributes, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Deletes a Group. Deletes cascade to all contained Resources and their Versions.</summary>
     /// <param name="groupType">The Group type (the xRegistry Group collection name).</param>
@@ -95,10 +96,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceExtensions">Resource-level extension attributes, keyed by extension name.</param>
     /// <param name="defaultVersionId">The Version id to assign to the Resource's default Version. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="defaultVersion">The attributes of the Resource's default Version.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreResourceEntity"/>.</returns>
-    Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreResourceEntity> CreateResourceAsync(string groupType, GroupId groupId, string resourceType, string resourceId, Models.CoreResourceMetaAttributes meta, Dictionary<string, byte[]> resourceExtensions, CreateVersionId defaultVersionId, Models.CoreVersionAttributes defaultVersion, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Lists the XIDs of Resources matching the query, optionally filtered by Resource type and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupQuery"/> for the available scopes.</param>
@@ -141,10 +143,11 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceLabels">Labels applied to the parent Resource.</param>
     /// <param name="versionId">The Version id to assign. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="version">The attributes of the Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreVersionEntity"/>.</returns>
-    Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.CoreVersionEntity> CreateVersionAsync(string groupType, GroupId groupId, string resourceType, string resourceId, IReadOnlyList<Models.Label> resourceLabels, CreateVersionId versionId, Models.CoreVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Lists the XIDs of Versions matching the query, optionally filtered by Resource type, Resource id, and/or a single label.</summary>
     /// <param name="groups">The Groups to search; see <see cref="GroupQuery"/> for the available scopes.</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ICoreClient.cs
@@ -60,7 +60,7 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="groupType">The Group type (the xRegistry Group collection name).</param>
     /// <param name="groupId">The Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>
     /// <param name="attributes">The attributes of the Group to create.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreGroupEntity"/>.</returns>
@@ -96,7 +96,7 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceExtensions">Resource-level extension attributes, keyed by extension name.</param>
     /// <param name="defaultVersionId">The Version id to assign to the Resource's default Version. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="defaultVersion">The attributes of the Resource's default Version.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreResourceEntity"/>.</returns>
@@ -143,7 +143,7 @@ public interface ICoreClient : IAsyncDisposable
     /// <param name="resourceLabels">Labels applied to the parent Resource.</param>
     /// <param name="versionId">The Version id to assign. Use <see cref="CreateVersionId.ServerAssigned"/> to let the service choose.</param>
     /// <param name="version">The attributes of the Version to create.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.CoreVersionEntity"/>.</returns>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
@@ -30,7 +30,7 @@ public interface ISchemaRegistryClient
     /// <param name="schemaId">The Schema (Resource) identifier.</param>
     /// <param name="schemaLabels">Labels applied to the parent Schema.</param>
     /// <param name="version">The attributes of the Schema Version to create.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.SchemaVersion"/>.</returns>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/ISchemaRegistryClient.cs
@@ -30,10 +30,11 @@ public interface ISchemaRegistryClient
     /// <param name="schemaId">The Schema (Resource) identifier.</param>
     /// <param name="schemaLabels">Labels applied to the parent Schema.</param>
     /// <param name="version">The attributes of the Schema Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.SchemaVersion"/>.</returns>
-    Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.SchemaVersion> CreateSchemaVersionAsync(GroupId groupId, string schemaId, IReadOnlyList<Models.Label> schemaLabels, Models.SchemaVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Schema Version.</summary>
     /// <param name="groupId">The Schema Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
@@ -31,10 +31,11 @@ public interface IThingDescriptionClient
     /// <param name="thingDescriptionId">The Thing Description (Resource) identifier.</param>
     /// <param name="thingDescriptionLabels">Labels applied to the parent Thing Description.</param>
     /// <param name="version">The attributes of the Thing Description Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingDescriptionVersion"/>.</returns>
-    Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.ThingDescriptionVersion> CreateThingDescriptionVersionAsync(GroupId groupId, string thingDescriptionId, IReadOnlyList<Models.Label> thingDescriptionLabels, Models.ThingDescriptionVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Thing Description Version.</summary>
     /// <param name="groupId">The Thing Description Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingDescriptionClient.cs
@@ -31,7 +31,7 @@ public interface IThingDescriptionClient
     /// <param name="thingDescriptionId">The Thing Description (Resource) identifier.</param>
     /// <param name="thingDescriptionLabels">Labels applied to the parent Thing Description.</param>
     /// <param name="version">The attributes of the Thing Description Version to create.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingDescriptionVersion"/>.</returns>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
@@ -31,10 +31,11 @@ public interface IThingModelClient
     /// <param name="thingModelId">The Thing Model (Resource) identifier.</param>
     /// <param name="thingModelLabels">Labels applied to the parent Thing Model.</param>
     /// <param name="version">The attributes of the Thing Model Version to create.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingModelVersion"/>.</returns>
-    Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    Task<Models.ThingModelVersion> CreateThingModelVersionAsync(GroupId groupId, string thingModelId, IReadOnlyList<Models.Label> thingModelLabels, Models.ThingModelVersionAttributes version, CreateOptions? options = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a Thing Model Version.</summary>
     /// <param name="groupId">The Thing Model Group. Use <see cref="GroupId.CloudDefault"/> for the cloud-default Group (the configured namespace).</param>

--- a/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
+++ b/dotnet/src/Azure.Iot.Operations.Services/EdgeRegistry/IThingModelClient.cs
@@ -31,7 +31,7 @@ public interface IThingModelClient
     /// <param name="thingModelId">The Thing Model (Resource) identifier.</param>
     /// <param name="thingModelLabels">Labels applied to the parent Thing Model.</param>
     /// <param name="version">The attributes of the Thing Model Version to create.</param>
-    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, <see cref="CreateOptions.Default"/> is used.</param>
+    /// <param name="options">The <see cref="CreateOptions"/> that control the behavior of the create operation; when <see langword="null"/>, the created entity is persisted.</param>
     /// <param name="timeout">The command timeout; when <see langword="null"/>, the client's default timeout is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task whose result is the created <see cref="Models.ThingModelVersion"/>.</returns>


### PR DESCRIPTION
Mirrors Rust #1474. Every create operation now takes CreateOptions, which sends the aio-persistence user property. Unlike the state store, persistence defaults to on: registry entities should always survive a restart, so this is opt-out rather than opt-in.